### PR TITLE
Expand documentation across Socioprophet web repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,105 @@
-# Welcome to SocioProphet
+# SocioProphet Web (monorepo wrapper)
 
-This repository contains the code for the SocioProphet website (https://socioprophet.com), split into /client and /server directories. This codebase is currently a work in progress.
+This repository contains the **full SocioProphet web stack**. The actual application lives under the `socioprophet-web/` folder and is split into a React frontend and an Express backend. The root folder only provides shared workflow helpers (Makefile, scripts) and high-level documentation.
 
-### Directory Layout
+> **Repository goal:** provide a working local development environment for the SocioProphet marketing site and its supporting RSS feed API.
 
-- Root directory contains the client and server directories and a scripts directory for working with socioprophet-web.
+## Repository layout (top level)
 
-- `/client` - React 18 application using TypeScript, Webpack and Styled Components.
-- `/server` - Express application currently serving the HackerNews RSS feed to the scrolling ticker on the SocioProphet website.
-- `/scripts` - Executed via the Makefile in the root directory. To help with installing and running the client and server code concurrently.
+| Path | Description |
+| --- | --- |
+| `README.md` | This file. Overview and workspace instructions. |
+| `CONTRIBUTING.md` | Contribution guidelines (style, workflow expectations). |
+| `Makefile` | Convenience commands that delegate to scripts in `socioprophet-web/scripts/`. |
+| `socioprophet-web/` | **Primary application code** (client, server, scripts). See that directory’s README for full details. |
 
-### Building with the Makefile and Yarn
+## Prerequisites
 
-socioprophet-web can be built and run using the Makefile within the project root directory. The commands executed by the Makefile are the same commands one would use to build a project and run the Webpack dev server and Node server.
+- **Node.js 18+** (the codebase uses Node 18 tooling and APIs).
+- **Yarn** package manager.
+- **GNU Make** (for running top-level `make` targets).
+- **Bash** (scripts are bash). 
 
-```bash
-.PHONY: install_web run_web
-
-# install dependencies for client and server concurrently
-install_web:
-	cd socioprophet-web/scripts/ && bash install_web.sh
-
-# run client and server
-run_web:
-	cd socioprophet-web/scripts/ && bash run_web.sh
-```
-
-To build and run the socioprophet-web application, run the following commands in the root directory:
+## Quick start (recommended)
 
 ```bash
-# install client and server dependencies
+# from /workspace/socioprophet
 make install_web
-
-# run client and server locally concurrently
 make run_web
 ```
 
-### Env Variables
+What this does:
+1. Installs dependencies in `socioprophet-web/client` and `socioprophet-web/server`.
+2. Starts the backend with `yarn run dev` and the frontend with `yarn start`.
 
-Create a `.env` in both the client and server folders. Check `./client/.env.example` and `./server/.env.examples` for details.
+## Manual start (no Makefile)
+
+```bash
+cd socioprophet-web/client
+cp .env.example .env
+# set REACT_PORT and NODE_PORT inside .env
+
+yarn
+
+yarn start
+```
+
+```bash
+cd socioprophet-web/server
+cp .env.example .env
+# set PORT inside .env
+
+yarn
+
+yarn run dev
+```
+
+## Environment variables
+
+Create `.env` files in the **client** and **server** folders.
+
+### Client (`socioprophet-web/client/.env`)
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `REACT_PORT` | ✅ | Port for the Webpack dev server (e.g., `3000`). |
+| `NODE_PORT` | ✅ | Port where the server is running (used for `/api` proxy). |
+
+### Server (`socioprophet-web/server/.env`)
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PORT` | ✅ | Port that the Express server listens on (e.g., `3001`). |
+
+## How the system fits together
+
+- The **client** is a React SPA (single-page app) served by Webpack in development.
+- The **server** is a lightweight Express API that fetches the Hacker News RSS feed and returns JSON.
+- The client makes requests to `/api/feed/rss`, which is proxied to the server when running locally.
+
+## Common tasks
+
+| Task | Command | Where |
+| --- | --- | --- |
+| Install dependencies | `make install_web` | repo root |
+| Run both apps | `make run_web` | repo root |
+| Run client only | `yarn start` | `socioprophet-web/client` |
+| Run server only | `yarn run dev` | `socioprophet-web/server` |
+
+## Where to find more documentation
+
+The project is intentionally verbose about documentation. Each major folder has its own README:
+
+- `socioprophet-web/README.md` – app-level documentation
+- `socioprophet-web/client/README.md` – frontend guide
+- `socioprophet-web/server/README.md` – backend guide
+- `socioprophet-web/scripts/README.md` – helper scripts
+- `socioprophet-web/client/src/**/README.md` – component-level notes
+- `socioprophet-web/server/src/**/README.md` – server source notes
+
+## Notes and gotchas
+
+- The root `Makefile` assumes a Unix-like shell environment (Bash).
+- Both apps are expected to run **concurrently** in development. Ensure ports do not conflict.
+- The client uses a Webpack dev server; it is not preconfigured for production SSR.
+- Dockerfiles exist in the client/server directories for container builds (see their READMEs for details).

--- a/socioprophet-web/README.md
+++ b/socioprophet-web/README.md
@@ -1,24 +1,125 @@
 # socioprophet-web
 
-## Purpose
-This directory is the root of the SocioProphet website codebase. It splits the frontend and backend into two sibling projects and keeps helper scripts for local development.
+This directory contains the **entire SocioProphet web application**, split into a frontend SPA and a backend API. Use this README for operational details; component-level documentation lives in subdirectories.
 
-## Major Subdirectories
-- `client/` – React + TypeScript single-page application bundled with Webpack.
-- `server/` – Express server that powers the RSS ticker endpoint used by the client.
-- `scripts/` – Shell helpers invoked by the root `Makefile` to install and run both apps.
+## Repository structure
 
-## Key Files
-- `client/package.json` – Frontend dependencies and scripts.
-- `server/package.json` – Backend dependencies and scripts.
-- `scripts/install_web.sh` – Installs client and server dependencies.
-- `scripts/run_web.sh` – Runs server and client concurrently for local dev.
+| Path | Description |
+| --- | --- |
+| `client/` | React 18 + TypeScript SPA bundled with Webpack. |
+| `server/` | Express server that exposes `/api/feed/rss`. |
+| `scripts/` | Shell helpers used by the root `Makefile`. |
 
-## Typical Workflow
-1. Install dependencies via the root `Makefile` (`make install_web`).
-2. Run both services (`make run_web`) which delegates to `scripts/run_web.sh`.
-3. Client will call the server at `/api/feed/rss` to populate the ticker feed.
+## Quick start (development)
+
+```bash
+# from /workspace/socioprophet
+make install_web
+make run_web
+```
+
+### What runs where
+
+| Service | Default runtime | Notes |
+| --- | --- | --- |
+| Client | Webpack dev server | Configured in `client/webpack.config.js`. |
+| Server | Express | Entry point: `server/src/server.ts`. |
+
+## Environment variables
+
+Create `.env` files in **both** subprojects.
+
+### Client (`client/.env`)
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `REACT_PORT` | ✅ | Port for the dev server (`webpack-dev-server`). |
+| `NODE_PORT` | ✅ | Target port for API proxying (`/api`). |
+
+### Server (`server/.env`)
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `PORT` | ✅ | HTTP port for the Express server. |
+
+## API overview
+
+The backend exposes one API namespace:
+
+- `GET /api/feed/rss`
+  - Returns a JSON array of items: `{ title, link }`.
+  - Sourced from `https://hnrss.org/newest` (Hacker News RSS).
+  - Cached for **10 minutes** in-memory using `node-cache`.
+
+The client fetches this endpoint in the ticker banner (`client/src/components/tickerFeed`).
+
+## Development workflows
+
+### Install dependencies
+
+```bash
+cd scripts
+bash install_web.sh
+```
+
+### Run client + server together
+
+```bash
+cd scripts
+bash run_web.sh
+```
+
+### Run projects individually
+
+```bash
+cd client
+cp .env.example .env
+# set REACT_PORT and NODE_PORT
+
+yarn
+
+yarn start
+```
+
+```bash
+cd server
+cp .env.example .env
+# set PORT
+
+yarn
+
+yarn run dev
+```
+
+## Docker builds
+
+Both subprojects include Dockerfiles. They are **not** wired together with a `docker-compose.yml`.
+
+### Client container
+
+- Build stage uses `node:18-alpine`, runs `yarn build`.
+- Runtime stage uses `nginx:stable-alpine`.
+- Copies `/build` output to `/usr/share/nginx/html`.
+- Exposes port **80**.
+- The Dockerfile expects an `nginx/nginx.conf` file under the client directory.
+
+### Server container
+
+- Uses `node:18-alpine`.
+- Installs dependencies and runs `yarn start`.
+- Exposes whatever `PORT` is configured at runtime.
+
+## Where to find detailed documentation
+
+Each directory ships with its own README. Start here:
+
+- `client/README.md`
+- `server/README.md`
+- `scripts/README.md`
+- `client/src/**/README.md`
+- `server/src/**/README.md`
 
 ## Notes
-- `node_modules/` folders live inside `client/` and `server/` and are intentionally excluded from documentation updates.
-- Environment configuration is expected to live in `.env` files within the `client/` and `server/` directories (see root README for guidance).
+
+- `node_modules/` directories are included in this workspace but are not part of documentation updates.
+- The server uses CommonJS `require` syntax inside TypeScript for consistency; follow the existing patterns unless you explicitly refactor.

--- a/socioprophet-web/client/README.md
+++ b/socioprophet-web/client/README.md
@@ -1,26 +1,90 @@
 # Client
 
-## Purpose
-The frontend application for SocioProphet. It is a React 18 SPA written in TypeScript and bundled with Webpack.
+The SocioProphet frontend is a **React 18** single-page application written in **TypeScript** and bundled with **Webpack**. It renders the marketing site and consumes the backend RSS API for the ticker banner.
 
-## Entry Points
-- `src/index.tsx` – Mounts the React root.
-- `src/App.tsx` – Sets up routing and global styles.
+## High-level responsibilities
 
-## Key Directories
-- `public/` – Static HTML and assets served by Webpack Dev Server or the build output.
-- `src/` – React components, views, routes, and styling.
+- Render the landing page, legal pages, and 404 page.
+- Provide global layout components (header/footer).
+- Fetch `/api/feed/rss` and display the feed in a scrolling ticker.
 
-## Tooling
-- `webpack.config.js` – Webpack configuration for development and production builds.
-- `babel.config.js` – Babel configuration for React + TypeScript.
-- `tsconfig.json` – TypeScript compiler settings.
+## Directory layout
 
-## Development Scripts
-- `yarn start` – Launches the webpack dev server with hot reloading.
-- `yarn build` – Produces a production build.
-- `yarn launch` – Opens a browser window while launching the dev server.
+| Path | Description |
+| --- | --- |
+| `src/` | React source code (components, views, routing, styling). |
+| `public/` | HTML template and static assets. |
+| `webpack.config.js` | Webpack build + dev server configuration. |
+| `babel.config.js` | Babel configuration for React + TS. |
+| `tsconfig.json` | TypeScript compiler options (type checking only). |
+| `Dockerfile` | Container build (builds and serves with Nginx). |
+| `.env.example` | Environment variable template. |
+| `package.json` | Scripts, dependencies, metadata. |
 
-## Notes
-- The client expects the backend to serve `/api/feed/rss` for the ticker feed.
-- Environment values should be placed in a `.env` file at this directory level when needed.
+## Entry points
+
+- `src/index.tsx` – Mounts the React root into the DOM.
+- `src/App.tsx` – Global styles + router.
+- `src/routes.js` – Route table for `react-router-dom`.
+
+## Environment variables
+
+Create `client/.env` (see `.env.example`).
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `REACT_PORT` | ✅ | Port for the Webpack dev server. |
+| `NODE_PORT` | ✅ | Port that the backend server listens on; used to proxy `/api` requests. |
+
+## Scripts
+
+| Script | Command | Description |
+| --- | --- | --- |
+| Start dev server | `yarn start` | Runs `webpack-dev-server` in development mode. |
+| Build production bundle | `yarn build` | Outputs static assets to `client/build/`. |
+| Launch in browser | `yarn launch` | Starts dev server and opens the browser. |
+
+## Routing
+
+Routing is configured in `src/routes.js` and wired into `<Routes>` in `src/App.tsx`.
+
+| Path | View component | Description |
+| --- | --- | --- |
+| `/` | `views/landing/Landing` | Primary landing page. |
+| `/terms-of-use` | `views/legal/Terms` | Terms of Use page. |
+| `/privacy-policy` | `views/legal/Privacy` | Privacy Policy page. |
+| `*` | `views/notFound/NotFound` | 404 fallback. |
+
+## Styling
+
+- Uses **styled-components** for most layout and typography.
+- Global CSS resets and typography are defined in `src/globalStyles.tsx`.
+- Component-specific styles live in adjacent `styles.tsx` files.
+
+## Data flow (RSS ticker)
+
+1. `TickerFeed` calls `/api/feed/rss` on mount.
+2. The response is mapped into link elements.
+3. `react-ticker` animates the scrolling display.
+
+See `src/components/tickerFeed/` for implementation details.
+
+## Static assets
+
+- Asset files live under `public/` and `public/images`.
+- Webpack copies assets during build based on imports in components and the HTML template.
+
+## Docker build notes
+
+The `Dockerfile` performs a two-stage build:
+
+1. Builds the React app with Node 18 Alpine.
+2. Serves the static build with Nginx.
+
+> The Dockerfile expects `client/nginx/nginx.conf` to exist. Ensure that file is present before building or update the Dockerfile accordingly.
+
+## Further documentation
+
+- `src/README.md` – source tree overview
+- `src/components/**/README.md` – component-level documentation
+- `src/views/**/README.md` – page-level documentation

--- a/socioprophet-web/client/src/README.md
+++ b/socioprophet-web/client/src/README.md
@@ -1,20 +1,49 @@
 # Client Source
 
-## Purpose
-Contains the React application source code, including routing, views, components, and shared styling.
+This directory contains the **entire React application**. It is organized by entry points, route-level views, and reusable components, with styling co-located via styled-components.
 
-## Core Files
-- `index.tsx` – React entry point that mounts `<App />`.
-- `App.tsx` – Applies global styles and routes.
-- `routes.js` – Route definitions for the SPA.
-- `routes.d.ts` – Type definitions to support the `routes` module.
-- `globalStyles.tsx` – Global CSS reset and theme defaults via styled-components.
+## File inventory (top level)
 
-## Structure
-- `components/` – Reusable UI components (header, footer, ticker feed, etc.).
-- `views/` – Page-level layouts mapped in `routes.js`.
-- `constants/` – Shared configuration values such as URL mappings.
+| File/Folder | Purpose |
+| --- | --- |
+| `index.tsx` | React entry point; mounts `<App />` into `#root`. |
+| `App.tsx` | Router container and `GlobalStyles`. |
+| `routes.js` | Route map for the SPA. |
+| `routes.d.ts` | Type definitions for `routes.js`. |
+| `globalStyles.tsx` | Global CSS and base typography via styled-components. |
+| `components/` | Reusable UI building blocks. |
+| `views/` | Page-level compositions that map to routes. |
+| `constants/` | Shared constants (links and URLs). |
 
-## Notes
-- Route-level components live under `views/` and should orchestrate components rather than implement styling directly.
-- Favor `styled-components` for styles to keep visuals co-located with components.
+## Routing flow
+
+1. `routes.js` defines the array of routes.
+2. `App.tsx` maps that array into `<Route />` components.
+3. Each route points to a view under `views/`.
+
+## Styling approach
+
+- **Global styles:** `globalStyles.tsx` sets typography, layout resets, and base colors.
+- **Local styles:** Each component/view includes a `styles.tsx` file with styled-components.
+
+## Components
+
+The `components/` directory has dedicated READMEs for each component group. Start with:
+
+- `components/README.md` – index of component groups
+- `components/header/README.md` – header navigation
+- `components/tickerFeed/README.md` – RSS ticker logic
+
+## Views
+
+Views are page-level and should avoid embedding reusable elements directly. The view READMEs describe layout and ownership:
+
+- `views/README.md`
+- `views/landing/README.md`
+- `views/legal/README.md`
+- `views/notFound/README.md`
+
+## Constants
+
+- `constants/urls.ts` maps named links (e.g., Terms, Privacy, GitHub, Blog) to their destinations.
+- Update URLs here instead of hardcoding them in components.

--- a/socioprophet-web/client/src/components/README.md
+++ b/socioprophet-web/client/src/components/README.md
@@ -1,17 +1,28 @@
 # Components
 
-## Purpose
-Reusable UI building blocks for the SocioProphet frontend.
+Reusable UI building blocks for the SocioProphet frontend. Each component group has its own directory with implementation (`*.tsx`) and styles (`styles.tsx`), plus a dedicated README with details.
 
-## Component Groups
-- `header/` – Global navigation bar and title.
-- `footer/` – Footer links and copyright line.
-- `headerLink/` – Small link wrapper used by the header.
-- `logo/` – Hero logo image component.
-- `main/` – Hero banner and feature section layout.
-- `featureItem/` – Individual feature card used in the landing page.
-- `tickerFeed/` – RSS ticker that streams feed entries across the top of the page.
+## Component index
+
+| Component | Purpose | Key files |
+| --- | --- | --- |
+| `header/` | Fixed top navigation with brand title and external links. | `Header.tsx`, `styles.tsx` |
+| `footer/` | Footer navigation and copyright line. | `Footer.tsx`, `FooterLink.tsx`, `styles.tsx` |
+| `headerLink/` | Consistent link styling for header navigation. | `HeaderLink.tsx`, `styles.tsx` |
+| `logo/` | Renders the hero logo image. | `Logo.tsx`, `styles.tsx` |
+| `main/` | Landing page hero + about sections. | `MainHero.tsx`, `MainAbout.tsx`, `styles.tsx` |
+| `featureItem/` | Individual feature card used by the landing page. | `FeatureItem.tsx`, `styles.tsx` |
+| `tickerFeed/` | Fetches and renders the scrolling RSS ticker. | `TickerFeed.tsx`, `RssFeedData.tsx`, `styles.tsx`, `types.ts` |
 
 ## Conventions
-- Each component typically has a `.tsx` implementation and a `styles.tsx` file with styled-components.
-- Keep components focused and composable; avoid routing or global state here.
+
+- **Co-location:** JSX and styled-components are kept together in each component directory.
+- **Props:** Components are typed explicitly (see `FeatureItem` and `TickerFeed` for examples).
+- **Routing:** Components do *not* create routes; routing is handled by `src/routes.js`.
+
+## How to add a new component
+
+1. Create a new folder under `components/`.
+2. Add `ComponentName.tsx` and `styles.tsx`.
+3. Add a `README.md` documenting the component’s responsibilities and props.
+4. Export the component (optionally via an `index.ts`).

--- a/socioprophet-web/client/src/constants/README.md
+++ b/socioprophet-web/client/src/constants/README.md
@@ -1,11 +1,19 @@
 # Client Constants
 
-## Purpose
 Central location for shared constants used by UI components and views.
 
-## Key Files
-- `urls.ts` – Maps UI labels to link destinations (contact email, privacy policy, terms of use, and external links).
+## Files
 
-## Notes
-- Keep external URLs here so navigation components can remain stateless.
-- Update these values if branding or destination URLs change.
+| File | Purpose |
+| --- | --- |
+| `urls.ts` | Maps labels to URLs and mailto destinations used across the app. |
+
+## Usage
+
+- Imported by the `Header` and `Footer` components.
+- Keeps external destinations centralized to avoid duplication.
+
+## Guidance
+
+- Update values here if link destinations change.
+- Avoid hardcoding external URLs directly in components.

--- a/socioprophet-web/client/src/views/README.md
+++ b/socioprophet-web/client/src/views/README.md
@@ -1,13 +1,22 @@
 # Views
 
-## Purpose
-Route-level components that map to the SPA’s pages. Views compose lower-level components and own page layout.
+Views are **route-level** components that map directly to URL paths. Each view composes shared components and owns page layout.
 
-## Structure
-- `landing/` – Home page composition.
-- `legal/` – Terms of Use and Privacy Policy pages.
-- `notFound/` – 404 fallback view.
+## View index
 
-## Notes
-- Views are referenced in `src/routes.js`.
-- Keep shared styling for a view in the view’s own `styles.tsx` file.
+| View | Route | Purpose | Files |
+| --- | --- | --- | --- |
+| Landing | `/` | Primary landing page. | `landing/Landing.tsx` |
+| Terms | `/terms-of-use` | Terms of Use policy page. | `legal/Terms.tsx` |
+| Privacy | `/privacy-policy` | Privacy Policy page. | `legal/Privacy.tsx` |
+| Not Found | `*` | 404 fallback. | `notFound/NotFound.tsx` |
+
+## Shared conventions
+
+- Views should avoid duplicating global layout elements; use `Header`, `Footer`, and other shared components.
+- Layout styling for a view belongs in the view’s `styles.tsx` file.
+- Any static copy that is specific to a page (terms, privacy) lives directly in the view file.
+
+## Where routes are configured
+
+Routes are defined in `src/routes.js` and rendered in `src/App.tsx` via `react-router-dom`.

--- a/socioprophet-web/scripts/README.md
+++ b/socioprophet-web/scripts/README.md
@@ -1,16 +1,40 @@
 # Scripts
 
-## Purpose
-Helper scripts invoked by the root `Makefile` to install dependencies and run the client/server together.
+Helper shell scripts invoked by the **root Makefile**. These scripts are intentionally small, and each assumes it is run from inside `socioprophet-web/scripts`.
 
-## Scripts
-- `install_web.sh`
-  - Installs dependencies in `client/` and `server/` sequentially.
-  - Uses Yarn in each directory.
-- `run_web.sh`
-  - Starts the server (`yarn run dev`) in the background.
-  - Starts the client (`yarn run start`) in the foreground.
+## Files
+
+| Script | Description |
+| --- | --- |
+| `install_web.sh` | Installs dependencies in `client/` and `server/` sequentially using Yarn. |
+| `run_web.sh` | Runs the server in the background and the client in the foreground. |
+
+## install_web.sh
+
+```bash
+cd .. && cd client && yarn
+cd .. && cd server && yarn
+```
+
+**Behavior:**
+- Installs `client/` dependencies first.
+- Installs `server/` dependencies second.
+- Does not accept arguments or flags.
+
+## run_web.sh
+
+```bash
+cd .. && cd server && (yarn run dev&)
+cd .. && cd client && yarn run start
+```
+
+**Behavior:**
+- Starts the server with `yarn run dev` **in the background**.
+- Starts the client with `yarn run start` **in the foreground**.
+- Relies on `.env` files in both directories for port configuration.
 
 ## Notes
-- These scripts assume they are executed from within `socioprophet-web/scripts` (as the Makefile does).
-- If you change client or server script names, update these files and the Makefile accordingly.
+
+- These scripts must be executed from `socioprophet-web/scripts` (the Makefile enforces this).
+- If you rename any `package.json` scripts, update these files and the root `Makefile`.
+- Because the server is backgrounded, you may need to manually stop it when finished (e.g., `pkill -f src/server.ts`).

--- a/socioprophet-web/server/README.md
+++ b/socioprophet-web/server/README.md
@@ -1,30 +1,78 @@
 # Server
 
-## Purpose
-The server directory hosts a lightweight Express application that provides the RSS feed API consumed by the frontend ticker.
+The server is a **lightweight Express API** that provides the RSS feed data consumed by the frontend ticker. It performs a single upstream fetch, normalizes the data into JSON, and caches responses for performance.
 
-## Entry Points
-- `src/server.ts` – Bootstraps the Express app, configures middleware, and mounts API routes.
+## Responsibilities
 
-## Runtime Responsibilities
-- Serve JSON data from the Hacker News RSS feed.
-- Apply middleware for compression, security headers, CORS, and session/cookie handling.
-- Provide a single API namespace under `/api/feed`.
+- Fetch Hacker News RSS (`https://hnrss.org/newest`).
+- Convert XML to JSON (array of `{ title, link }`).
+- Cache responses for 10 minutes.
+- Expose the API at `/api/feed/rss`.
 
-## Key Files
-- `package.json` – Contains dependencies such as `express`, `jsdom`, `node-cache`, and `node-fetch`.
-- `tsconfig.json` – TypeScript configuration for the server.
-- `Dockerfile` – Container build instructions for deployment.
-- `src/routes/api/rss-route.ts` – Implements `/api/feed/rss`.
-- `src/constants/index.js` – Centralized constants (e.g., `HN_URL`).
+## Directory layout
 
-## Environment Expectations
-- `PORT` – The HTTP port the server listens on.
+| Path | Description |
+| --- | --- |
+| `src/` | Server source code (entry point, routes, constants). |
+| `Dockerfile` | Container build for the API server. |
+| `.env.example` | Example environment variables. |
+| `package.json` | Scripts and dependencies. |
+| `tsconfig.json` | TypeScript configuration. |
 
-## Development
-- `yarn run dev` – Starts the server with `nodemon`.
-- `yarn start` – Runs the server directly with Node.
+## Entry point
 
-## Notes
-- The server uses CommonJS `require` in `.ts` files; keep consistency when adding new modules.
-- Responses are cached for 10 minutes using `node-cache`.
+- `src/server.ts` – Configures Express middleware and mounts `/api/feed` routes.
+
+## Environment variables
+
+Create `server/.env` (see `.env.example`).
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `PORT` | ✅ | Port the Express server listens on. |
+
+## Scripts
+
+| Script | Command | Description |
+| --- | --- | --- |
+| Start | `yarn start` | Runs the server directly with Node. |
+| Dev | `yarn run dev` | Runs the server with `nodemon`. |
+
+## Middleware stack (order matters)
+
+`src/server.ts` registers middleware in this order:
+
+1. `cookie-session` – session cookies.
+2. `cors` – allows cross-origin requests.
+3. `helmet` – security headers.
+4. `compression` – gzip compression.
+5. `express.json` – JSON parsing.
+6. `express.urlencoded` – URL-encoded parsing.
+7. `cookie-parser` – cookie parsing.
+
+## API routes
+
+| Route | Method | Description |
+| --- | --- | --- |
+| `/api/feed/rss` | GET | Returns cached JSON from the HN RSS feed. |
+
+For implementation details, see `src/routes/api/rss-route.ts` and its README.
+
+## Caching behavior
+
+- Uses `node-cache` with a **600 second** TTL.
+- Cache key = `HN_URL` constant.
+- If cache is present, no upstream request is made.
+
+## Docker notes
+
+- Base image: `node:18-alpine`.
+- The container runs `yarn start`.
+- Ensure `PORT` is configured at runtime.
+
+## Further documentation
+
+- `src/README.md` – overview of server source structure
+- `src/routes/README.md` – route-level conventions
+- `src/routes/api/README.md` – API-specific notes
+- `src/constants/README.md` – shared constants

--- a/socioprophet-web/server/src/README.md
+++ b/socioprophet-web/server/src/README.md
@@ -1,19 +1,32 @@
 # Server Source
 
-## Purpose
-Holds all runtime source for the Express server.
+This directory contains the runtime source for the Express server. The code is intentionally small and focused on a single API endpoint.
 
-## Structure
-- `server.ts` – Application entry point; configures middleware and mounts routes.
-- `routes/` – Express routers grouped by feature area.
-- `constants/` – Shared constants used by routes and middleware.
+## Top-level layout
 
-## Execution Flow
-1. `server.ts` loads environment variables when not in production.
-2. Express middleware is registered (sessions, CORS, security headers, compression, parsers).
-3. API routes are mounted at `/api/feed`.
-4. The server listens on `process.env.PORT` and handles shutdown on `SIGINT`.
+| Path | Purpose |
+| --- | --- |
+| `server.ts` | Entry point; registers middleware and mounts routes. |
+| `routes/` | Express routers grouped by feature area. |
+| `constants/` | Shared constants (URLs, configuration values). |
 
-## Notes
-- Keep route modules focused on request/response logic; share reusable values via `constants/`.
-- Add new API route groups by creating a new subfolder under `routes/` and mounting it in `server.ts`.
+## Execution flow (startup)
+
+1. If `NODE_ENV` is not `production`, loads `.env` with `dotenv`.
+2. Creates an Express `app` instance.
+3. Registers middleware (sessions, CORS, security, compression, parsers).
+4. Mounts API routes at `/api/feed`.
+5. Starts listening on `process.env.PORT`.
+6. Handles `SIGINT` for graceful shutdown.
+
+## Conventions
+
+- Use CommonJS `require` in TypeScript files to match existing modules.
+- Keep route handlers small and delegate shared values to `constants/`.
+- Prefer stateless route handlers with explicit input/output.
+
+## Where to look next
+
+- `routes/README.md` – router layout and conventions
+- `routes/api/README.md` – the RSS endpoint details
+- `constants/README.md` – shared constants

--- a/socioprophet-web/server/src/constants/README.md
+++ b/socioprophet-web/server/src/constants/README.md
@@ -1,13 +1,20 @@
 # Server Constants
 
-## Purpose
 Centralized constants used by server modules, keeping magic strings and URLs in one place.
 
-## Current Constants
-- `HN_URL` (from `index.js`) – The Hacker News RSS feed endpoint (`https://hnrss.org/newest`).
+## Files
 
-## Usage
-- Imported by `src/routes/api/rss-route.ts` to fetch and cache the feed.
+| File | Description |
+| --- | --- |
+| `index.js` | Exports shared constants (currently only `HN_URL`). |
 
-## Notes
-- Prefer adding new shared constants here rather than duplicating values across route files.
+## Current constants
+
+| Constant | Value | Used by |
+| --- | --- | --- |
+| `HN_URL` | `https://hnrss.org/newest` | `src/routes/api/rss-route.ts` |
+
+## Guidance
+
+- Add new shared values here rather than duplicating them in route modules.
+- Keep naming uppercase and descriptive (e.g., `EXTERNAL_API_URL`).

--- a/socioprophet-web/server/src/routes/README.md
+++ b/socioprophet-web/server/src/routes/README.md
@@ -1,12 +1,19 @@
 # Server Routes
 
-## Purpose
 Contains Express routers grouped by API namespace.
 
 ## Structure
-- `api/` – Routes intended for client consumption (currently the RSS feed endpoint).
+
+| Path | Description |
+| --- | --- |
+| `api/` | Endpoints intended for client consumption. |
 
 ## Conventions
-- Keep routers small and focused on a single resource or feature.
-- Export routers with `module.exports = router` for consistency with the server entry point.
-- Mount routers in `src/server.ts` so the route tree is visible from one place.
+
+- Each router should focus on a single resource or feature.
+- Export routers with `module.exports = router` to match current usage.
+- Mount routers in `src/server.ts` to keep route wiring centralized.
+
+## Current routers
+
+- `api/rss-route.ts` – Hacker News RSS JSON endpoint.

--- a/socioprophet-web/server/src/routes/api/README.md
+++ b/socioprophet-web/server/src/routes/api/README.md
@@ -1,18 +1,25 @@
 # API Routes
 
-## Purpose
-Defines API endpoints that the frontend consumes. This layer is responsible for converting upstream data into a lightweight JSON payload.
+Defines API endpoints that the frontend consumes. This layer fetches upstream data, normalizes it to JSON, and returns a minimal payload to the client.
 
-## Current Endpoints
-- `GET /api/feed/rss` – Fetches and caches the Hacker News RSS feed. Returns an array of items with `title` and `link`.
+## Current endpoints
 
-## Key Files
-- `rss-route.ts`
-  - Fetches XML from `HN_URL`.
-  - Uses `jsdom` to parse the RSS feed into DOM nodes.
-  - Transforms `item` nodes into `{ title, link }` objects.
-  - Caches the result in `node-cache` for 10 minutes.
+| Method | Path | Response | Source |
+| --- | --- | --- | --- |
+| GET | `/api/feed/rss` | `[{ title, link }, ...]` | `https://hnrss.org/newest` |
 
-## Notes
-- New API routes should follow the same pattern: parse upstream data, normalize it, then send JSON.
-- If you introduce new external calls, consider adding caching or throttling to avoid rate limits.
+## Implementation details (`rss-route.ts`)
+
+- Fetches XML from `HN_URL` (defined in `src/constants/index.js`).
+- Uses `jsdom` to parse the RSS response into DOM nodes.
+- Extracts `<title>` and `<link>` from each `<item>`.
+- Stores the normalized array in `node-cache` for 10 minutes.
+- Returns cached data if available to avoid hitting the upstream endpoint.
+
+## Error handling
+
+- The current implementation does not explicitly handle fetch failures.
+- If you add additional endpoints, consider:
+  - `try/catch` around upstream calls.
+  - Status code and error payload conventions.
+  - Cache invalidation policies.


### PR DESCRIPTION
### Motivation
- Provide comprehensive, pedantic documentation for users and contributors across the monorepo.
- Clarify setup, environment variables, and development workflows for both the client and server.
- Make the client architecture and data flow (routing, components, styling, RSS ticker) explicit for maintainers.
- Explain server behavior, middleware order, API endpoint (`GET /api/feed/rss`), caching, and Docker expectations.

### Description
- Rewrote and expanded the root `README.md` and `socioprophet-web/README.md` to include quick-start, prerequisites, env var tables, and common tasks (e.g., `make install_web`, `make run_web`).
- Added and expanded README files under `socioprophet-web/client`, `socioprophet-web/client/src`, `socioprophet-web/client/src/components`, `socioprophet-web/client/src/constants`, and `socioprophet-web/client/src/views` to document routing, styling, components, and the RSS ticker data flow.
- Added and expanded server documentation in `socioprophet-web/server`, `socioprophet-web/server/src`, `socioprophet-web/server/src/constants`, `socioprophet-web/server/src/routes`, and `socioprophet-web/server/src/routes/api` to document middleware order, constants, caching behavior, and implementation details of the RSS route.
- Documentation-only edits span multiple files (13 files changed in the commit with approximately 583 insertions and 191 deletions) and include notes about Dockerfiles and script behavior (`scripts/install_web.sh`, `scripts/run_web.sh`).

### Testing
- No automated tests were run because these changes are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955ba6ff788832392374f7bcfa575c4)