### PR TITLE
marketing: add Organizations lane + fix landing styling in dev

### DIFF
--- a/marketing/public/index.html
+++ b/marketing/public/index.html
@@ -31,7 +31,7 @@
       gtag("config", "G-GL5Y2786Z6");
       function spTrack(name, params){ try{ if(typeof gtag==="function") gtag("event", name, params||{}); }catch(e){} }
     </script>
-    <link rel="stylesheet" href="/tailwind.css">
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 
   <body class="bg-white text-slate-900 font-sans">

--- a/marketing/public/index.html
+++ b/marketing/public/index.html
@@ -43,6 +43,7 @@
         </a>
 
         <nav class="flex items-center gap-6 text-sm">
+          <a class="hover:underline" href="/organizations/">Organizations</a>
           <a class="hover:underline" href="/documentation" onclick="spTrack(cta_docs_click,{href:this.getAttribute(href)});">Documentation</a>
           <a class="hover:underline" href="https://vue.socioprophet.com" onclick="spTrack(cta_portal_click,{href:this.getAttribute(href)});">Portal</a>
           <a class="inline-flex items-center rounded-md bg-slate-900 px-4 py-2 text-white hover:bg-slate-800"


### PR DESCRIPTION
Summary:\n- Add /organizations/ landing page (people-first platform, org lane supports commons)\n- Add Organizations link in landing nav\n- Fix dev landing styling by restoring Tailwind CDN runtime (compiled tailwind.css was broken)\n\nNotes:\n- Dev URLs:\n  - https://socioprophet-marketing-dev.web.app/\n  - https://socioprophet-marketing-dev.web.app/organizations/\n\nNext:\n- Align Academy surface + survey schema\n- Implement first-party /api/lead capture so surveys store email+segmentation without tracker reliance\n