### PR TITLE
chore: improve hygiene check preflight and include agentplane hygiene

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -7,6 +7,12 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUTDIR="$(mktemp -d)"
 trap 'rm -rf "$OUTDIR"' EXIT
 
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "[check] ERROR: missing dependency: PyYAML (import yaml failed)." >&2
+  echo "[check] Hint: install dev dependencies with: python3 -m pip install -r requirements-dev.txt" >&2
+  exit 2
+fi
+
 python3 "$ROOT/scripts/validate_registry.py" \
   "$ROOT/registry/agentos-tool-registry.yaml" \
   "$ROOT/registry/base-image-tools.yaml" \
@@ -14,3 +20,8 @@ python3 "$ROOT/scripts/validate_registry.py" \
 
 python3 "$ROOT/agentplane/scripts/validate_bundle.py" \
   "$ROOT/agentplane/bundles/example-agent/bundle.json"
+
+(
+  cd "$ROOT/agentplane"
+  bash scripts/hygiene.sh
+)


### PR DESCRIPTION
### Motivation
- Make the repository-level hygiene check fail fast with a clear remediation when the `PyYAML` dependency is missing.
- Ensure the top-level `scripts/check.sh` covers Agentplane script hygiene so one command validates registry, bundle, and script syntax hygiene end-to-end.

### Description
- Update `scripts/check.sh` to perform a PyYAML preflight (`python3 -c 'import yaml'`) that prints an actionable hint to run `python3 -m pip install -r requirements-dev.txt` and exits non-zero on failure.
- Extend `scripts/check.sh` to `cd` into `agentplane` and run `agentplane/scripts/hygiene.sh` as part of the standard check flow.

### Testing
- Ran `bash scripts/check.sh`, which now exits early with an explicit PyYAML error when the dependency is not installed (expected in this environment).
- Ran `cd agentplane && bash scripts/hygiene.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d18c9c6e58832388a4da26c60fec79)