### PR TITLE
chore: ignore Yarn Berry cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ local_deploy/
 .env
 
 .DS_Store
+
+# Yarn berry cache/state
+**/.yarn/
+**/.yarnrc.yml
 # Secrets / local env
 .env.*
 *.pem


### PR DESCRIPTION
### Motivation
- Prevent local Yarn Berry cache and state files from appearing as untracked files across workspace packages by updating repository ignore rules.

### Description
- Add `**/.yarn/` and `**/.yarnrc.yml` entries to the repository-level `.gitignore`.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d18fc951ac832380393ba57f17e55a)