### PR TITLE
Add AOKC repo alignment and merge-order note

### DIFF
--- a/docs/agentic-open-knowledge-commons-repo-alignment.md
+++ b/docs/agentic-open-knowledge-commons-repo-alignment.md
@@ -1,0 +1,70 @@
+# Agentic Open Knowledge Commons repo alignment v0.1
+
+## Purpose
+
+This note records where the first Agentic Open Knowledge Commons work belongs in the current SocioProphet GitHub organization.
+
+## Current placement
+
+### `socioprophet-standards-storage`
+Owns the normative contract pack:
+- `GeneralDescriptor`
+- `OrderDescriptor`
+- initial event contracts
+- ADR for the descriptor split
+
+### `socioprophet-standards-knowledge`
+Owns knowledge semantics:
+- object class taxonomy
+- promotion rules
+- PARA projection rules
+- content space model
+- JSON-LD context skeleton
+
+### `TriTRPC`
+Owns typed carriage and deterministic transport notes for:
+- descriptor services
+- order services
+- execution bridge services
+- future fixture vectors
+
+### `agentplane`
+Owns the narrow execution bridge:
+- `OrderDescriptor` to `Bundle` mapping note
+- evidence linking for `orderId` and `descriptorId`
+
+### `socioprophet`
+Owns umbrella integration and cross-repo alignment.
+It should not absorb the full commons runtime, but it should document the dependency chain and integration seams.
+
+## Open PR set
+
+- `socioprophet-standards-storage` PR #11 — descriptor contract pack
+- `socioprophet-standards-knowledge` PR #22 — taxonomy and promotion rules
+- `TriTRPC` PR #19 — descriptor and order transport notes
+- `agentplane` PR #11 — order-to-bundle bridge notes
+
+## Merge order
+
+The intended merge order is:
+1. `socioprophet-standards-storage`
+2. `socioprophet-standards-knowledge`
+3. `TriTRPC`
+4. `agentplane`
+
+This preserves dependency direction:
+- contracts first
+- semantics second
+- transport third
+- execution bridge fourth
+
+## Next runtime step
+
+After the four PRs above land, the next step is to create the dedicated commons runtime repository and wire it to the staged contracts rather than inventing new ones.
+
+## Constraint
+
+The commons runtime must not duplicate:
+- transport responsibilities already owned by `TriTRPC`
+- execution responsibilities already owned by `agentplane`
+- normative schema ownership already held by the standards repositories

--- a/docs/agentic-open-knowledge-commons-runtime-bootstrap.md
+++ b/docs/agentic-open-knowledge-commons-runtime-bootstrap.md
@@ -1,0 +1,48 @@
+# Agentic Open Knowledge Commons runtime bootstrap v0.1
+
+## Purpose
+
+This note defines the first post-merge bootstrap path for the dedicated commons runtime.
+
+## Constraint
+
+The runtime must consume the staged contracts and bridge notes. It must not invent a competing descriptor, order, transport, or execution model.
+
+## First end-to-end slice
+
+The first runtime slice should implement this path:
+
+1. ingest a GitHub-backed knowledge object
+2. wrap it in a valid `GeneralDescriptor`
+3. register it through the descriptor service surface
+4. create an `OrderDescriptor` for promotion or publication when needed
+5. validate the order
+6. resolve to `agentplane` only if governed execution is required
+7. preserve `descriptorId` and `orderId` in resulting evidence
+8. expose retrieval by descriptor id, task, and PARA projection
+
+## Minimum runtime components
+
+- connector adapter for GitHub
+- descriptor registry client
+- order orchestration client
+- policy check hook
+- optional execution bridge client
+- retrieval/index projection layer
+
+## First code-facing milestone
+
+A runtime implementation is ready for its first PR when it can:
+- read a GitHub source object
+- emit a valid `GeneralDescriptor`
+- emit a valid `OrderDescriptor`
+- call the typed transport surface with stable schema/context identifiers
+- persist the resulting ids and evidence refs
+
+## Dependency chain
+
+The runtime should start only after these PRs are merged:
+- `socioprophet-standards-storage` PR #11
+- `socioprophet-standards-knowledge` PR #22
+- `TriTRPC` PR #19
+- `agentplane` PR #11

--- a/docs/agentic-open-knowledge-commons-stack-status-2026-04-09.md
+++ b/docs/agentic-open-knowledge-commons-stack-status-2026-04-09.md
@@ -1,0 +1,64 @@
+# Agentic Open Knowledge Commons live stack status — 2026-04-09
+
+## Purpose
+
+This note records the updated live state of the staged AOKC stack after the latest repository changes.
+
+## Merged foundation PRs
+
+### `socioprophet-standards-storage` PR #11
+Merged.
+Contains:
+- `GeneralDescriptor` schema v0.1
+- `OrderDescriptor` schema v0.1
+- initial event contracts
+- ADR for descriptor split
+- descriptor and order examples
+
+### `TriTRPC` PR #19
+Merged.
+Contains:
+- descriptor/order/execution-bridge contract notes
+- descriptor and order example payloads
+- initial fixture placeholders
+
+### `agentplane` PR #11
+Merged.
+Contains:
+- order-to-bundle bridge note
+- evidence-linking note
+- implementation checklist
+
+## Remaining open PRs
+
+### `socioprophet-standards-knowledge` PR #22
+Still open.
+This remains the knowledge-semantics layer:
+- object class taxonomy
+- promotion rules
+- PARA projection rules
+- content space model
+- JSON-LD context skeleton
+
+### `socioprophet` PR #255
+Still open.
+This remains the umbrella alignment and merge-order lane.
+
+### `socioprophet` PR #256
+Still open.
+This remains the temporary umbrella-repo runtime incubator and now contains starter runtime stubs in addition to docs and examples.
+
+## Immediate dependency order
+
+Given the current live state, the remaining intended order is:
+1. `socioprophet-standards-knowledge` PR #22
+2. `socioprophet` PR #255
+3. `socioprophet` PR #256
+
+## Follow-on work
+
+Now that the transport foundation in `TriTRPC` has merged, follow-on transport example and fixture work should land as new PRs against `main`, not as additions to the already-merged PR #19 branch.
+
+## Exit condition
+
+After the remaining open PRs land, the temporary `aokc-runtime/` incubator in `socioprophet` PR #256 should be extracted into a dedicated commons runtime repository.

--- a/docs/agentic-open-knowledge-commons-stack-status.md
+++ b/docs/agentic-open-knowledge-commons-stack-status.md
@@ -1,0 +1,59 @@
+# Agentic Open Knowledge Commons live stack status
+
+## Purpose
+
+This note records the current staged AOKC pull-request stack as it exists today in the SocioProphet GitHub organization.
+
+## Live staged PR set
+
+1. `socioprophet-standards-storage` PR #11
+   - descriptor contract pack
+   - event contracts
+   - ADR for descriptor split
+   - descriptor and order examples
+
+2. `socioprophet-standards-knowledge` PR #22
+   - object class taxonomy
+   - promotion rules
+   - PARA projection rules
+   - content space model
+   - JSON-LD context skeleton
+
+3. `TriTRPC` PR #19
+   - descriptor/order/execution-bridge contract notes
+   - descriptor and order example payloads
+   - fixture placeholders
+
+4. `agentplane` PR #11
+   - order-to-bundle bridge note
+   - evidence-linking note
+   - implementation checklist
+
+5. `socioprophet` PR #255
+   - umbrella repo alignment note
+   - merge-order note
+
+6. `socioprophet` PR #256
+   - temporary runtime bootstrap scaffold
+   - first-slice flow
+   - runtime implementation checklist
+   - concrete example descriptor/order payloads for the first slice
+
+## Intended merge order
+
+The intended merge order is:
+1. `socioprophet-standards-storage` PR #11
+2. `socioprophet-standards-knowledge` PR #22
+3. `TriTRPC` PR #19
+4. `agentplane` PR #11
+5. `socioprophet` PR #255
+6. `socioprophet` PR #256
+
+## Dependency rule
+
+PR #256 is downstream of the preceding five PRs.
+It is a temporary incubator in the umbrella repo and must not be treated as a substitute for a dedicated commons runtime repository.
+
+## Exit condition
+
+After the stack above lands, the temporary `aokc-runtime/` scaffold should be extracted into a dedicated commons runtime repository and continue from there.


### PR DESCRIPTION
## Summary
- add umbrella repo alignment note for the Agentic Open Knowledge Commons
- record where the staged work lives across the org
- record the intended merge order and dependency direction

## Why
The commons work now spans standards, knowledge semantics, typed transport, and execution bridging. This note keeps the integration layer explicit in the umbrella repo so follow-on runtime work lands against the right contract spine.

## File
- `docs/agentic-open-knowledge-commons-repo-alignment.md`
