### PR TITLE
Docs: add public trust and assurance surface pages

### DIFF
--- a/docs/guide/deployment-modes-and-data-boundaries.md
+++ b/docs/guide/deployment-modes-and-data-boundaries.md
@@ -1,0 +1,31 @@
+# Deployment Modes and Data Boundaries
+
+This page summarizes the public deployment and data-boundary posture for the visible SocioProphet surface.
+
+## Public-safe deployment modes
+
+Publicly visible deployment discussion should distinguish among:
+
+- local or bounded environments
+- institutionally governed deployments
+- hosted or integrated public surfaces
+
+## Boundary principle
+
+Different deployment modes imply different data and control boundaries.
+
+The public docs should make those differences legible without publishing restricted operational internals.
+
+## Why this matters
+
+Institutions evaluating the platform need to understand:
+
+- where data and control boundaries sit
+- which surfaces are public-safe
+- which details remain restricted by design
+
+## Related pages
+
+- [Trust Center](/guide/trust-center)
+- [Model Behavior and Command Resolution](/guide/model-behavior-and-command-resolution)
+- [Reporting and Disclosure](/guide/reporting-and-disclosure)

--- a/docs/guide/documentation-home-and-repository-status.md
+++ b/docs/guide/documentation-home-and-repository-status.md
@@ -1,0 +1,28 @@
+# Documentation Home and Repository Status
+
+This page explains where the canonical public documentation currently lives.
+
+## Canonical public docs home
+
+The canonical public docs home is currently:
+
+- repository: `SocioProphet/socioprophet`
+- docs system: **VitePress**
+- docs source path: `docs/`
+- VitePress config path: `docs/.vitepress/`
+
+## Repository status notes
+
+### `SocioProphet/socioprophet`
+This repository currently contains the active visible VitePress docs surface.
+
+### `SocioProphet/socioprophet-docs`
+That repository is a former docs surface and should be treated as archival / retired.
+
+## Contributor guidance
+
+If the goal is to improve or extend the public documentation, route work to the active VitePress docs surface rather than the retired docs repository.
+
+## Why this page exists
+
+This page exists to reduce confusion while the old docs repository is being retired and archived.

--- a/docs/guide/model-behavior-and-command-resolution.md
+++ b/docs/guide/model-behavior-and-command-resolution.md
@@ -1,0 +1,30 @@
+# Model Behavior and Command Resolution
+
+This page explains the public command-resolution posture for the visible SocioProphet surface.
+
+## Principles
+
+The public claim is not that the system acts with unlimited discretion.
+
+The public claim is that:
+
+- human intent and authority stay primary
+- bounded systems assist within explicit governance envelopes
+- consequential transitions are reviewable
+- public-safe documentation describes the boundary honestly
+
+## Resolution order
+
+At a high level, public-safe command resolution follows this order:
+
+1. explicit operator or user intent
+2. policy and safety boundary checks
+3. capability and routing eligibility
+4. execution within bounded runtime surfaces
+5. evidence and review output
+
+## What this page does not do
+
+This page does not publish restricted operational internals, tactical controls, or high-misuse-value details.
+
+Its purpose is to make the public command and control posture legible without turning the docs into an operator kit.

--- a/docs/guide/reporting-and-disclosure.md
+++ b/docs/guide/reporting-and-disclosure.md
@@ -1,0 +1,26 @@
+# Reporting and Disclosure
+
+This page summarizes the public reporting and disclosure posture for the visible SocioProphet surface.
+
+## Reporting channels
+
+Public-facing reporting should support:
+
+- documentation corrections
+- safety or governance concerns
+- responsible security disclosure through the appropriate channel
+- questions about public versus restricted boundaries
+
+## Disclosure principle
+
+Public reporting should improve safety, accuracy, and accountability without increasing misuse value.
+
+## Why this page exists
+
+A governed platform should make its reporting and disclosure posture legible rather than assuming trust by default.
+
+## Related pages
+
+- [Trust Center](/guide/trust-center)
+- [System Cards and Assurance](/guide/system-cards-and-assurance)
+- [Deployment Modes and Data Boundaries](/guide/deployment-modes-and-data-boundaries)

--- a/docs/guide/system-cards-and-assurance.md
+++ b/docs/guide/system-cards-and-assurance.md
@@ -1,0 +1,33 @@
+# System Cards and Assurance
+
+This page explains the role of public assurance artifacts in the visible SocioProphet surface.
+
+## What belongs here
+
+Public assurance artifacts can include:
+
+- system cards
+- model and capability notes
+- deployment-mode summaries
+- reporting and disclosure guidance
+- trust-center style explanations of the public boundary
+
+## What they should do
+
+These artifacts should:
+
+- explain what the public layer is claiming
+- explain what it is not claiming
+- clarify where restricted detail begins
+- support institutional review without inflating misuse value
+
+## What they should not do
+
+They should not become a hidden operator manual for sensitive workflows.
+
+## Relationship to the rest of the docs
+
+See also:
+- [Trust Center](/guide/trust-center)
+- [Deployment Modes and Data Boundaries](/guide/deployment-modes-and-data-boundaries)
+- [Reporting and Disclosure](/guide/reporting-and-disclosure)

--- a/docs/guide/trust-center.md
+++ b/docs/guide/trust-center.md
@@ -1,0 +1,48 @@
+# Trust Center
+
+This page summarizes the public trust and assurance posture for the visible SocioProphet documentation surface.
+
+## What this page is for
+
+Use this page when the question is:
+- what is the public trust posture of the system?
+- where is the line between public-safe and restricted material?
+- what can an institution evaluate from the public layer?
+
+## Public trust commitments
+
+The public layer is designed around:
+
+- bounded execution rather than ambient authority
+- evidence-bearing transitions for consequential actions
+- reversibility and reviewability for important state changes
+- explicit separation between public-safe and restricted material
+- human legitimacy and responsibility remaining primary
+
+## Current public assurance surfaces
+
+The public docs describe:
+
+- architecture
+- governance
+- safety boundaries
+- deterministic and bounded AI claims
+- evidence and provenance framing
+- institutional deployment posture
+
+## What is intentionally not public
+
+The public layer does not publish:
+
+- sensitive operator kits
+- exploit or persistence workflows
+- high-fidelity adversary procedures
+- restricted thresholds and misuse-amplifying internals
+
+## Reporting and review
+
+See:
+- [Reporting and Disclosure](/guide/reporting-and-disclosure)
+- [Deployment Modes and Data Boundaries](/guide/deployment-modes-and-data-boundaries)
+- [System Cards and Assurance](/guide/system-cards-and-assurance)
+- [Model Behavior and Command Resolution](/guide/model-behavior-and-command-resolution)


### PR DESCRIPTION
## Summary
- add a first trust-center style page set to the current visible VitePress docs lane
- add pages for trust center, model behavior and command resolution, system cards and assurance, deployment modes and data boundaries, and reporting and disclosure

## Why
The currently visible docs lane needs additive public trust/assurance material so the documentation surface does not lag behind the runtime/governance posture.

## Scope
Additive docs only. This PR does not yet patch nav/sidebar wiring.
