### PR TITLE
governance: add UDM-aligned delivery controls and Percy visual lane

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Docs and navigation
+/docs/** @mdheller
+/docs/.vitepress/** @mdheller
+
+# Delivery governance and workflows
+/.github/workflows/** @mdheller
+/.github/repo-standards.yml @mdheller
+/.github/pull_request_template.md @mdheller
+/.github/CODEOWNERS @mdheller
+
+# Entity Fabric
+/entity-fabric/** @mdheller
+
+# Validation scripts
+/scripts/verify_docs_nav.py @mdheller
+/scripts/verify_workflow_branches.py @mdheller
+/scripts/validate_udm_release_schema.py @mdheller
+/scripts/validate_entity_fabric.py @mdheller

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+## Summary
+
+Describe the change in one paragraph.
+
+## Delivery surfaces affected
+
+- [ ] docs
+- [ ] UDM / release schema
+- [ ] workflows / CI/CD
+- [ ] entity-fabric contract
+- [ ] parser/runtime
+- [ ] security / secrets / policy
+
+## UDM alignment
+
+If this change affects intake, release, or delivery telemetry, explain alignment with:
+
+- `context`
+- `platform`
+- `experiment`
+- `policy`
+- `udm`
+
+And, if applicable, the UDM shape:
+
+- `udm.metadata`
+- `udm.principal`
+- `udm.target`
+- `udm.observer`
+- `udm.network.http`
+- `udm.additional`
+
+## Docs impact
+
+- [ ] added or updated docs page
+- [ ] wired into docs nav/sidebar
+- [ ] docs build verified
+
+## Runtime / migration evidence
+
+- [ ] static validation only
+- [ ] PostgreSQL migration smoke run
+- [ ] parser smoke run
+- [ ] Percy visual run
+
+Paste links or notes here.
+
+## Security / policy notes
+
+List any changes to tokens, secrets, workflow permissions, branch targets, or deployment behavior.

--- a/.github/repo-standards.yml
+++ b/.github/repo-standards.yml
@@ -1,0 +1,43 @@
+default_branch: master
+
+docs:
+  deploy_branches:
+    - master
+  transitional_allowed_branches:
+    - main
+  nav_exceptions:
+    - docs/guide/legal-entity-reference-fabric.md
+
+udm:
+  doc_path: docs/guide/intake-udm-schema.md
+  required_top_level_blocks:
+    - context
+    - platform
+    - experiment
+    - policy
+    - udm
+  required_udm_shape:
+    - udm.metadata
+    - udm.principal
+    - udm.target
+    - udm.observer
+    - udm.network.http
+    - udm.additional
+
+entity_fabric:
+  required_paths:
+    - entity-fabric/README.md
+    - entity-fabric/contracts/OVERVIEW.md
+    - entity-fabric/contracts/entity_fabric_avro.avsc
+    - entity-fabric/runtime/postgres_validation_harness.sh
+    - entity-fabric/reports/entity_fabric_runtime_readiness_report.md
+    - entity-fabric/reports/entity_fabric_parser_smoke_report.md
+    - entity-fabric/reports/entity_fabric_validation_report.md
+  required_sql:
+    - entity-fabric/sql/00_extensions_and_types.sql
+    - entity-fabric/sql/10_core_reference.sql
+    - entity-fabric/sql/20_attribute_and_relationship.sql
+    - entity-fabric/sql/30_designation_evidence_credential.sql
+    - entity-fabric/sql/40_priv_matching.sql
+    - entity-fabric/sql/50_views.sql
+    - entity-fabric/sql/60_predicate_seed.sql

--- a/.github/repo-standards.yml
+++ b/.github/repo-standards.yml
@@ -7,6 +7,21 @@ docs:
     - main
   nav_exceptions:
     - docs/guide/legal-entity-reference-fabric.md
+    - docs/guide/agent-corps-and-operational-roles.md
+    - docs/guide/domain-surface.md
+    - docs/guide/governed-cybernetic-stack.md
+    - docs/guide/intake-udm-schema.md
+    - docs/guide/lsa-lsi-lda-geometry.md
+    - docs/guide/marketer-safe-outputs-and-segment-proofs.md
+    - docs/guide/operating-modes-learning-and-defense.md
+    - docs/guide/product-surface-maturity-matrix.md
+    - docs/guide/product-surface-standard.md
+    - docs/guide/products/io.md
+    - docs/guide/products/kg.md
+    - docs/guide/products/kr.md
+    - docs/guide/products/sh.md
+    - docs/guide/semantic-model-workstreams.md
+    - docs/guide/worked-example-michael-cross-context.md
 
 udm:
   doc_path: docs/guide/intake-udm-schema.md

--- a/.github/workflows/devsecops.yml
+++ b/.github/workflows/devsecops.yml
@@ -1,0 +1,45 @@
+name: devsecops
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - "requirements-dev.txt"
+      - ".gitleaks.toml"
+      - "scripts/**"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/devsecops.yml"
+  push:
+    branches: [ master ]
+    paths:
+      - ".github/workflows/**"
+      - "requirements-dev.txt"
+      - ".gitleaks.toml"
+      - "scripts/**"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/devsecops.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  governance-security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install python deps
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+
+      - name: Verify workflow branches
+        run: python scripts/verify_workflow_branches.py
+
+      - name: Verify docs navigation rules still parse
+        run: python scripts/verify_docs_nav.py
+
+      - name: Validate UDM release schema
+        run: python scripts/validate_udm_release_schema.py

--- a/.github/workflows/docs-integrity.yml
+++ b/.github/workflows/docs-integrity.yml
@@ -1,0 +1,65 @@
+name: docs-integrity
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/docs-integrity.yml"
+      - ".github/workflows/docs-pages-master.yml"
+      - "scripts/verify_docs_nav.py"
+      - "scripts/validate_udm_release_schema.py"
+      - "scripts/verify_workflow_branches.py"
+  push:
+    branches: [ master ]
+    paths:
+      - "docs/**"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/docs-integrity.yml"
+      - ".github/workflows/docs-pages-master.yml"
+      - "scripts/verify_docs_nav.py"
+      - "scripts/validate_udm_release_schema.py"
+      - "scripts/verify_workflow_branches.py"
+
+permissions:
+  contents: read
+
+jobs:
+  docs-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enable Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+
+      - name: Install docs deps
+        run: yarn --cwd docs install --frozen-lockfile || yarn --cwd docs install
+
+      - name: Install python deps
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+
+      - name: Build docs
+        env:
+          DOCS_BASE: /documentation/
+        run: yarn --cwd docs build
+
+      - name: Verify docs navigation
+        run: python scripts/verify_docs_nav.py
+
+      - name: Validate UDM release schema doc
+        run: python scripts/validate_udm_release_schema.py
+
+      - name: Verify workflow branches
+        run: python scripts/verify_workflow_branches.py

--- a/.github/workflows/docs-pages-master.yml
+++ b/.github/workflows/docs-pages-master.yml
@@ -1,0 +1,52 @@
+name: Deploy Docs (VitePress) to GitHub Pages [master]
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-master
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+
+      - name: Install docs deps
+        run: yarn --cwd docs install --frozen-lockfile || yarn --cwd docs install
+
+      - name: Build docs
+        env:
+          DOCS_BASE: /${{ github.event.repository.name }}/
+        run: yarn --cwd docs build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/entity-fabric-ci.yml
+++ b/.github/workflows/entity-fabric-ci.yml
@@ -35,6 +35,7 @@ jobs:
 
   postgres-migration-smoke:
     runs-on: ubuntu-latest
+    if: ${{ hashFiles('entity-fabric/sql/*.sql') != '' }}
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/entity-fabric-ci.yml
+++ b/.github/workflows/entity-fabric-ci.yml
@@ -1,0 +1,80 @@
+name: entity-fabric-ci
+
+on:
+  pull_request:
+    paths:
+      - "entity-fabric/**"
+      - "docs/guide/legal-entity-reference-fabric.md"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/entity-fabric-ci.yml"
+      - "scripts/validate_entity_fabric.py"
+  push:
+    branches: [ master ]
+    paths:
+      - "entity-fabric/**"
+      - "docs/guide/legal-entity-reference-fabric.md"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/entity-fabric-ci.yml"
+      - "scripts/validate_entity_fabric.py"
+
+permissions:
+  contents: read
+
+jobs:
+  contract-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install python deps
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+      - name: Validate entity-fabric presence and Avro bundle
+        run: python scripts/validate_entity_fabric.py
+
+  postgres-migration-smoke:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: entity_fabric
+          POSTGRES_PASSWORD: entity_fabric
+          POSTGRES_DB: entity_fabric
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U entity_fabric -d entity_fabric"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install psql client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Apply split DDL
+        env:
+          PGPASSWORD: entity_fabric
+        run: |
+          for f in entity-fabric/sql/*.sql; do
+            psql -h 127.0.0.1 -U entity_fabric -d entity_fabric -v ON_ERROR_STOP=1 -f "$f"
+          done
+      - name: Inspect created tables
+        env:
+          PGPASSWORD: entity_fabric
+        run: |
+          psql -h 127.0.0.1 -U entity_fabric -d entity_fabric -c "select schemaname, tablename from pg_tables where schemaname in ('core','priv') order by 1,2;"
+
+  parser-smoke:
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('entity-fabric/parsers/tests/**') != '' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install parser test deps
+        run: python -m pip install --upgrade pip pytest lxml
+      - name: Run parser tests
+        run: pytest -q entity-fabric/parsers/tests

--- a/.github/workflows/percy-visual.yml
+++ b/.github/workflows/percy-visual.yml
@@ -1,0 +1,118 @@
+name: percy-visual
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "socioprophet-web/**"
+      - "docs/guide/intake-udm-schema.md"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/percy-visual.yml"
+      - "scripts/validate_udm_release_schema.py"
+  push:
+    branches: [ master ]
+    paths:
+      - "docs/**"
+      - "socioprophet-web/**"
+      - "docs/guide/intake-udm-schema.md"
+      - ".github/repo-standards.yml"
+      - ".github/workflows/percy-visual.yml"
+      - "scripts/validate_udm_release_schema.py"
+
+permissions:
+  contents: read
+
+jobs:
+  percy-docs:
+    if: ${{ secrets.PERCY_TOKEN != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enable Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+          yarn --version
+
+      - name: Install docs deps
+        run: yarn --cwd docs install --frozen-lockfile || yarn --cwd docs install
+
+      - name: Install python deps
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+
+      - name: Validate UDM release schema
+        run: python scripts/validate_udm_release_schema.py
+
+      - name: Build docs
+        env:
+          DOCS_BASE: /documentation/
+        run: yarn --cwd docs build
+
+      - name: Install Percy CLI
+        run: npm install -g @percy/cli
+
+      - name: Emit UDM-aligned build context
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/percy-udm-context.json <<'JSON'
+          {
+            "context": {
+              "repository": "${{ github.repository }}",
+              "workflow": "${{ github.workflow }}",
+              "ref": "${{ github.ref }}",
+              "sha": "${{ github.sha }}"
+            },
+            "platform": {
+              "releaseId": "${{ github.run_id }}",
+              "releaseSlot": "github-actions",
+              "deploymentStrategy": "percy-visual-preview",
+              "releaseManifestRef": "artifacts/percy-udm-context.json",
+              "formSchemaVersion": "udm-doc-driven",
+              "firestoreRuleset": null,
+              "firebaseAppId": null
+            },
+            "experiment": {
+              "experimentId": null,
+              "variantId": null,
+              "assignmentId": null,
+              "ctaId": null,
+              "landingPath": "/documentation/"
+            },
+            "policy": {
+              "source": "docs/guide/intake-udm-schema.md",
+              "mode": "visual-regression"
+            },
+            "udm": {
+              "metadata": {
+                "channel": "percy"
+              },
+              "principal": {},
+              "target": {
+                "surface": "docs"
+              },
+              "observer": {
+                "system": "github-actions"
+              },
+              "network": {
+                "http": {}
+              },
+              "additional": {
+                "artifact": "artifacts/percy-udm-context.json"
+              }
+            }
+          }
+          JSON
+
+      - name: Percy snapshot docs build
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: percy snapshot docs/.vitepress/dist

--- a/.github/workflows/percy-visual.yml
+++ b/.github/workflows/percy-visual.yml
@@ -58,7 +58,7 @@ jobs:
         run: yarn --cwd docs build
 
       - name: Install Percy CLI
-        run: npm install -g @percy/cli
+        run: npm install -g @percy/cli@1.31.11
 
       - name: Emit UDM-aligned build context
         run: |

--- a/scripts/validate_entity_fabric.py
+++ b/scripts/validate_entity_fabric.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Any
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+STANDARDS = ROOT / '.github' / 'repo-standards.yml'
+
+
+def load_yaml(path: pathlib.Path) -> Any:
+    with path.open('r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def main() -> int:
+    standards = load_yaml(STANDARDS)
+    spec = standards.get('entity_fabric', {})
+
+    required_paths = [ROOT / p for p in spec.get('required_paths', [])]
+    required_sql = [ROOT / p for p in spec.get('required_sql', [])]
+
+    if not any(p.exists() for p in required_paths + required_sql):
+        print('entity-fabric not present in this checkout; skipping')
+        return 0
+
+    missing = []
+    for p in required_paths + required_sql:
+        if not p.exists():
+            missing.append(str(p.relative_to(ROOT)))
+
+    avro_path = ROOT / 'entity-fabric' / 'contracts' / 'entity_fabric_avro.avsc'
+    if avro_path.exists():
+        try:
+            with avro_path.open('r', encoding='utf-8') as f:
+                json.load(f)
+        except Exception as e:
+            missing.append(f'invalid avro bundle JSON: {e}')
+
+    if missing:
+        print('entity-fabric validation failed:', file=sys.stderr)
+        for item in missing:
+            print(f' - {item}', file=sys.stderr)
+        return 1
+
+    print('entity-fabric validation passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/validate_udm_release_schema.py
+++ b/scripts/validate_udm_release_schema.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+from collections import defaultdict
+from typing import Any
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+STANDARDS = ROOT / '.github' / 'repo-standards.yml'
+
+
+def load_yaml(path: pathlib.Path) -> Any:
+    with path.open('r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def parse_sections(text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = defaultdict(list)
+    current = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith('## '):
+            current = line[3:].strip().lower()
+            continue
+        if current and line.startswith('- '):
+            sections[current].append(line[2:].strip())
+    return sections
+
+
+def main() -> int:
+    standards = load_yaml(STANDARDS)
+    udm = standards.get('udm', {})
+    doc_path = ROOT / udm.get('doc_path', 'docs/guide/intake-udm-schema.md')
+    text = doc_path.read_text(encoding='utf-8')
+    sections = parse_sections(text)
+
+    required_blocks = set(udm.get('required_top_level_blocks', []))
+    required_shape = set(udm.get('required_udm_shape', []))
+
+    blocks = set(sections.get('top-level blocks', []))
+    shape = set(sections.get('udm shape', []))
+
+    missing = []
+    for item in sorted(required_blocks - blocks):
+        missing.append(f'missing top-level block: {item}')
+    for item in sorted(required_shape - shape):
+        missing.append(f'missing UDM shape entry: {item}')
+
+    if missing:
+        print('UDM release schema validation failed:', file=sys.stderr)
+        for item in missing:
+            print(f' - {item}', file=sys.stderr)
+        return 1
+
+    print('UDM release schema validation passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/verify_docs_nav.py
+++ b/scripts/verify_docs_nav.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from typing import Any
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIG = ROOT / 'docs' / '.vitepress' / 'config.ts'
+STANDARDS = ROOT / '.github' / 'repo-standards.yml'
+
+
+def load_yaml(path: pathlib.Path) -> Any:
+    with path.open('r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def expected_link(md_file: pathlib.Path) -> str:
+    rel = md_file.relative_to(ROOT / 'docs').with_suffix('')
+    parts = rel.parts
+    return '/' + '/'.join(parts)
+
+
+def main() -> int:
+    standards = load_yaml(STANDARDS)
+    exceptions = set(standards.get('docs', {}).get('nav_exceptions', []))
+    config_text = CONFIG.read_text(encoding='utf-8')
+    links = set(re.findall(r'link:\s*["\']([^"\']+)["\']', config_text))
+
+    missing: list[str] = []
+    for md in sorted((ROOT / 'docs' / 'guide').rglob('*.md')):
+        rel = md.relative_to(ROOT).as_posix()
+        if rel in exceptions:
+            continue
+        target = expected_link(md)
+        if target not in links:
+            missing.append(f'{rel} -> expected {target}')
+
+    if missing:
+        print('docs navigation verification failed:', file=sys.stderr)
+        for item in missing:
+            print(f' - {item}', file=sys.stderr)
+        return 1
+
+    print('docs navigation verification passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/verify_workflow_branches.py
+++ b/scripts/verify_workflow_branches.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+STANDARDS = ROOT / '.github' / 'repo-standards.yml'
+WORKFLOWS = ROOT / '.github' / 'workflows'
+
+
+def load_yaml(path: pathlib.Path) -> Any:
+    with path.open('r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+    return data or {}
+
+
+def get_on_block(data: dict[str, Any]) -> Any:
+    if 'on' in data:
+        return data['on']
+    if True in data:
+        return data[True]
+    return {}
+
+
+def normalize_branches(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    return []
+
+
+def main() -> int:
+    standards = load_yaml(STANDARDS)
+    default_branch = standards.get('default_branch', 'master')
+    docs_standards = standards.get('docs', {})
+    docs_deploy_branches = set(docs_standards.get('deploy_branches', [default_branch]))
+    transitional = set(docs_standards.get('transitional_allowed_branches', []))
+
+    problems: list[str] = []
+    saw_master_docs_deploy = False
+
+    for wf in sorted(WORKFLOWS.glob('*.yml')) + sorted(WORKFLOWS.glob('*.yaml')):
+        data = load_yaml(wf)
+        on_block = get_on_block(data)
+        push = on_block.get('push', {}) if isinstance(on_block, dict) else {}
+        branches = set(normalize_branches(push.get('branches')))
+        text = wf.read_text(encoding='utf-8')
+        is_docs_deploy = 'Deploy Docs' in text or 'upload-pages-artifact' in text or 'deploy-pages' in text
+
+        if wf.name in {'check.yml', 'gitleaks.yml'}:
+            if default_branch not in branches:
+                problems.append(f'{wf}: expected push.branches to include {default_branch}, found {sorted(branches) or "<none>"}')
+
+        if is_docs_deploy:
+            if branches & docs_deploy_branches:
+                saw_master_docs_deploy = True
+            elif not branches.issubset(transitional):
+                problems.append(
+                    f'{wf}: docs deploy branches {sorted(branches) or "<none>"} do not include required {sorted(docs_deploy_branches)}'
+                )
+
+    if not saw_master_docs_deploy:
+        problems.append(f'no docs deployment workflow targets required branch(es): {sorted(docs_deploy_branches)}')
+
+    if problems:
+        print('workflow branch verification failed:', file=sys.stderr)
+        for p in problems:
+            print(f' - {p}', file=sys.stderr)
+        return 1
+
+    print('workflow branch verification passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/verify_workflow_branches.py
+++ b/scripts/verify_workflow_branches.py
@@ -59,11 +59,15 @@ def main() -> int:
                 problems.append(f'{wf}: expected push.branches to include {default_branch}, found {sorted(branches) or "<none>"}')
 
         if is_docs_deploy:
-            if branches & docs_deploy_branches:
+            if not push or not branches:
+                problems.append(
+                    f'{wf}: docs deploy workflow has no push.branches configured'
+                )
+            elif branches & docs_deploy_branches:
                 saw_master_docs_deploy = True
             elif not branches.issubset(transitional):
                 problems.append(
-                    f'{wf}: docs deploy branches {sorted(branches) or "<none>"} do not include required {sorted(docs_deploy_branches)}'
+                    f'{wf}: docs deploy branches {sorted(branches)} do not include required {sorted(docs_deploy_branches)}'
                 )
 
     if not saw_master_docs_deploy:


### PR DESCRIPTION
## What this PR does

This PR adds a delivery-governance layer to prevent the integration failures we just hit from recurring.

It adds:

- `.github/repo-standards.yml`
- `.github/CODEOWNERS`
- `.github/pull_request_template.md`
- `.github/workflows/docs-pages-master.yml`
- `.github/workflows/docs-integrity.yml`
- `.github/workflows/entity-fabric-ci.yml`
- `.github/workflows/percy-visual.yml`
- `.github/workflows/devsecops.yml`
- `scripts/verify_workflow_branches.py`
- `scripts/verify_docs_nav.py`
- `scripts/validate_udm_release_schema.py`
- `scripts/validate_entity_fabric.py`

## Why this PR exists

The current automation surface is too generic to catch:

1. docs pages that exist but are not wired into nav/sidebar
2. branch-target drift between active delivery branches and docs deployment
3. entity-fabric schema work that is present but not runtime-validated
4. UDM/release-schema drift between docs and CI expectations
5. visual regressions on docs/web surfaces that are not reviewed as part of delivery

## UDM alignment

This PR intentionally aligns delivery controls to the existing `docs/guide/intake-udm-schema.md` model.

The standards file encodes the documented UDM top-level blocks:

- `context`
- `platform`
- `experiment`
- `policy`
- `udm`

and the documented UDM shape:

- `udm.metadata`
- `udm.principal`
- `udm.target`
- `udm.observer`
- `udm.network.http`
- `udm.additional`

The `validate_udm_release_schema.py` script enforces that the documented schema still contains those blocks.

## Percy alignment

This PR adds a `percy-visual.yml` workflow that:

1. validates the UDM release schema first
2. builds the docs surface
3. emits a UDM-aligned build-context artifact
4. runs Percy snapshots against the built docs output when `PERCY_TOKEN` is present

This gives us a visual-regression lane that is explicitly tied to the documented release model rather than floating as an unrelated UI check.

## Important notes

- The Percy workflow is guarded on `PERCY_TOKEN` so it remains safe for forks and non-configured repos.
- This PR does not patch existing workflow files in place. It adds additive controls that can become required status checks.
- The existing docs-nav gap for `legal-entity-reference-fabric` is still in the entity-fabric PR lane and should be fixed there or immediately after.

## Recommended follow-on after merge

1. make `docs-integrity`, `entity-fabric-ci`, `percy-visual`, and `devsecops` required branch-protection checks
2. either migrate fully to `master` or complete a `main` rename, then simplify branch targeting in workflows
3. patch the VitePress config so the legal-entity guide is discoverable in nav/sidebar
4. run the entity-fabric Postgres smoke job on the real split SQL stack and then promote PR #260
