### PR TITLE
semantic: add repo descriptor

### DIFF
--- a/semantic/repo.jsonld
+++ b/semantic/repo.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": "https://raw.githubusercontent.com/SourceOS-Linux/sourceos-spec/main/semantic/context.jsonld",
+  "@id": "urn:sourceos:repo:SocioProphet:socioprophet",
+  "@type": ["RepoDescriptor", "Repository"],
+  "name": "socioprophet",
+  "description": "Umbrella public surface and integration presentation repo for the broader SocioProphet platform.",
+  "repositoryFullName": "SocioProphet/socioprophet",
+  "repoUrl": "https://github.com/SocioProphet/socioprophet",
+  "organization": "SocioProphet",
+  "defaultBranch": "master",
+  "semanticDescriptorVersion": "0.1.0",
+  "topologyRole": "rolePublicDocsSurface",
+  "connectsTo": [
+    "urn:sourceos:repo:SocioProphet:sociosphere",
+    "urn:sourceos:repo:SociOS-Linux:agentos-spine",
+    "urn:sourceos:repo:SourceOS-Linux:sourceos-spec",
+    "urn:sourceos:repo:SociOS-Linux:socioslinux-web"
+  ],
+  "publicSurfaceFor": [
+    "urn:sourceos:repo:SocioProphet:sociosphere",
+    "urn:sourceos:repo:SociOS-Linux:agentos-spine",
+    "urn:sourceos:repo:SourceOS-Linux:sourceos-spec"
+  ],
+  "consumesVocabularyFrom": "urn:sourceos:repo:SourceOS-Linux:sourceos-spec",
+  "notThisRepo": [
+    "platform workspace controller",
+    "Linux integration spine",
+    "canonical typed-contract registry",
+    "immutable substrate"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a machine-readable `semantic/repo.jsonld` descriptor for `socioprophet`.

## Why

This repo now has a clearer README role statement, but it still benefits from a machine-readable descriptor so tooling can distinguish its umbrella public-surface role from the controller, spine, and canonical spec lanes.

## Notes

The descriptor references the shared context and vocabulary being established in `SourceOS-Linux/sourceos-spec`.
