### PR TITLE
fix: import re in audit_rendered_links

### DIFF
--- a/scripts/audit_rendered_links.py
+++ b/scripts/audit_rendered_links.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin, urlparse
 from urllib.error import HTTPError, URLError
 from html.parser import HTMLParser
 import json, csv
+import re
 
 BASE = "https://socioprophet.com"
 SEEDS = [


### PR DESCRIPTION
Clean recut from current master. This salvages the one remaining live fix from stale PR #249: add missing `import re` to scripts/audit_rendered_links.py.