### PR TITLE
docs: refreshed AOKC repo alignment and live stack status

### DIFF
--- a/docs/agentic-open-knowledge-commons-repo-alignment.md
+++ b/docs/agentic-open-knowledge-commons-repo-alignment.md
@@ -1,0 +1,59 @@
+# Agentic Open Knowledge Commons repo alignment v0.1
+
+## Purpose
+
+This note records where the current Agentic Open Knowledge Commons work belongs in the SocioProphet GitHub organization.
+
+## Current placement
+
+### `socioprophet-standards-storage`
+Owns the merged normative contract pack:
+- `GeneralDescriptor`
+- `OrderDescriptor`
+- initial event contracts
+- ADR for the descriptor split
+- descriptor and order examples
+
+### `socioprophet-standards-knowledge`
+Owns knowledge semantics:
+- object class taxonomy
+- promotion rules
+- PARA projection rules
+- content space model
+- JSON-LD context skeleton
+
+### `TriTRPC`
+Owns typed carriage and deterministic transport notes for:
+- descriptor services
+- order services
+- execution bridge services
+- example envelopes and future fixture vectors
+
+### `agentplane`
+Owns the narrow execution bridge:
+- `OrderDescriptor` to `Bundle` mapping note
+- evidence linking for `orderId` and `descriptorId`
+- implementation checklist
+
+### `socioprophet`
+Owns umbrella integration and temporary incubation for the commons runtime scaffold until a dedicated repository exists.
+
+## Merged foundations
+
+The following AOKC foundations are already merged:
+- `socioprophet-standards-storage` PR #11
+- `TriTRPC` PR #19
+- `agentplane` PR #11
+- `socioprophet-standards-knowledge` PR #22
+
+## Remaining open umbrella work
+
+- `socioprophet` PR #255 — umbrella alignment and stack-status lane
+- `socioprophet` PR #256 — temporary runtime incubator lane
+
+## Constraint
+
+The commons runtime must not duplicate:
+- transport responsibilities already owned by `TriTRPC`
+- execution responsibilities already owned by `agentplane`
+- normative schema ownership already held by the standards repositories

--- a/docs/agentic-open-knowledge-commons-runtime-bootstrap.md
+++ b/docs/agentic-open-knowledge-commons-runtime-bootstrap.md
@@ -1,0 +1,48 @@
+# Agentic Open Knowledge Commons runtime bootstrap v0.1
+
+## Purpose
+
+This note defines the post-foundation bootstrap path for the dedicated commons runtime.
+
+## Current foundation state
+
+The following foundations are already merged:
+- `socioprophet-standards-storage` PR #11
+- `socioprophet-standards-knowledge` PR #22
+- `TriTRPC` PR #19
+- `agentplane` PR #11
+
+## Current temporary incubator
+
+Until a dedicated commons runtime repository is created, the temporary runtime scaffold lives in:
+- `socioprophet` PR #256
+
+That incubator now includes:
+- first-slice flow docs
+- implementation checklist
+- example descriptor and order payloads
+- source normalization stub
+- promotion-order builder stub
+- typed transport request helpers
+- execution bridge helpers
+- evidence linkage helpers
+- retrieval projection helper
+
+## First post-merge extraction step
+
+Once the umbrella PRs land, the temporary `aokc-runtime/` scaffold should be moved into a dedicated commons runtime repository and normalized into a package-friendly layout.
+
+## Runtime target path
+
+The first runtime slice should implement this path:
+1. ingest a GitHub-backed knowledge object
+2. wrap it in a valid `GeneralDescriptor`
+3. register it through the descriptor service surface
+4. create and validate an `OrderDescriptor` for promotion or publication when needed
+5. resolve to `agentplane` only if governed execution is required
+6. preserve `descriptorId` and `orderId` in resulting evidence
+7. expose retrieval by descriptor id, task, content space, and PARA projection
+
+## Constraint
+
+The runtime must consume the merged contracts and bridge notes. It must not invent a competing descriptor, order, transport, or execution model.

--- a/docs/agentic-open-knowledge-commons-stack-status-2026-04-09.md
+++ b/docs/agentic-open-knowledge-commons-stack-status-2026-04-09.md
@@ -1,0 +1,68 @@
+# Agentic Open Knowledge Commons live stack status — 2026-04-09
+
+## Purpose
+
+This note records the updated live state of the staged AOKC stack after the latest repository changes.
+
+## Merged foundation PRs
+
+### `socioprophet-standards-storage` PR #11
+Merged.
+Contains:
+- `GeneralDescriptor` schema v0.1
+- `OrderDescriptor` schema v0.1
+- initial event contracts
+- ADR for descriptor split
+- descriptor and order examples
+
+### `socioprophet-standards-knowledge` PR #22
+Merged.
+Contains:
+- object class taxonomy
+- promotion rules
+- PARA projection rules
+- content space model
+- JSON-LD context skeleton
+
+### `TriTRPC` PR #19
+Merged.
+Contains:
+- descriptor/order/execution-bridge contract notes
+- descriptor and order example payloads
+- initial fixture placeholders
+
+### `agentplane` PR #11
+Merged.
+Contains:
+- order-to-bundle bridge note
+- evidence-linking note
+- implementation checklist
+
+## Open follow-on work
+
+### `TriTRPC` PR #26
+Open.
+Adds follow-on transport example envelopes for:
+- `ValidateOrder`
+- `ResolveOrderToBundle`
+- `AttachRunArtifact`
+
+### `socioprophet` PR #255
+Open.
+This is the umbrella alignment and stack-status lane.
+
+### `socioprophet` PR #256
+Open.
+This is the temporary umbrella-repo runtime incubator with docs, examples, transport helpers, bridge helpers, evidence linkage, and retrieval projection starter stubs.
+
+## Immediate dependency order
+
+Given the current live state, the remaining intended order is:
+1. `socioprophet` PR #255
+2. `socioprophet` PR #256
+
+`TriTRPC` PR #26` is a follow-on transport enhancement on top of the already-merged transport foundation and is not a prerequisite for the umbrella alignment PR.
+
+## Exit condition
+
+After the remaining umbrella PRs land, the temporary `aokc-runtime/` incubator in `socioprophet` PR #256 should be extracted into a dedicated commons runtime repository.


### PR DESCRIPTION
Clean recut from current `master` to replace stale PR #274.

Carries only the three additive AOKC umbrella docs:
- `docs/agentic-open-knowledge-commons-repo-alignment.md`
- `docs/agentic-open-knowledge-commons-stack-status-2026-04-09.md`
- `docs/agentic-open-knowledge-commons-runtime-bootstrap.md`

Why this replacement exists:
- the earlier branch was behind current `master`
- these docs are still useful and additive
- this recut keeps the umbrella alignment lane clean before deciding what to do with `#256`
