### PR TITLE
docs(process): add GitOps branching and merge policy v0.1

### DIFF
--- a/docs/process/gitops-branching-and-merge-policy.md
+++ b/docs/process/gitops-branching-and-merge-policy.md
@@ -1,0 +1,105 @@
+# GitOps Branching and Merge Policy v0.1
+
+Status: draft
+Scope: `SocioProphet/socioprophet`
+
+## Purpose
+
+This repository is moving to a three-tier branching model so that proposal work, integration work, and production work are separated clearly.
+
+The goal is to reduce branch sprawl, keep review state explicit, and make GitOps promotion predictable.
+
+## Branch tiers
+
+### 1. `proposal/*`
+Proposal branches are short-lived work branches.
+
+Rules:
+- branch from `development`
+- open a **draft PR** into `development`
+- use these branches for scoped changes, experiments, and reviewable work-in-progress
+- do not treat a long-lived proposal branch as an integration branch
+
+Examples:
+- `proposal/public-sector-copy-pass`
+- `proposal/aokc-runtime-bootstrap-r1`
+- `proposal/openclaw-pack-r2`
+
+### 2. `development`
+`development` is the integration branch.
+
+Rules:
+- proposal PRs merge here first
+- this branch is the staging and integration surface
+- preview or staging deployments should track this branch
+- do not push directly; use PRs
+- squash merge or rebase policy should keep history readable
+
+### 3. `master`
+`master` remains the production branch.
+
+Rules:
+- production-ready work reaches `master` only through promotion from `development`
+- production deployment tracks `master`
+- no direct pushes
+- branch protection should be strongest here
+
+## Merge sequence
+
+Canonical sequence:
+
+1. create `proposal/*` branch from `development`
+2. open draft PR from `proposal/*` to `development`
+3. review, revise, and land into `development`
+4. when a coherent set of integrated changes is ready, open a promotion PR from `development` to `master`
+5. merge promotion PR to `master`
+
+## Pull request expectations
+
+### Proposal PRs
+- default state: draft
+- must say what repo role they touch: public surface, integration workspace, or subsystem staging
+- should be small enough to review without hidden stacked dependency chains
+
+### Promotion PRs
+- compare `development` to `master`
+- summarize all features or fixes being promoted
+- list any intentionally deferred items that remain on `development`
+- should be the only regular path into `master`
+
+## GitOps mapping
+
+- `proposal/*` -> ephemeral review or preview context
+- `development` -> staging / integration deployment
+- `master` -> production deployment
+
+## Protection rules
+
+Recommended enforcement:
+
+- protect `master`
+- protect `development`
+- require PRs for both
+- require CI checks before merge
+- prevent force-push on both protected branches
+- use squash merges by default unless a repo-specific exception is justified
+
+## Branch hygiene
+
+- close stale proposal PRs aggressively
+- delete merged proposal branches
+- do not keep dozens of unreviewed long-lived feature branches alive
+- if a proposal branch goes stale, recut it from current `development` rather than trying to merge a heavily diverged branch
+
+## Hotfix rule
+
+If a production fix must bypass the normal sequence:
+- cut a short-lived `hotfix/*` branch from `master`
+- PR into `master`
+- after merge, immediately backport the same change into `development`
+
+This should be exceptional, not normal practice.
+
+## Immediate adoption note
+
+This policy is being introduced after a period of branch sprawl. During transition, stale PRs may be closed or recut so that future work can follow the `proposal/* -> development -> master` model cleanly.

--- a/docs/process/gitops-transition-plan-2026-04.md
+++ b/docs/process/gitops-transition-plan-2026-04.md
@@ -1,0 +1,67 @@
+# GitOps Transition Plan — 2026-04
+
+Status: draft
+Scope: `SocioProphet/socioprophet`
+
+## Why this exists
+
+The repository accumulated too many long-lived branches and PRs targeting `master` directly.
+
+The new target model is:
+- `proposal/*` -> draft PR into `development`
+- `development` -> integration and staging
+- `master` -> production promotion only
+
+This note explains how to transition from the old branch state to the new one.
+
+## Transition rule
+
+During the cleanup window, a very small number of already-open PRs may still land directly into `master` as a **bootstrap exception** if all of the following are true:
+
+- the PR is small and additive
+- the PR is already cleanly recut from current `master`
+- the PR reduces branch debt rather than increasing it
+- the PR does not introduce a new subsystem ownership ambiguity
+
+All other open work should be:
+- closed if stale or superseded, or
+- recut from current `development` after the new policy lands
+
+## Bootstrap exception candidates
+
+The intended bootstrap exception class is narrow:
+- small docs corrections
+- small additive public-surface docs
+- tiny fix recuts already cut from current `master`
+
+## Not bootstrap exceptions
+
+The following should normally not merge directly to `master` during transition:
+- subsystem runtime packs
+- control-plane hardening branches
+- staging/integration packs that are still incomplete
+- large scaffold branches that should first integrate on `development`
+
+## Immediate queue handling
+
+### Merge-to-master bootstrap exceptions
+Use only where the branch is already fresh and trivially reviewable.
+
+### Recut-to-development candidates
+These should be recut after the policy PR lands:
+- larger AOKC runtime scaffold work
+- agentplane hardening
+- integration packs such as OpenClaw
+- any stale branch that is behind current `master`
+
+### Close-now candidates
+Close stale, superseded, or no-op branches aggressively rather than carrying them forward.
+
+## Target steady state
+
+After transition:
+1. work starts on `proposal/*`
+2. draft PRs target `development`
+3. integrated work accumulates on `development`
+4. promotion PRs move reviewed sets from `development` to `master`
+5. stale proposal branches are deleted quickly


### PR DESCRIPTION
This PR introduces the three-tier GitOps branch model discussed in the repo cleanup work:

- `proposal/*` for scoped draft work
- `development` as the integration/staging branch
- `master` as the production branch

It also records the merge sequence:
`proposal/* -> development -> master`

Why this is needed now:
- the repo accumulated too many long-lived branches and stale PRs
- the public-surface + integration-workspace dual role needs a stricter merge discipline
- future work should land through staged integration, not directly into `master`

File added:
- `docs/process/gitops-branching-and-merge-policy.md`

Recommended next operational steps after review:
1. protect `development`
2. route future proposal PRs into `development`
3. use promotion PRs from `development` into `master`
4. aggressively close or recut stale proposal branches
