### PR TITLE
wip(ui): mirror recovered UI inventory and schemas from sociosphere salvage tranche

### DIFF
--- a/wip/ui-foundations/2026-04-13/PROVENANCE.md
+++ b/wip/ui-foundations/2026-04-13/PROVENANCE.md
@@ -1,0 +1,19 @@
+# UI Files Mirrored from `SocioProphet/sociosphere` - WIP
+
+This file documents the provenance of UI-specific files mirrored into this branch from the `SocioProphet/sociosphere` repo.
+
+## Source PR
+
+The UI work mirrored here was originally recovered from PR #77 in `SocioProphet/sociosphere`, which salvaged the `wip/ui-inventory-2026-01-09` branch.
+
+The mirrored content reflects only UI-specific artifacts, which are relevant to ongoing UI development efforts within `SocioProphet/socioprophet`.
+
+## Purpose
+
+This subtree provides a WIP mirror of UI inventory and schemas, not the final home of UI assets. The purpose is to place them in a reviewable space within `socioprophet` while keeping the final path and structure decisions pending.
+
+## Next Steps
+
+- Review files for integration into the active UI surfaces of `SocioProphet/socioprophet`.
+- Decide on the permanent path for these files.
+- Evaluate which files should move to a dedicated standards repo, separate from UI-specific assets.

--- a/wip/ui-foundations/2026-04-13/README.md
+++ b/wip/ui-foundations/2026-04-13/README.md
@@ -1,0 +1,36 @@
+# UI Foundations WIP Mirror — 2026-04-13
+
+This subtree mirrors the **UI-specific** portion of the UI inventory recovery work that was first salvaged in `SocioProphet/sociosphere` from the stale branch `wip/ui-inventory-2026-01-09`.
+
+## Why this exists
+
+The recovered UI tranche should not be stranded inside `sociosphere`, because `sociosphere` is primarily a workspace/controller and integration surface rather than the durable home for active UI work.
+
+This WIP mirror gives the UI work a reviewable landing zone inside `SocioProphet/socioprophet`.
+
+## Source provenance
+
+Recovered source branch in `SocioProphet/sociosphere`:
+- `salvage/ui-inventory-2026-01-09`
+
+Related PRs in `SocioProphet/sociosphere`:
+- PR #77 — salvage/provenance bucket for recovered UI + standards content
+- PR #76 — separate non-stale branch recovery tranche
+
+## Scope mirrored here
+
+This subtree intentionally mirrors only the UI-specific subset:
+- human-authored interface inventory
+- UI schemas
+- UI component inventory contract
+
+It does **not** mirror the broader finance / ops / delex / conformance / non-UI standards payload from the same salvage PR.
+
+## Intent
+
+This is a **WIP mirror**, not a claim that every file here is already in final canonical form.
+
+Next review should decide:
+1. which files graduate into active repo-local UI paths,
+2. which files belong in a dedicated standards/specification repo instead,
+3. and which files should remain archival/provenance-only.

--- a/wip/ui-foundations/2026-04-13/docs/ui/INTERFACE-INVENTORY.md
+++ b/wip/ui-foundations/2026-04-13/docs/ui/INTERFACE-INVENTORY.md
@@ -1,0 +1,80 @@
+# Interface Inventory (canonical)
+
+This is the human-authored UI contract: screens, routes, ownership, contracts, and evidence events.
+
+## apps/ui-workbench
+
+### Home
+- Route: `/`
+- File: `apps/ui-workbench/src/routes/HomePage.vue`
+- Purpose: landing / navigation hub
+- Data contracts: none
+- Evidence events: `ui.page.viewed(home)`
+- Legacy parity: unknown (legacy not located)
+
+### Search Results
+- Route: `/search`
+- File: `apps/ui-workbench/src/routes/SearchResultsPage.vue`
+- Components:
+  - `apps/ui-workbench/src/components/search/ResultCard.vue`
+  - `packages/ui-kit/src/TrustBadge.vue`
+- Data contracts:
+  - `apps/ui-workbench/src/schemas/search.ts` (to migrate to `packages/schemas`)
+- API:
+  - `apps/ui-workbench/src/api/search.ts` (stubbed provider)
+- State:
+  - `apps/ui-workbench/src/stores/search.ts`
+- Evidence events:
+  - `search.executed`
+  - `search.results.rendered`
+  - `search.result.opened`
+- Legacy parity: unknown
+
+### Entity Profile
+- Route: `/entity/:id`
+- File: `apps/ui-workbench/src/routes/EntityProfilePage.vue`
+- Purpose: entity detail surface (attributes, links, evidence, provenance)
+- Evidence events: `entity.viewed`
+- Legacy parity: unknown
+
+### Graph Explorer
+- Route: `/graph`
+- File: `apps/ui-workbench/src/routes/GraphExplorerPage.vue`
+- Purpose: graph traversal / neighborhood explorer
+- Evidence events: `graph.viewed`, `graph.node.selected`, `graph.edge.selected`
+- Legacy parity: unknown
+
+### KB Home
+- Route: `/kb`
+- File: `apps/ui-workbench/src/routes/KbHomePage.vue`
+- Purpose: knowledge base surfaces (collections, taxonomies, saved queries)
+- Evidence events: `kb.viewed`
+- Legacy parity: unknown
+
+### Settings
+- Route: `/settings`
+- File: `apps/ui-workbench/src/routes/SettingsPage.vue`
+- Purpose: user prefs (display, trust thresholds, evidence export, connector defaults)
+- Evidence events: `settings.viewed`, `settings.updated`
+- Legacy parity: unknown
+
+### Admin: Connectors
+- Route: `/admin/connectors`
+- File: `apps/ui-workbench/src/routes/admin/ConnectorsPage.vue`
+- Purpose: manage data connectors / sources
+- Evidence events: `connector.created`, `connector.updated`, `connector.deleted`
+- Legacy parity: unknown
+
+### Admin: Curation
+- Route: `/admin/curation`
+- File: `apps/ui-workbench/src/routes/admin/CurationPage.vue`
+- Purpose: HITL queue + label/override workflows
+- Evidence events: `curation.task.opened`, `curation.label.applied`, `curation.override.saved`
+- Legacy parity: unknown
+
+### Admin: Trust Registry
+- Route: `/admin/trust`
+- File: `apps/ui-workbench/src/routes/admin/TrustRegistryPage.vue`
+- Purpose: trust rules + provenance policy registry
+- Evidence events: `trust.rule.created`, `trust.rule.updated`, `trust.rule.deleted`
+- Legacy parity: unknown

--- a/wip/ui-foundations/2026-04-13/schemas/ui/ui-component.v0.schema.json
+++ b/wip/ui-foundations/2026-04-13/schemas/ui/ui-component.v0.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "@type": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "component_type": {
+      "type": "string"
+    },
+    "props": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "a11y_role": {
+      "type": "string"
+    },
+    "tokens": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "@type",
+    "id",
+    "version",
+    "component_type"
+  ],
+  "title": "UI Component (v0)"
+}

--- a/wip/ui-foundations/2026-04-13/schemas/ui/ui-inventory.schema.json
+++ b/wip/ui-foundations/2026-04-13/schemas/ui/ui-inventory.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sociosphere.local/schemas/ui/ui-inventory.schema.json",
+  "title": "UI Inventory",
+  "type": "object",
+  "required": ["version", "screens"],
+  "additionalProperties": false,
+  "properties": {
+    "version": { "type": "string", "minLength": 1 },
+    "product": { "type": "string" },
+    "screens": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "route", "title", "blocks"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z][a-z0-9_\\-\\.]*$" },
+          "route": { "type": "string", "pattern": "^/" },
+          "title": { "type": "string", "minLength": 1 },
+          "icon": { "type": "string" },
+          "description": { "type": "string" },
+          "capabilities_required": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "policy_actions": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "evidence_events": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "blocks": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "type"],
+              "additionalProperties": true,
+              "properties": {
+                "id": { "type": "string", "pattern": "^[a-z][a-z0-9_\\-\\.]*$" },
+                "type": { "type": "string", "minLength": 1 },
+                "title": { "type": "string" },
+                "props": { "type": "object", "additionalProperties": true },
+                "capability_ref": { "type": "string" },
+                "policy_action": { "type": "string" },
+                "evidence_event": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/wip/ui-foundations/2026-04-13/schemas/ui/ui-ontology.v0.schema.json
+++ b/wip/ui-foundations/2026-04-13/schemas/ui/ui-ontology.v0.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "@type": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "@type",
+    "id",
+    "version"
+  ]
+}

--- a/wip/ui-foundations/2026-04-13/schemas/ui/ui-view.v0.schema.json
+++ b/wip/ui-foundations/2026-04-13/schemas/ui/ui-view.v0.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "@type": {
+      "type": "string"
+    },
+    "id": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "page": {
+      "type": "string"
+    },
+    "viewport": {
+      "type": "object",
+      "properties": {
+        "w": {
+          "type": "integer"
+        },
+        "h": {
+          "type": "integer"
+        },
+        "dpr": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "w",
+        "h"
+      ]
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "regions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
+  "required": [
+    "@type",
+    "id",
+    "version",
+    "page",
+    "viewport"
+  ],
+  "title": "UI View (v0)"
+}

--- a/wip/ui-foundations/2026-04-13/standards/ui/component-inventory.v1.yaml
+++ b/wip/ui-foundations/2026-04-13/standards/ui/component-inventory.v1.yaml
@@ -1,0 +1,143 @@
+version: 1
+inventory_id: ui.component-inventory.v1
+owner_repo: sociosphere
+description: >
+  Canonical UI component + action inventory (contracts) for SocioProphet.
+  This is NOT implementation code. Implementations live in socioprophet-web.
+  Agents and UI both bind to these ids.
+
+components:
+  # --- Shell / global framing ---
+  - id: component.shell.app
+    kind: shell
+    title: App Shell
+    actions: [action.nav.open_global, action.search.open]
+  - id: component.nav.top_domains
+    kind: nav
+    title: Top Domain Navigation
+    actions: [action.nav.select_domain, action.nav.open_overflow]
+  - id: component.nav.left_rail
+    kind: nav
+    title: Left Rail Navigation
+    actions: [action.nav.select_section, action.nav.collapse]
+
+  # --- News & Events domain hub ---
+  - id: component.domain.news_events.hub
+    kind: page
+    title: News & Events Domain Hub
+    actions: [action.search.query, action.filters.open, action.nav.open_global]
+  - id: component.news.latest_list
+    kind: list
+    title: Latest News List
+    actions: [action.news.open_story, action.news.save_story, action.news.share_story]
+  - id: component.events.upcoming_widget
+    kind: widget
+    title: Upcoming Events Widget
+    actions: [action.events.open_event, action.events.open_calendar]
+  - id: component.maps_analytics.widget
+    kind: widget
+    title: Maps & Analytics Widget
+    actions: [action.maps.open_analysis, action.maps.open_map]
+
+  # --- Dashboard / feed mechanics shown in screenshots ---
+  - id: component.dashboard.news_feed
+    kind: page
+    title: News Feed Dashboard
+    actions: [action.news.refresh, action.search.query, action.filters.open]
+  - id: component.dashboard.stock_ticker
+    kind: widget
+    title: Stock Ticker Strip
+    actions: [action.ticker.select_symbol, action.ticker.pin_symbol]
+  - id: component.news.story_card
+    kind: card
+    title: News Story Card
+    actions: [action.news.open_story, action.news.open_source, action.news.rate_quality]
+  - id: component.qos.badges
+    kind: widget
+    title: Quality / QoS Badges
+    actions: [action.qos.explain, action.qos.filter_by_level]
+  - id: component.trending.topics
+    kind: widget
+    title: Trending Topics
+    actions: [action.trending.select_topic, action.filters.open]
+
+  # --- Facets / summaries / agent activity (bottom-left & rails in screenshots) ---
+  - id: component.facet.domain_rail
+    kind: facet
+    title: Domain Facet Rail
+    actions: [action.facet.select, action.facet.clear]
+  - id: component.agent.activity
+    kind: panel
+    title: Agent Activity Panel
+    actions: [action.agent.open_trace, action.agent.pause, action.agent.resume]
+  - id: component.argument.summaries
+    kind: panel
+    title: Argument Summaries
+    actions: [action.argument.open, action.argument.expand, action.argument.export]
+
+  # --- Document + PDF + annotations ---
+  - id: component.doc.composer
+    kind: editor
+    title: Document Composer
+    actions: [action.doc.format_bold, action.doc.format_italic, action.doc.insert_link, action.doc.insert_image]
+  - id: component.doc.pdf_viewer
+    kind: viewer
+    title: PDF Viewer
+    actions: [action.pdf.page_next, action.pdf.page_prev, action.pdf.zoom_in, action.pdf.zoom_out, action.pdf.download]
+  - id: component.doc.annotation_overlay
+    kind: overlay
+    title: Annotation Overlay
+    actions: [action.annotation.highlight, action.annotation.comment, action.annotation.link, action.annotation.delete]
+  - id: component.doc.notes_panel
+    kind: panel
+    title: Notes Panel
+    actions: [action.notes.create, action.notes.edit, action.notes.delete]
+
+actions:
+  - id: action.nav.open_global
+  - id: action.nav.open_overflow
+  - id: action.nav.select_domain
+  - id: action.nav.select_section
+  - id: action.nav.collapse
+  - id: action.search.open
+  - id: action.search.query
+  - id: action.filters.open
+  - id: action.news.refresh
+  - id: action.news.open_story
+  - id: action.news.open_source
+  - id: action.news.save_story
+  - id: action.news.share_story
+  - id: action.news.rate_quality
+  - id: action.events.open_event
+  - id: action.events.open_calendar
+  - id: action.ticker.select_symbol
+  - id: action.ticker.pin_symbol
+  - id: action.maps.open_analysis
+  - id: action.maps.open_map
+  - id: action.qos.explain
+  - id: action.qos.filter_by_level
+  - id: action.trending.select_topic
+  - id: action.facet.select
+  - id: action.facet.clear
+  - id: action.agent.open_trace
+  - id: action.agent.pause
+  - id: action.agent.resume
+  - id: action.argument.open
+  - id: action.argument.expand
+  - id: action.argument.export
+  - id: action.doc.format_bold
+  - id: action.doc.format_italic
+  - id: action.doc.insert_link
+  - id: action.doc.insert_image
+  - id: action.pdf.page_next
+  - id: action.pdf.page_prev
+  - id: action.pdf.zoom_in
+  - id: action.pdf.zoom_out
+  - id: action.pdf.download
+  - id: action.annotation.highlight
+  - id: action.annotation.comment
+  - id: action.annotation.link
+  - id: action.annotation.delete
+  - id: action.notes.create
+  - id: action.notes.edit
+  - id: action.notes.delete


### PR DESCRIPTION
## Summary

Create a WIP landing zone inside `SocioProphet/socioprophet` for the UI-specific subset that was recovered in `SocioProphet/sociosphere` from the stale `wip/ui-inventory-2026-01-09` branch.

## Why

The recovered UI tranche should not be stranded in `sociosphere` as its effective long-term home. `socioprophet` is the more appropriate public/docs/integration surface for this WIP UI material.

## Included here

- WIP provenance/README notes
- human-authored interface inventory
- UI inventory schema
- UI component schema
- UI ontology schema
- UI view schema
- UI component inventory contract

## Not included here

This PR intentionally does **not** mirror the broader non-UI standards, finance, ops, delex, or conformance payload that also appeared in `sociosphere` salvage PR #77.

## Related upstream provenance

- `SocioProphet/sociosphere` PR #77 — salvage/provenance bucket that was later merged to `main`
- `SocioProphet/sociosphere` PR #76 — separate non-stale recovery tranche that still needs its own restoration path

## Intent

This is a WIP mirror, not a final claim about permanent canonical file locations.

The next review should decide:
1. which files graduate into active repo-local UI paths,
2. which files belong in a dedicated standards/spec repo instead,
3. and which files should remain provenance-only.
