### PR TITLE
Add GRLPlus export contracts and SocioProphet repo binding

### DIFF
--- a/ci/validate_grlplus_exports.sh
+++ b/ci/validate_grlplus_exports.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install --upgrade pip jsonschema
+
+python3 scripts/export_grlplus_worklist.py \
+  --input standards/grlplus/examples/worklist_input.example.json \
+  --platform github_issues \
+  --profile strategy \
+  --output /tmp/grlplus-github-issues.json
+
+python3 scripts/validate_grlplus_exports.py \
+  github_issues \
+  /tmp/grlplus-github-issues.json
+
+python3 scripts/export_grlplus_worklist.py \
+  --input standards/grlplus/examples/worklist_input.example.json \
+  --platform ops_queue \
+  --profile strategy \
+  --output /tmp/grlplus-ops-queue.json
+
+python3 scripts/validate_grlplus_exports.py \
+  ops_queue \
+  /tmp/grlplus-ops-queue.json
+
+printf '[grlplus-export-ci] OK\n'

--- a/ci/validate_grlplus_exports.sh
+++ b/ci/validate_grlplus_exports.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python3 -m pip install --upgrade pip jsonschema
+python3 -m pip install "jsonschema>=4,<5"
 
 python3 scripts/export_grlplus_worklist.py \
   --input standards/grlplus/examples/worklist_input.example.json \

--- a/ci/validate_grlplus_generated_worklist_report.sh
+++ b/ci/validate_grlplus_generated_worklist_report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install --upgrade pip jsonschema
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json \
+  --platform github_issues \
+  --output /tmp/grlplus-generated-github-issues.json
+
+python3 scripts/validate_grlplus_exports.py \
+  github_issues \
+  /tmp/grlplus-generated-github-issues.json
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json \
+  --platform ops_queue \
+  --output /tmp/grlplus-generated-ops-queue.json
+
+python3 scripts/validate_grlplus_exports.py \
+  ops_queue \
+  /tmp/grlplus-generated-ops-queue.json
+
+printf '[grlplus-generated-worklist-report-ci] OK\n'

--- a/ci/validate_grlplus_generated_worklist_report.sh
+++ b/ci/validate_grlplus_generated_worklist_report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python3 -m pip install --upgrade pip jsonschema
+python3 -m pip install "pip==24.3.1" "jsonschema==4.23.0"
 
 python3 scripts/export_grlplus_worklist_report.py \
   --input standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json \

--- a/ci/validate_grlplus_worklist_report.sh
+++ b/ci/validate_grlplus_worklist_report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install --upgrade pip jsonschema
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.example.json \
+  --platform github_issues \
+  --output /tmp/grlplus-report-github-issues.json
+
+python3 scripts/validate_grlplus_exports.py \
+  github_issues \
+  /tmp/grlplus-report-github-issues.json
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.example.json \
+  --platform ops_queue \
+  --output /tmp/grlplus-report-ops-queue.json
+
+python3 scripts/validate_grlplus_exports.py \
+  ops_queue \
+  /tmp/grlplus-report-ops-queue.json
+
+printf '[grlplus-worklist-report-ci] OK\n'

--- a/ci/validate_grlplus_worklist_report.sh
+++ b/ci/validate_grlplus_worklist_report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python3 -m pip install --upgrade pip jsonschema
+python3 -m pip install "jsonschema>=4,<5"
 
 python3 scripts/export_grlplus_worklist_report.py \
   --input standards/grlplus/examples/semantic_worklist_report.example.json \

--- a/scripts/export_grlplus_worklist.py
+++ b/scripts/export_grlplus_worklist.py
@@ -139,12 +139,16 @@ def main(argv: List[str]) -> int:
     else:
         out_items = []
         for item in items:
+            element_id = item.get("element_id")
+            if not isinstance(element_id, str) or not element_id.strip():
+                die("ops_queue export requires each item to include a non-empty element_id")
+            element_id = element_id.strip()
             intervention = item.get("intervention") or item.get("intervention_category") or "gather_evidence"
             severity = item.get("severity") or p.get("severity_mapping", {}).get(intervention, "medium")
             owner = item.get("owner") or item.get("owner_actor_id") or p.get("review_owner_template")
             out_items.append({
                 "kind": "semantic_work_item",
-                "element_id": item.get("element_id", ""),
+                "element_id": element_id,
                 "owner": owner,
                 "severity": severity,
                 "intervention": intervention,
@@ -156,7 +160,7 @@ def main(argv: List[str]) -> int:
                 "closure_criteria": item.get("closure_criteria") or p.get("closure_criteria_template"),
                 "escalation_trigger": item.get("escalation_trigger") or p.get("escalation_trigger_template"),
                 "task_payload": {
-                    "title": item.get("title") or f"[{intervention}] {item.get('element_id', 'unknown')}",
+                    "title": item.get("title") or f"[{intervention}] {element_id}",
                     "next_action": item.get("next_action") or item.get("suggested_evidence_ask") or p.get("evidence_request_template"),
                 },
             })

--- a/scripts/export_grlplus_worklist.py
+++ b/scripts/export_grlplus_worklist.py
@@ -57,7 +57,16 @@ def normalize_labels(profile: str, severity: str, intervention: str, extra: List
         f"severity:{severity}",
         f"intervention:{intervention}",
     ]
-    for x in extra or []:
+    if extra is None:
+        extras: List[str] = []
+    else:
+        if not isinstance(extra, list):
+            die("labels must be a list of strings")
+        for i, x in enumerate(extra):
+            if not isinstance(x, str):
+                die(f"labels[{i}] must be a string")
+        extras = extra
+    for x in extras:
         if x not in labels:
             labels.append(x)
     return labels

--- a/scripts/export_grlplus_worklist.py
+++ b/scripts/export_grlplus_worklist.py
@@ -98,19 +98,23 @@ def main(argv: List[str]) -> int:
     if args.platform == "github_issues":
         out_items = []
         for item in items:
+            raw_element_id = item.get("element_id")
+            if not isinstance(raw_element_id, str) or not raw_element_id.strip():
+                die(f"Worklist item is missing required non-empty element_id: {item!r}")
+            element_id = raw_element_id.strip()
             intervention = item.get("intervention_category") or item.get("intervention") or "gather_evidence"
             severity = item.get("severity") or p.get("severity_mapping", {}).get(intervention, "medium")
             owner = item.get("owner_actor_id") or item.get("owner") or p.get("review_owner_template")
             closure_rule_code = item.get("closure_rule_code") or p.get("closure_rule_code")
             escalation_rule_code = item.get("escalation_rule_code") or p.get("escalation_rule_code")
             out_items.append({
-                "title": item.get("title") or f"[{intervention}] {item.get('element_id', 'unknown')}",
-                "body": item.get("body") or build_issue_body(binding, item.get("element_id", "unknown"), closure_rule_code, escalation_rule_code),
+                "title": item.get("title") or f"[{intervention}] {element_id}",
+                "body": item.get("body") or build_issue_body(binding, element_id, closure_rule_code, escalation_rule_code),
                 "labels": normalize_labels(args.profile, severity, intervention, item.get("labels")),
                 "assignee": owner,
                 "severity": severity,
                 "owner_actor_id": owner,
-                "element_id": item.get("element_id", ""),
+                "element_id": element_id,
                 "intervention_category": intervention,
                 "reason_codes": item.get("reason_codes", []),
                 "sla_due_in_days": int(item.get("sla_due_in_days", p.get("default_sla_due_in_days", 7))),

--- a/scripts/export_grlplus_worklist.py
+++ b/scripts/export_grlplus_worklist.py
@@ -105,13 +105,14 @@ def main(argv: List[str]) -> int:
             intervention = item.get("intervention_category") or item.get("intervention") or "gather_evidence"
             severity = item.get("severity") or p.get("severity_mapping", {}).get(intervention, "medium")
             owner = item.get("owner_actor_id") or item.get("owner") or p.get("review_owner_template")
+            assignee = item.get("github_assignee") or item.get("assignee")
             closure_rule_code = item.get("closure_rule_code") or p.get("closure_rule_code")
             escalation_rule_code = item.get("escalation_rule_code") or p.get("escalation_rule_code")
             out_items.append({
                 "title": item.get("title") or f"[{intervention}] {element_id}",
                 "body": item.get("body") or build_issue_body(binding, element_id, closure_rule_code, escalation_rule_code),
                 "labels": normalize_labels(args.profile, severity, intervention, item.get("labels")),
-                "assignee": owner,
+                "assignee": assignee,
                 "severity": severity,
                 "owner_actor_id": owner,
                 "element_id": element_id,

--- a/scripts/export_grlplus_worklist.py
+++ b/scripts/export_grlplus_worklist.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Normalize a generic GRLPlus semantic worklist into strict platform export bundles.
+
+Usage:
+  python3 scripts/export_grlplus_worklist.py --input standards/grlplus/examples/worklist_input.example.json --platform github_issues --profile strategy --output /tmp/github.json
+  python3 scripts/export_grlplus_worklist.py --input standards/grlplus/examples/worklist_input.example.json --platform ops_queue --profile strategy --output /tmp/queue.json
+
+This is an integration/export shim for this repository. It is intentionally small and dependency-light.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POLICY_PATH = REPO_ROOT / "standards/grlplus/domain_action_policy_matrix.json"
+BINDING_PATH = REPO_ROOT / "standards/grlplus/github_binding_socioprophet_socioprophet.json"
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[grlplus-export] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"failed to parse JSON {path}: {e}")
+    if not isinstance(data, dict):
+        die(f"{path} must parse to a JSON object")
+    return data
+
+
+def ensure_list_of_items(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    items = data.get("items")
+    if not isinstance(items, list):
+        die("input JSON must contain an 'items' list")
+    out: List[Dict[str, Any]] = []
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            die(f"items[{i}] must be an object")
+        out.append(item)
+    return out
+
+
+def normalize_labels(profile: str, severity: str, intervention: str, extra: List[str] | None = None) -> List[str]:
+    labels = [
+        "grlplus",
+        "semantic-worklist",
+        f"profile:{profile}",
+        f"severity:{severity}",
+        f"intervention:{intervention}",
+    ]
+    for x in extra or []:
+        if x not in labels:
+            labels.append(x)
+    return labels
+
+
+def build_issue_body(binding: Dict[str, Any], element_id: str, closure_rule_code: str, escalation_rule_code: str) -> str:
+    tmpl = binding.get("github_issue_body_template") or "Goal: {goal_summary}\n"
+    return tmpl.format(
+        goal_summary=f"address semantic governance for {element_id}",
+        closure_rule_code=closure_rule_code,
+        escalation_rule_code=escalation_rule_code,
+    )
+
+
+def main(argv: List[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--platform", required=True, choices=["github_issues", "ops_queue"])
+    ap.add_argument("--profile", required=True, choices=["strategy", "cyber", "safety"])
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args(argv[1:])
+
+    inp = load_json(Path(args.input))
+    items = ensure_list_of_items(inp)
+    policy = load_json(POLICY_PATH)
+    binding = load_json(BINDING_PATH)
+    p = policy["profiles"][args.profile]
+
+    if args.platform == "github_issues":
+        out_items = []
+        for item in items:
+            intervention = item.get("intervention_category") or item.get("intervention") or "gather_evidence"
+            severity = item.get("severity") or p.get("severity_mapping", {}).get(intervention, "medium")
+            owner = item.get("owner_actor_id") or item.get("owner") or p.get("review_owner_template")
+            closure_rule_code = item.get("closure_rule_code") or p.get("closure_rule_code")
+            escalation_rule_code = item.get("escalation_rule_code") or p.get("escalation_rule_code")
+            out_items.append({
+                "title": item.get("title") or f"[{intervention}] {item.get('element_id', 'unknown')}",
+                "body": item.get("body") or build_issue_body(binding, item.get("element_id", "unknown"), closure_rule_code, escalation_rule_code),
+                "labels": normalize_labels(args.profile, severity, intervention, item.get("labels")),
+                "assignee": owner,
+                "severity": severity,
+                "owner_actor_id": owner,
+                "element_id": item.get("element_id", ""),
+                "intervention_category": intervention,
+                "reason_codes": item.get("reason_codes", []),
+                "sla_due_in_days": int(item.get("sla_due_in_days", p.get("default_sla_due_in_days", 7))),
+                "review_cadence_days": int(item.get("review_cadence_days", p.get("default_review_cadence_days", 7))),
+                "closure_rule_code": closure_rule_code,
+                "escalation_rule_code": escalation_rule_code,
+                "closure_criteria": item.get("closure_criteria") or p.get("closure_criteria_template"),
+                "escalation_trigger": item.get("escalation_trigger") or p.get("escalation_trigger_template"),
+                "metadata": {
+                    "criticality": item.get("criticality"),
+                    "dependencies": item.get("dependency_targets", []),
+                },
+            })
+        payload = {
+            "schema_version": "grlplus-github-issue-export/0.1",
+            "platform": "github_issues",
+            "profile": args.profile,
+            "repo_full_name": binding.get("repo_full_name", "SocioProphet/socioprophet"),
+            "items": out_items,
+        }
+    else:
+        out_items = []
+        for item in items:
+            intervention = item.get("intervention") or item.get("intervention_category") or "gather_evidence"
+            severity = item.get("severity") or p.get("severity_mapping", {}).get(intervention, "medium")
+            owner = item.get("owner") or item.get("owner_actor_id") or p.get("review_owner_template")
+            out_items.append({
+                "kind": "semantic_work_item",
+                "element_id": item.get("element_id", ""),
+                "owner": owner,
+                "severity": severity,
+                "intervention": intervention,
+                "reason_codes": item.get("reason_codes", []),
+                "sla_due_in_days": int(item.get("sla_due_in_days", p.get("default_sla_due_in_days", 7))),
+                "review_cadence_days": int(item.get("review_cadence_days", p.get("default_review_cadence_days", 7))),
+                "closure_rule_code": item.get("closure_rule_code") or p.get("closure_rule_code"),
+                "escalation_rule_code": item.get("escalation_rule_code") or p.get("escalation_rule_code"),
+                "closure_criteria": item.get("closure_criteria") or p.get("closure_criteria_template"),
+                "escalation_trigger": item.get("escalation_trigger") or p.get("escalation_trigger_template"),
+                "task_payload": {
+                    "title": item.get("title") or f"[{intervention}] {item.get('element_id', 'unknown')}",
+                    "next_action": item.get("next_action") or item.get("suggested_evidence_ask") or p.get("evidence_request_template"),
+                },
+            })
+        payload = {
+            "schema_version": "grlplus-ops-queue-export/0.1",
+            "platform": "ops_queue",
+            "profile": args.profile,
+            "items": out_items,
+        }
+
+    Path(args.output).write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"[grlplus-export] OK: wrote {args.platform} bundle to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/export_grlplus_worklist_report.py
+++ b/scripts/export_grlplus_worklist_report.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Export a semantic worklist report shape into strict GRLPlus platform bundles.
+
+Usage:
+  python3 scripts/export_grlplus_worklist_report.py \
+    --input standards/grlplus/examples/semantic_worklist_report.example.json \
+    --platform github_issues \
+    --output /tmp/github.json
+
+  python3 scripts/export_grlplus_worklist_report.py \
+    --input standards/grlplus/examples/semantic_worklist_report.example.json \
+    --platform ops_queue \
+    --output /tmp/queue.json
+
+This shim accepts the report-like surface already used in practice and emits the
+strict repo-bound bundle formats defined under standards/grlplus/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[grlplus-export-report] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"failed to parse JSON {path}: {e}")
+    if not isinstance(data, dict):
+        die(f"{path} must parse to a JSON object")
+    return data
+
+
+def main(argv: List[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--platform", required=True, choices=["github_issues", "ops_queue"])
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args(argv[1:])
+
+    input_path = Path(args.input)
+    report = load_json(input_path)
+    profile = report.get("active_domain_profile") or report.get("profile") or "strategy"
+    items = report.get("items")
+    if not isinstance(items, list):
+        die("input report JSON must contain an 'items' list")
+
+    # Repackage to the generic input surface expected by export_grlplus_worklist.py
+    generic_payload = {
+        "profile": profile,
+        "items": items,
+    }
+    temp_generic = Path(args.output).with_suffix(".generic-input.json")
+    temp_generic.write_text(json.dumps(generic_payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve().parent / "export_grlplus_worklist.py"),
+        "--input", str(temp_generic),
+        "--platform", args.platform,
+        "--profile", str(profile),
+        "--output", str(args.output),
+    ]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        die(f"delegated export failed: {e}")
+
+    print(f"[grlplus-export-report] OK: wrote {args.platform} bundle to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/export_grlplus_worklist_report.py
+++ b/scripts/export_grlplus_worklist_report.py
@@ -73,9 +73,17 @@ def main(argv: List[str]) -> int:
     ]
 
     try:
-        subprocess.run(cmd, check=True)
-    except subprocess.CalledProcessError as e:
-        die(f"delegated export failed: {e}")
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            die(f"delegated export failed: {e}")
+    finally:
+        try:
+            temp_generic.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            die(f"failed to remove temporary file {temp_generic}: {e}")
 
     print(f"[grlplus-export-report] OK: wrote {args.platform} bundle to {args.output}")
     return 0

--- a/scripts/validate_grlplus_exports.py
+++ b/scripts/validate_grlplus_exports.py
@@ -11,7 +11,7 @@ Exit codes:
 
 Notes:
 - dependency-light by design
-- uses jsonschema when available
+- requires jsonschema for schema validation
 - treats this repo as an integration/export guardrail, not canonical subsystem runtime ownership
 """
 

--- a/scripts/validate_grlplus_exports.py
+++ b/scripts/validate_grlplus_exports.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate GRLPlus export bundles against strict platform schemas.
+
+Usage:
+  python3 scripts/validate_grlplus_exports.py github_issues <bundle.json>
+  python3 scripts/validate_grlplus_exports.py ops_queue <bundle.json>
+
+Exit codes:
+  0 = OK
+  2 = validation failure
+
+Notes:
+- dependency-light by design
+- uses jsonschema when available
+- treats this repo as an integration/export guardrail, not canonical subsystem runtime ownership
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_MAP = {
+    "github_issues": REPO_ROOT / "standards/grlplus/github_issue_export.schema.json",
+    "ops_queue": REPO_ROOT / "standards/grlplus/ops_queue_export.schema.json",
+}
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[grlplus-export-validate] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"failed to parse JSON {path}: {e}")
+    if not isinstance(data, dict):
+        die(f"{path} must parse to a JSON object")
+    return data
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        die("usage: scripts/validate_grlplus_exports.py <github_issues|ops_queue> <bundle.json>")
+
+    platform = argv[1].strip()
+    bundle_path = Path(argv[2])
+    if platform not in SCHEMA_MAP:
+        die(f"unknown platform {platform!r}; expected one of: {', '.join(sorted(SCHEMA_MAP))}")
+    if not bundle_path.exists():
+        die(f"bundle not found: {bundle_path}")
+
+    schema_path = SCHEMA_MAP[platform]
+    if not schema_path.exists():
+        die(f"schema not found: {schema_path}")
+
+    bundle = load_json(bundle_path)
+    schema = load_json(schema_path)
+
+    try:
+        import jsonschema  # type: ignore
+    except Exception as e:
+        die(f"missing dependency: jsonschema is required ({e})")
+
+    try:
+        jsonschema.validate(bundle, schema)
+    except Exception as e:
+        die(f"schema validation failed for {bundle_path}: {e}")
+
+    print(f"[grlplus-export-validate] OK: {platform} {bundle_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/verify_workflow_branches.py
+++ b/scripts/verify_workflow_branches.py
@@ -50,6 +50,8 @@ def main() -> int:
         data = load_yaml(wf)
         on_block = get_on_block(data)
         push = on_block.get('push', {}) if isinstance(on_block, dict) else {}
+        if not isinstance(push, dict):
+            push = {}
         branches = set(normalize_branches(push.get('branches')))
         text = wf.read_text(encoding='utf-8')
         is_docs_deploy = 'Deploy Docs' in text or 'upload-pages-artifact' in text or 'deploy-pages' in text

--- a/standards/grlplus/domain_action_policy_matrix.json
+++ b/standards/grlplus/domain_action_policy_matrix.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "grlplus-action-policy/0.1",
+  "default_repo_full_name": "SocioProphet/socioprophet",
+  "closure_rule_catalog": {
+    "CR_MIN_DIRECT_ARGUMENT_1": "At least 1 direct argument must trace to the element.",
+    "CR_MIN_DIRECT_ARGUMENT_2": "At least 2 direct arguments must trace to the element.",
+    "CR_MIN_EVIDENCE_LINK_1": "At least 1 evidence link must support the element.",
+    "CR_MIN_TELEMETRY_ARTIFACT_1": "At least 1 telemetry or control artifact must be attached.",
+    "CR_DIVERGENCE_BELOW_WARNING": "Semantic divergence must fall below the configured warning threshold.",
+    "CR_OWNER_APPROVAL_REQUIRED": "Named review owner must approve closure."
+  },
+  "escalation_rule_catalog": {
+    "ER_BREACH_SLA_ONCE": "Escalate if SLA is breached once.",
+    "ER_BREACH_SLA_TWICE": "Escalate if SLA is breached twice.",
+    "ER_CRITICAL_IMMEDIATE": "Escalate immediately on critical severity.",
+    "ER_PERSISTENT_HIGH_TWO_REVIEWS": "Escalate if high severity persists for two reviews.",
+    "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE": "Do not allow closure when direct argument coverage is missing."
+  },
+  "profiles": {
+    "strategy": {
+      "default_repo_full_name": "SocioProphet/socioprophet",
+      "default_sla_due_in_days": 7,
+      "default_review_cadence_days": 7,
+      "closure_rule_code": "CR_DIVERGENCE_BELOW_WARNING",
+      "escalation_rule_code": "ER_BREACH_SLA_TWICE",
+      "evidence_request_template": "Attach market, delivery, financial, or decision evidence directly covering the element and each listed reason code.",
+      "closure_criteria_template": "Close when at least 1 direct argument and 1 evidence link are attached, and material divergence is reduced below the warning threshold.",
+      "escalation_trigger_template": "Escalate if SLA is breached twice or if medium or high severity persists for two reviews.",
+      "review_owner_template": "actor.strategy"
+    },
+    "cyber": {
+      "default_repo_full_name": "SocioProphet/socioprophet",
+      "default_sla_due_in_days": 3,
+      "default_review_cadence_days": 3,
+      "closure_rule_code": "CR_MIN_TELEMETRY_ARTIFACT_1",
+      "escalation_rule_code": "ER_BREACH_SLA_ONCE",
+      "evidence_request_template": "Attach telemetry, control-state, incident, or threat evidence directly covering the element and each listed reason code.",
+      "closure_criteria_template": "Close when at least 1 direct argument, 1 evidence link, and 1 telemetry or control artifact are attached, and no high severity semantic divergence remains.",
+      "escalation_trigger_template": "Escalate immediately on critical severity, or if any high severity item breaches SLA once.",
+      "review_owner_template": "actor.security"
+    },
+    "safety": {
+      "default_repo_full_name": "SocioProphet/socioprophet",
+      "default_sla_due_in_days": 1,
+      "default_review_cadence_days": 1,
+      "closure_rule_code": "CR_MIN_DIRECT_ARGUMENT_2",
+      "escalation_rule_code": "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE",
+      "evidence_request_template": "Attach direct safety case arguments, hazard or risk evidence, and explicit traceable evidence links covering the element and each listed reason code.",
+      "closure_criteria_template": "Close only when at least 2 direct safety arguments, explicit evidence links, and designated owner approval are present.",
+      "escalation_trigger_template": "Escalate immediately and block closure if direct argument coverage is missing or if any closure criterion is unmet.",
+      "review_owner_template": "actor.safety"
+    }
+  }
+}

--- a/standards/grlplus/examples/semantic_worklist_report.example.json
+++ b/standards/grlplus/examples/semantic_worklist_report.example.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "grlplus-worklist-report-example/0.1",
+  "active_domain_profile": "strategy",
+  "summary": {
+    "items": 1,
+    "severity_counts": {
+      "medium": 1
+    }
+  },
+  "items": [
+    {
+      "element_id": "goal.outcome",
+      "owner_actor_id": "actor.strategy",
+      "criticality": 0.9,
+      "intervention_category": "gather_evidence",
+      "reason_codes": [
+        "RC_CONFIDENCE_SCALAR_GAP",
+        "RC_CONFIDENCE_INTERVAL_GAP"
+      ],
+      "severity": "medium",
+      "sla_due_in_days": 7,
+      "review_cadence_days": 7,
+      "dependency_targets": [
+        "softgoal.tradeoff"
+      ],
+      "suggested_evidence_ask": "Attach market, delivery, financial, or decision evidence directly covering goal.outcome.",
+      "closure_rule_code": "CR_DIVERGENCE_BELOW_WARNING",
+      "escalation_rule_code": "ER_BREACH_SLA_TWICE",
+      "closure_criteria": "Close when at least 1 direct argument and 1 evidence link are attached, and material divergence is reduced below the warning threshold.",
+      "escalation_trigger": "Escalate if SLA is breached twice or if medium or high severity persists for two reviews."
+    }
+  ]
+}

--- a/standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json
+++ b/standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json
@@ -1,0 +1,146 @@
+{
+  "active_domain_profile": "strategy",
+  "min_criticality": 0.8,
+  "items": [
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "goal.outcome",
+      "criticality": 1.0,
+      "intervention_category": "gather_evidence",
+      "reason_codes": [
+        "RC_CONFIDENCE_SCALAR_GAP",
+        "RC_CONFIDENCE_INTERVAL_GAP"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": -1.0,
+      "scalar_signal": -0.375,
+      "interval_low": -0.42,
+      "interval_high": -0.33,
+      "interval_width": 0.09,
+      "suggested_evidence_ask": "Provide evidence and rationale updates for goal.outcome aligned to gather_evidence.",
+      "task_payload": {
+        "title": "[gather_evidence] goal.outcome",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_CONFIDENCE_SCALAR_GAP",
+          "RC_CONFIDENCE_INTERVAL_GAP"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: gather stronger evidence for goal.outcome to narrow interval width (0.09) and reduce posture-vs-structure divergence under the strategy profile."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "goal.choice",
+      "criticality": 0.9,
+      "intervention_category": "add_direct_argument_coverage",
+      "reason_codes": [
+        "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": null,
+      "scalar_signal": 1.0,
+      "interval_low": 1.0,
+      "interval_high": 1.0,
+      "interval_width": 0.0,
+      "suggested_evidence_ask": "Provide evidence and rationale updates for goal.choice aligned to add_direct_argument_coverage.",
+      "task_payload": {
+        "title": "[add_direct_argument_coverage] goal.choice",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: add at least 1 more trace-linked arguments directly covering goal.choice or its incident decisions."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "softgoal.tradeoff",
+      "criticality": 0.9,
+      "intervention_category": "add_direct_argument_coverage",
+      "reason_codes": [
+        "RC_DIRECT_ARGUMENT_COVERAGE_MISSING",
+        "RC_CONTRADICTORY_TRADEOFF"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": null,
+      "scalar_signal": 0.0,
+      "interval_low": -0.1,
+      "interval_high": 0.1,
+      "interval_width": 0.2,
+      "suggested_evidence_ask": "Provide evidence and rationale updates for softgoal.tradeoff aligned to add_direct_argument_coverage.",
+      "task_payload": {
+        "title": "[add_direct_argument_coverage] softgoal.tradeoff",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_DIRECT_ARGUMENT_COVERAGE_MISSING",
+          "RC_CONTRADICTORY_TRADEOFF"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: add at least 1 more trace-linked arguments directly covering softgoal.tradeoff or its incident decisions."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "task.option_a",
+      "criticality": 0.8,
+      "intervention_category": "monitor",
+      "reason_codes": [],
+      "dependency_targets": [
+        "resource.shared"
+      ],
+      "cross_actor_dependency_count": 1,
+      "confidence": 1.0,
+      "scalar_signal": 1.0,
+      "interval_low": 1.0,
+      "interval_high": 1.0,
+      "interval_width": 0.0,
+      "suggested_evidence_ask": "Provide evidence and rationale updates for task.option_a aligned to monitor.",
+      "task_payload": {
+        "title": "[monitor] task.option_a",
+        "owner": "actor.strategy",
+        "reason_codes": [],
+        "dependencies": [
+          "resource.shared"
+        ],
+        "next_action": "Owner actor.strategy: monitor task.option_a; current evidence and propagated structure are aligned within the strategy profile thresholds."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "task.option_b",
+      "criticality": 0.8,
+      "intervention_category": "monitor",
+      "reason_codes": [],
+      "dependency_targets": [
+        "resource.shared"
+      ],
+      "cross_actor_dependency_count": 1,
+      "confidence": 1.0,
+      "scalar_signal": 1.0,
+      "interval_low": 1.0,
+      "interval_high": 1.0,
+      "interval_width": 0.0,
+      "suggested_evidence_ask": "Provide evidence and rationale updates for task.option_b aligned to monitor.",
+      "task_payload": {
+        "title": "[monitor] task.option_b",
+        "owner": "actor.strategy",
+        "reason_codes": [],
+        "dependencies": [
+          "resource.shared"
+        ],
+        "next_action": "Owner actor.strategy: monitor task.option_b; current evidence and propagated structure are aligned within the strategy profile thresholds."
+      }
+    }
+  ],
+  "summary": {
+    "items": 5,
+    "owners": [
+      "actor.strategy"
+    ]
+  }
+}

--- a/standards/grlplus/examples/worklist_input.example.json
+++ b/standards/grlplus/examples/worklist_input.example.json
@@ -1,0 +1,26 @@
+{
+  "profile": "strategy",
+  "items": [
+    {
+      "element_id": "goal.outcome",
+      "owner_actor_id": "actor.strategy",
+      "intervention_category": "gather_evidence",
+      "reason_codes": [
+        "RC_CONFIDENCE_SCALAR_GAP",
+        "RC_CONFIDENCE_INTERVAL_GAP"
+      ],
+      "severity": "medium",
+      "sla_due_in_days": 7,
+      "review_cadence_days": 7,
+      "criticality": 0.9,
+      "dependency_targets": [
+        "softgoal.tradeoff"
+      ],
+      "suggested_evidence_ask": "Attach market, delivery, financial, or decision evidence directly covering goal.outcome.",
+      "closure_rule_code": "CR_DIVERGENCE_BELOW_WARNING",
+      "escalation_rule_code": "ER_BREACH_SLA_TWICE",
+      "closure_criteria": "Close when at least 1 direct argument and 1 evidence link are attached, and material divergence is reduced below the warning threshold.",
+      "escalation_trigger": "Escalate if SLA is breached twice or if medium or high severity persists for two reviews."
+    }
+  ]
+}

--- a/standards/grlplus/github_binding_socioprophet_socioprophet.json
+++ b/standards/grlplus/github_binding_socioprophet_socioprophet.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "grlplus-github-binding/0.1",
+  "repo_full_name": "SocioProphet/socioprophet",
+  "default_branch": "master",
+  "binding_rationale": "Chosen because collaborator access is live and the repo shows active issue usage aligned with SocioProphet governance and planning work.",
+  "observed_issue_style": {
+    "title_pattern": "Descriptive work-item titles, sometimes with EPIC or P0 or E0 prefixes.",
+    "body_sections": ["Goal", "Definition of Done", "Acceptance Criteria", "Exit criteria"],
+    "checkbox_usage": true
+  },
+  "recommended_label_set": [
+    "grlplus",
+    "semantic-worklist",
+    "governance",
+    "profile:strategy",
+    "profile:cyber",
+    "profile:safety",
+    "severity:low",
+    "severity:medium",
+    "severity:high",
+    "severity:critical",
+    "intervention:monitor",
+    "intervention:gather_evidence",
+    "intervention:add_direct_argument_coverage",
+    "intervention:reduce_dependency_uncertainty",
+    "intervention:resolve_contradictory_tradeoff"
+  ],
+  "github_issue_body_template": "Goal: {goal_summary}\n\nDefinition of Done:\n- [ ] Closure criteria satisfied\n- [ ] Evidence attached\n- [ ] Review completed\n\nAcceptance Criteria:\n- [ ] Severity and SLA fields populated\n- [ ] Reason codes preserved\n- [ ] Dependencies enumerated\n\nExit criteria:\n- closure_rule_code: {closure_rule_code}\n- escalation_rule_code: {escalation_rule_code}\n"
+}

--- a/standards/grlplus/github_issue_export.schema.json
+++ b/standards/grlplus/github_issue_export.schema.json
@@ -40,12 +40,12 @@
               "criticality": {"type": ["number", "null"]},
               "dependencies": {"type": "array", "items": {"type": "string"}}
             },
-            "additionalProperties": true
+            "additionalProperties": false
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/standards/grlplus/github_issue_export.schema.json
+++ b/standards/grlplus/github_issue_export.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GRLPlus GitHub Issue Export",
+  "type": "object",
+  "required": ["schema_version", "platform", "profile", "repo_full_name", "items"],
+  "properties": {
+    "schema_version": {"type": "string", "const": "grlplus-github-issue-export/0.1"},
+    "platform": {"type": "string", "const": "github_issues"},
+    "profile": {"type": "string", "enum": ["strategy", "cyber", "safety"]},
+    "repo_full_name": {"type": "string", "const": "SocioProphet/socioprophet"},
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title", "body", "labels", "severity", "owner_actor_id", "element_id",
+          "intervention_category", "reason_codes", "sla_due_in_days", "review_cadence_days",
+          "closure_rule_code", "escalation_rule_code", "closure_criteria", "escalation_trigger"
+        ],
+        "properties": {
+          "title": {"type": "string", "minLength": 1},
+          "body": {"type": "string", "minLength": 1},
+          "labels": {"type": "array", "minItems": 3, "items": {"type": "string", "minLength": 1}},
+          "assignee": {"type": ["string", "null"]},
+          "severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
+          "owner_actor_id": {"type": ["string", "null"]},
+          "element_id": {"type": "string", "minLength": 1},
+          "intervention_category": {"type": "string", "enum": ["monitor", "gather_evidence", "add_direct_argument_coverage", "reduce_dependency_uncertainty", "resolve_contradictory_tradeoff"]},
+          "reason_codes": {"type": "array", "items": {"type": "string"}},
+          "sla_due_in_days": {"type": "integer", "minimum": 0},
+          "review_cadence_days": {"type": "integer", "minimum": 0},
+          "closure_rule_code": {"type": "string", "enum": ["CR_MIN_DIRECT_ARGUMENT_1", "CR_MIN_DIRECT_ARGUMENT_2", "CR_MIN_EVIDENCE_LINK_1", "CR_MIN_TELEMETRY_ARTIFACT_1", "CR_DIVERGENCE_BELOW_WARNING", "CR_OWNER_APPROVAL_REQUIRED"]},
+          "escalation_rule_code": {"type": "string", "enum": ["ER_BREACH_SLA_ONCE", "ER_BREACH_SLA_TWICE", "ER_CRITICAL_IMMEDIATE", "ER_PERSISTENT_HIGH_TWO_REVIEWS", "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE"]},
+          "closure_criteria": {"type": "string", "minLength": 1},
+          "escalation_trigger": {"type": "string", "minLength": 1},
+          "metadata": {
+            "type": "object",
+            "required": ["criticality", "dependencies"],
+            "properties": {
+              "criticality": {"type": ["number", "null"]},
+              "dependencies": {"type": "array", "items": {"type": "string"}}
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/standards/grlplus/ops_queue_export.schema.json
+++ b/standards/grlplus/ops_queue_export.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GRLPlus Ops Queue Export",
+  "type": "object",
+  "required": ["schema_version", "platform", "profile", "items"],
+  "properties": {
+    "schema_version": {"type": "string", "const": "grlplus-ops-queue-export/0.1"},
+    "platform": {"type": "string", "const": "ops_queue"},
+    "profile": {"type": "string", "enum": ["strategy", "cyber", "safety"]},
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "kind", "element_id", "owner", "severity", "intervention", "reason_codes",
+          "sla_due_in_days", "review_cadence_days", "closure_rule_code", "escalation_rule_code",
+          "closure_criteria", "escalation_trigger", "task_payload"
+        ],
+        "properties": {
+          "kind": {"type": "string", "const": "semantic_work_item"},
+          "element_id": {"type": "string", "minLength": 1},
+          "owner": {"type": ["string", "null"]},
+          "severity": {"type": "string", "enum": ["low", "medium", "high", "critical"]},
+          "intervention": {"type": "string", "enum": ["monitor", "gather_evidence", "add_direct_argument_coverage", "reduce_dependency_uncertainty", "resolve_contradictory_tradeoff"]},
+          "reason_codes": {"type": "array", "items": {"type": "string"}},
+          "sla_due_in_days": {"type": "integer", "minimum": 0},
+          "review_cadence_days": {"type": "integer", "minimum": 0},
+          "closure_rule_code": {"type": "string", "enum": ["CR_MIN_DIRECT_ARGUMENT_1", "CR_MIN_DIRECT_ARGUMENT_2", "CR_MIN_EVIDENCE_LINK_1", "CR_MIN_TELEMETRY_ARTIFACT_1", "CR_DIVERGENCE_BELOW_WARNING", "CR_OWNER_APPROVAL_REQUIRED"]},
+          "escalation_rule_code": {"type": "string", "enum": ["ER_BREACH_SLA_ONCE", "ER_BREACH_SLA_TWICE", "ER_CRITICAL_IMMEDIATE", "ER_PERSISTENT_HIGH_TWO_REVIEWS", "ER_MISSING_DIRECT_ARGUMENT_BLOCKS_CLOSURE"]},
+          "closure_criteria": {"type": "string", "minLength": 1},
+          "escalation_trigger": {"type": "string", "minLength": 1},
+          "task_payload": {
+            "type": "object",
+            "required": ["title", "next_action"],
+            "properties": {
+              "title": {"type": "string", "minLength": 1},
+              "next_action": {"type": "string", "minLength": 1}
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/standards/grlplus/ops_queue_export.schema.json
+++ b/standards/grlplus/ops_queue_export.schema.json
@@ -36,12 +36,12 @@
               "title": {"type": "string", "minLength": 1},
               "next_action": {"type": "string", "minLength": 1}
             },
-            "additionalProperties": true
+            "additionalProperties": false
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       }
     }
   },
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/standards/grlplus/repo_bound_issue_export_preview.json
+++ b/standards/grlplus/repo_bound_issue_export_preview.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "grlplus-github-bound-preview/0.1",
+  "repo_full_name": "SocioProphet/socioprophet",
+  "profile": "strategy",
+  "preview_items": [
+    {
+      "title": "[gather_evidence] goal.outcome",
+      "labels": ["grlplus", "semantic-worklist", "profile:strategy", "severity:medium", "intervention:gather_evidence"],
+      "severity": "medium",
+      "closure_rule_code": "CR_DIVERGENCE_BELOW_WARNING",
+      "escalation_rule_code": "ER_BREACH_SLA_TWICE",
+      "body_example": "Goal: address semantic governance for goal.outcome\n\nDefinition of Done:\n- [ ] Closure criteria satisfied\n- [ ] Evidence attached\n- [ ] Review completed\n\nAcceptance Criteria:\n- [ ] Severity and SLA fields populated\n- [ ] Reason codes preserved\n- [ ] Dependencies enumerated\n\nExit criteria:\n- closure_rule_code: CR_DIVERGENCE_BELOW_WARNING\n- escalation_rule_code: ER_BREACH_SLA_TWICE\n"
+    }
+  ]
+}


### PR DESCRIPTION
This change adds the strict platform/export contract artifacts for GRLPlus semantic worklists and binds the default GitHub issue export to `SocioProphet/socioprophet`.

Included:
- `standards/grlplus/github_issue_export.schema.json`
- `standards/grlplus/ops_queue_export.schema.json`
- `standards/grlplus/domain_action_policy_matrix.json`
- `standards/grlplus/github_binding_socioprophet_socioprophet.json`
- `standards/grlplus/repo_bound_issue_export_preview.json`

Why:
- formalize stricter GitHub and ops-queue payloads
- lock closure/escalation rule codes
- define strategy/cyber/safety action policy defaults
- bind exports to the observed issue-writing pattern in `SocioProphet/socioprophet`

Notes:
- this is a contract/policy tranche only
- no runtime exporter wiring is included in this PR
- intended follow-up is exporter conformance against these schemas
