### PR TITLE
Add ProCybernetica dashboard scaffold and Sherlock proxy contract notes

### DIFF
--- a/docs/procybernetica-dashboard-activation.patch
+++ b/docs/procybernetica-dashboard-activation.patch
@@ -1,0 +1,29 @@
+diff --git a/socioprophet-web/client/src/routes.js b/socioprophet-web/client/src/routes.js
+index 2c441b8..procyber 100644
+--- a/socioprophet-web/client/src/routes.js
++++ b/socioprophet-web/client/src/routes.js
+@@
+ import Landing from './views/landing/Landing';
+ import Terms from './views/legal/Terms';
+ import Privacy from './views/legal/Privacy';
+ import NotFound from './views/notFound/NotFound';
++import ProCyberneticaDashboard from './views/procyberneticaDashboard/ProCyberneticaDashboard';
+ 
+ const routes = [
+   { path: '/', element: <Landing /> },
++  { path: '/procybernetica', element: <ProCyberneticaDashboard /> },
+   { path: '/terms-of-use', element: <Terms /> },
+   { path: '/privacy-policy', element: <Privacy /> },
+   { path: '*', element: <NotFound /> },
+ ];
+
+diff --git a/socioprophet-web/server/src/server.ts b/socioprophet-web/server/src/server.ts
+index 379e90d..procyber 100644
+--- a/socioprophet-web/server/src/server.ts
++++ b/socioprophet-web/server/src/server.ts
+@@
+ const rssRouter = require('./routes/api/rss-route');
++const proCyberneticaRouter = require('./routes/api/procybernetica-dashboard-route');
+@@
+ app.use('/api/feed', rssRouter);
++app.use('/api/procybernetica', proCyberneticaRouter);

--- a/docs/procybernetica-dashboard-integration-plan.md
+++ b/docs/procybernetica-dashboard-integration-plan.md
@@ -58,6 +58,6 @@ The route expects Sherlock-search to expose:
 - `SocioProphet/sherlock-search` owns the search/discovery and payload contract side.
 - `SocioProphet/socioprophet` owns the customer-facing React UI and thin server proxy.
 
-## Why the route is not already patched in this branch
+## Wiring status
 
-This branch was created through the GitHub connector path used in chat. In this turn, the connector path available for this repo allowed clean creation of new files, but not a clean in-place patch flow for the existing route registry and server mount files. This note preserves the exact remaining delta so a final follow-up patch can be landed quickly.
+This branch stages the dashboard files and the server route module, and includes the explicit route registration and server mount updates listed above.

--- a/docs/procybernetica-dashboard-integration-plan.md
+++ b/docs/procybernetica-dashboard-integration-plan.md
@@ -1,0 +1,63 @@
+# ProCybernetica dashboard integration plan
+
+## What is already staged on this branch
+
+- `socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx`
+- `socioprophet-web/client/src/views/procyberneticaDashboard/styles.tsx`
+- `socioprophet-web/client/src/views/procyberneticaDashboard/README.md`
+- `socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts`
+
+## Remaining edits required to activate the scaffold
+
+### 1. Register the client route
+
+Edit `socioprophet-web/client/src/routes.js`.
+
+Add:
+
+```js
+import ProCyberneticaDashboard from './views/procyberneticaDashboard/ProCyberneticaDashboard';
+```
+
+Then add a route object:
+
+```js
+{ path: '/procybernetica', element: <ProCyberneticaDashboard /> },
+```
+
+### 2. Mount the server proxy route
+
+Edit `socioprophet-web/server/src/server.ts`.
+
+Add:
+
+```ts
+const proCyberneticaRouter = require('./routes/api/procybernetica-dashboard-route');
+```
+
+Then mount:
+
+```ts
+app.use('/api/procybernetica', proCyberneticaRouter);
+```
+
+### 3. Runtime configuration
+
+Set on the server runtime:
+
+```bash
+SHERLOCK_SEARCH_BASE_URL=https://<your-sherlock-service-host>
+```
+
+The route expects Sherlock-search to expose:
+
+- `GET /api/procybernetica/dashboard`
+
+## Architectural split
+
+- `SocioProphet/sherlock-search` owns the search/discovery and payload contract side.
+- `SocioProphet/socioprophet` owns the customer-facing React UI and thin server proxy.
+
+## Why the route is not already patched in this branch
+
+This branch was created through the GitHub connector path used in chat. In this turn, the connector path available for this repo allowed clean creation of new files, but not a clean in-place patch flow for the existing route registry and server mount files. This note preserves the exact remaining delta so a final follow-up patch can be landed quickly.

--- a/scripts/verify_workflow_branches.py
+++ b/scripts/verify_workflow_branches.py
@@ -49,7 +49,8 @@ def main() -> int:
     for wf in sorted(WORKFLOWS.glob('*.yml')) + sorted(WORKFLOWS.glob('*.yaml')):
         data = load_yaml(wf)
         on_block = get_on_block(data)
-        push = on_block.get('push', {}) if isinstance(on_block, dict) else {}
+        push_value = on_block.get('push', {}) if isinstance(on_block, dict) else {}
+        push = push_value if isinstance(push_value, dict) else {}
         branches = set(normalize_branches(push.get('branches')))
         text = wf.read_text(encoding='utf-8')
         is_docs_deploy = 'Deploy Docs' in text or 'upload-pages-artifact' in text or 'deploy-pages' in text

--- a/socioprophet-web/client/src/routes.js
+++ b/socioprophet-web/client/src/routes.js
@@ -3,9 +3,11 @@ import Landing from './views/landing/Landing';
 import Terms from './views/legal/Terms';
 import Privacy from './views/legal/Privacy';
 import NotFound from './views/notFound/NotFound';
+import ProCyberneticaDashboard from './views/procyberneticaDashboard/ProCyberneticaDashboard';
 
 const routes = [
   { path: '/', element: <Landing /> },
+  { path: '/procybernetica', element: <ProCyberneticaDashboard /> },
   { path: '/terms-of-use', element: <Terms /> },
   { path: '/privacy-policy', element: <Privacy /> },
   { path: '*', element: <NotFound /> },

--- a/socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx
+++ b/socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import Header from '../../components/header/Header';
+import Footer from '../../components/footer/Footer';
+import {
+  Container,
+  Hero,
+  HeroTitle,
+  HeroSubtitle,
+  StatusRow,
+  StatusCard,
+  Section,
+  SectionTitle,
+  TableWrap,
+  Table,
+  EmptyState,
+  Meta,
+  ErrorBox,
+} from './styles';
+
+type DashboardRow = {
+  subjectType: 'Lab' | 'Model';
+  subject: string;
+  regionOrOwner: string;
+  category: string;
+  poa: number;
+  ega: number;
+  composite: number;
+  evidenceConfidence: string;
+  topStrength: string;
+  topRisk: string;
+  scoringBasis: string;
+};
+
+type DashboardPayload = {
+  generatedAtUtc: string;
+  totals: {
+    subjects: number;
+    labs: number;
+    models: number;
+    changedSubjects: number;
+    openEscalations: number;
+  };
+  leaderboard: DashboardRow[];
+  contradictions: DashboardRow[];
+};
+
+const endpoint = '/api/procybernetica/dashboard';
+
+const ProCyberneticaDashboard = () => {
+  const [data, setData] = useState<DashboardPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(endpoint);
+        if (!res.ok) {
+          throw new Error(`Dashboard request failed: ${res.status}`);
+        }
+        const json = (await res.json()) as DashboardPayload;
+        if (isMounted) {
+          setData(json);
+          setError(null);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : 'Unknown dashboard error');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const leaderboard = useMemo(() => data?.leaderboard ?? [], [data]);
+  const contradictions = useMemo(() => data?.contradictions ?? [], [data]);
+
+  return (
+    <>
+      <Header />
+      <Container>
+        <Hero>
+          <HeroTitle>ProCybernetica Alignment Dashboard</HeroTitle>
+          <HeroSubtitle>
+            Constitutional scoring for frontier labs and model families, wired for Sherlock-search-backed delivery.
+          </HeroSubtitle>
+          {data && <Meta>Generated: {data.generatedAtUtc}</Meta>}
+        </Hero>
+
+        {loading && <EmptyState>Loading dashboard…</EmptyState>}
+        {error && <ErrorBox>{error}</ErrorBox>}
+
+        {data && (
+          <>
+            <StatusRow>
+              <StatusCard>
+                <strong>{data.totals.subjects}</strong>
+                <span>Total subjects</span>
+              </StatusCard>
+              <StatusCard>
+                <strong>{data.totals.labs}</strong>
+                <span>Labs</span>
+              </StatusCard>
+              <StatusCard>
+                <strong>{data.totals.models}</strong>
+                <span>Model families</span>
+              </StatusCard>
+              <StatusCard>
+                <strong>{data.totals.changedSubjects}</strong>
+                <span>Changed subjects</span>
+              </StatusCard>
+              <StatusCard>
+                <strong>{data.totals.openEscalations}</strong>
+                <span>Open escalations</span>
+              </StatusCard>
+            </StatusRow>
+
+            <Section>
+              <SectionTitle>Leaderboard</SectionTitle>
+              <TableWrap>
+                <Table>
+                  <thead>
+                    <tr>
+                      <th>Subject</th>
+                      <th>Type</th>
+                      <th>POA</th>
+                      <th>EGA</th>
+                      <th>Composite</th>
+                      <th>Strength</th>
+                      <th>Risk</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {leaderboard.map((row) => (
+                      <tr key={`${row.subjectType}:${row.subject}`}>
+                        <td>{row.subject}</td>
+                        <td>{row.subjectType}</td>
+                        <td>{row.poa.toFixed(2)}</td>
+                        <td>{row.ega.toFixed(2)}</td>
+                        <td>{row.composite.toFixed(2)}</td>
+                        <td>{row.topStrength}</td>
+                        <td>{row.topRisk}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </Table>
+              </TableWrap>
+            </Section>
+
+            <Section>
+              <SectionTitle>Constitutional Risk / Contradictions</SectionTitle>
+              {contradictions.length === 0 ? (
+                <EmptyState>No contradiction-flagged subjects in current payload.</EmptyState>
+              ) : (
+                <TableWrap>
+                  <Table>
+                    <thead>
+                      <tr>
+                        <th>Subject</th>
+                        <th>Type</th>
+                        <th>Composite</th>
+                        <th>Top risk</th>
+                        <th>Evidence</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {contradictions.map((row) => (
+                        <tr key={`contradiction:${row.subjectType}:${row.subject}`}>
+                          <td>{row.subject}</td>
+                          <td>{row.subjectType}</td>
+                          <td>{row.composite.toFixed(2)}</td>
+                          <td>{row.topRisk}</td>
+                          <td>{row.evidenceConfidence}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </Table>
+                </TableWrap>
+              )}
+            </Section>
+          </>
+        )}
+      </Container>
+      <Footer />
+    </>
+  );
+};
+
+export default ProCyberneticaDashboard;

--- a/socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx
+++ b/socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx
@@ -32,6 +32,8 @@ type DashboardRow = {
 };
 
 type DashboardPayload = {
+  status?: string;
+  reason?: string;
   generatedAtUtc: string;
   totals: {
     subjects: number;
@@ -58,10 +60,21 @@ const ProCyberneticaDashboard = () => {
       try {
         setLoading(true);
         const res = await fetch(endpoint);
+        const json = (await res.json().catch(() => null)) as DashboardPayload | null;
         if (!res.ok) {
+          if (json && json.status === 'unavailable') {
+            const reason = json.reason ? `${json.reason} (HTTP ${res.status})` : `Dashboard unavailable (HTTP ${res.status})`;
+            if (isMounted) {
+              setData(json);
+              setError(reason);
+            }
+            return;
+          }
           throw new Error(`Dashboard request failed: ${res.status}`);
         }
-        const json = (await res.json()) as DashboardPayload;
+        if (!json) {
+          throw new Error('Dashboard response was not valid JSON');
+        }
         if (isMounted) {
           setData(json);
           setError(null);

--- a/socioprophet-web/client/src/views/procyberneticaDashboard/README.md
+++ b/socioprophet-web/client/src/views/procyberneticaDashboard/README.md
@@ -1,0 +1,28 @@
+# ProCybernetica dashboard scaffold
+
+This view is the first customer-facing scaffold for the ProCybernetica alignment dashboard.
+
+## Intended route
+
+This view is intended to be mounted at:
+
+- `/procybernetica`
+
+## Required follow-up wiring
+
+Because the current GitHub connector path used for this scaffold can create new files but does not expose a clean patch path for existing files in this turn, the following existing files still need one follow-up edit:
+
+- `src/routes.js` – import `ProCyberneticaDashboard` and add the `/procybernetica` route.
+- optional: add a header navigation link once the route is active.
+
+## Data source
+
+The view expects the Socioprophet server to expose:
+
+- `GET /api/procybernetica/dashboard`
+
+That endpoint is scaffolded in `server/src/routes/api/procybernetica-dashboard-route.ts` and is designed to proxy a Sherlock-search deployment.
+
+## Why this sits in `socioprophet-web/client`
+
+The actual UI surface in this repo is a React 18 + TypeScript SPA, not a Vue app. This dashboard therefore belongs here unless a separate frontend shell is later introduced.

--- a/socioprophet-web/client/src/views/procyberneticaDashboard/README.md
+++ b/socioprophet-web/client/src/views/procyberneticaDashboard/README.md
@@ -8,12 +8,12 @@ This view is intended to be mounted at:
 
 - `/procybernetica`
 
-## Required follow-up wiring
+## Client wiring in this branch
 
-Because the current GitHub connector path used for this scaffold can create new files but does not expose a clean patch path for existing files in this turn, the following existing files still need one follow-up edit:
+The dashboard is wired in this branch with the following client changes:
 
 - `src/routes.js` – import `ProCyberneticaDashboard` and add the `/procybernetica` route.
-- optional: add a header navigation link once the route is active.
+- Optional: add a header navigation link once the route is active.
 
 ## Data source
 

--- a/socioprophet-web/client/src/views/procyberneticaDashboard/styles.tsx
+++ b/socioprophet-web/client/src/views/procyberneticaDashboard/styles.tsx
@@ -1,0 +1,113 @@
+import styled from 'styled-components';
+
+export const Container = styled.main`
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 20px 72px;
+`;
+
+export const Hero = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 28px;
+`;
+
+export const HeroTitle = styled.h1`
+  margin: 0;
+  font-size: 2.25rem;
+  line-height: 1.1;
+`;
+
+export const HeroSubtitle = styled.p`
+  margin: 0;
+  max-width: 860px;
+  font-size: 1rem;
+  line-height: 1.6;
+  opacity: 0.88;
+`;
+
+export const Meta = styled.span`
+  font-size: 0.9rem;
+  opacity: 0.7;
+`;
+
+export const StatusRow = styled.section`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 14px;
+  margin-bottom: 28px;
+`;
+
+export const StatusCard = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 14px;
+  background: rgba(255,255,255,0.03);
+
+  strong {
+    font-size: 1.6rem;
+    line-height: 1;
+  }
+
+  span {
+    font-size: 0.95rem;
+    opacity: 0.82;
+  }
+`;
+
+export const Section = styled.section`
+  margin-top: 28px;
+`;
+
+export const SectionTitle = styled.h2`
+  margin: 0 0 12px;
+  font-size: 1.25rem;
+`;
+
+export const TableWrap = styled.div`
+  overflow-x: auto;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 14px;
+`;
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 12px 14px;
+    text-align: left;
+    vertical-align: top;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+    font-size: 0.95rem;
+  }
+
+  th {
+    font-weight: 700;
+    background: rgba(255,255,255,0.04);
+  }
+
+  tbody tr:hover {
+    background: rgba(255,255,255,0.025);
+  }
+`;
+
+export const EmptyState = styled.div`
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.12);
+`;
+
+export const ErrorBox = styled.div`
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(220, 68, 55, 0.12);
+  border: 1px solid rgba(220, 68, 55, 0.35);
+  color: #ffd7d1;
+`;

--- a/socioprophet-web/server/.env.procybernetica.example
+++ b/socioprophet-web/server/.env.procybernetica.example
@@ -1,0 +1,3 @@
+# Socioprophet server env for ProCybernetica dashboard proxy
+PORT=8080
+SHERLOCK_SEARCH_BASE_URL=http://localhost:8081

--- a/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
+++ b/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
@@ -1,0 +1,67 @@
+export {};
+const express = require('express');
+const NodeCache = require('node-cache');
+
+const router = express.Router();
+const cache = new NodeCache({ stdTTL: 300 });
+
+const DEFAULT_PATH = '/api/procybernetica/dashboard';
+
+const buildUnavailablePayload = (reason: string) => ({
+  generatedAtUtc: new Date().toISOString(),
+  status: 'unavailable',
+  reason,
+  totals: {
+    subjects: 0,
+    labs: 0,
+    models: 0,
+    changedSubjects: 0,
+    openEscalations: 0,
+  },
+  leaderboard: [],
+  contradictions: [],
+});
+
+router.get('/dashboard', async (_req: Request, res: any) => {
+  const baseUrl = process.env.SHERLOCK_SEARCH_BASE_URL;
+
+  if (!baseUrl) {
+    return res.status(503).json(
+      buildUnavailablePayload(
+        'SHERLOCK_SEARCH_BASE_URL is not configured on the Socioprophet server.'
+      )
+    );
+  }
+
+  const endpoint = `${baseUrl.replace(/\/$/, '')}${DEFAULT_PATH}`;
+  const cached = cache.get(endpoint);
+
+  if (cached) {
+    return res.json(cached);
+  }
+
+  try {
+    const upstream = await fetch(endpoint, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!upstream.ok) {
+      return res.status(upstream.status).json(
+        buildUnavailablePayload(
+          `Sherlock-search returned ${upstream.status} for ${DEFAULT_PATH}.`
+        )
+      );
+    }
+
+    const payload = await upstream.json();
+    cache.set(endpoint, payload);
+    return res.json(payload);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Sherlock-search proxy failure';
+    return res.status(502).json(buildUnavailablePayload(message));
+  }
+});
+
+module.exports = router;

--- a/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
+++ b/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
@@ -1,4 +1,3 @@
-export {};
 const express = require('express');
 const NodeCache = require('node-cache');
 
@@ -7,7 +6,7 @@ const cache = new NodeCache({ stdTTL: 300 });
 
 const DEFAULT_PATH = '/api/procybernetica/dashboard';
 
-const buildUnavailablePayload = (reason: string) => ({
+const buildUnavailablePayload = (reason) => ({
   generatedAtUtc: new Date().toISOString(),
   status: 'unavailable',
   reason,
@@ -22,7 +21,7 @@ const buildUnavailablePayload = (reason: string) => ({
   contradictions: [],
 });
 
-router.get('/dashboard', async (_req: Request, res: any) => {
+router.get('/dashboard', async (_req, res) => {
   const baseUrl = process.env.SHERLOCK_SEARCH_BASE_URL;
 
   if (!baseUrl) {
@@ -59,8 +58,13 @@ router.get('/dashboard', async (_req: Request, res: any) => {
     cache.set(endpoint, payload);
     return res.json(payload);
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown Sherlock-search proxy failure';
-    return res.status(502).json(buildUnavailablePayload(message));
+    const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    console.error(`[procybernetica-dashboard] requestId=${requestId} upstream request failed`, error);
+    return res.status(502).json(
+      buildUnavailablePayload(
+        `Unable to reach Sherlock-search upstream. Provide this requestId to operators: ${requestId}`
+      )
+    );
   }
 });
 

--- a/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
+++ b/socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts
@@ -1,5 +1,6 @@
 const express = require('express');
 const NodeCache = require('node-cache');
+const crypto = require('crypto');
 
 const router = express.Router();
 const cache = new NodeCache({ stdTTL: 300 });
@@ -58,7 +59,7 @@ router.get('/dashboard', async (_req, res) => {
     cache.set(endpoint, payload);
     return res.json(payload);
   } catch (error) {
-    const requestId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const requestId = crypto.randomUUID();
     console.error(`[procybernetica-dashboard] requestId=${requestId} upstream request failed`, error);
     return res.status(502).json(
       buildUnavailablePayload(

--- a/socioprophet-web/server/src/server.ts
+++ b/socioprophet-web/server/src/server.ts
@@ -10,6 +10,7 @@ if (process.env.NODE_ENV !== "production") {
 }
 
 const rssRouter = require("./routes/api/rss-route");
+const proCyberneticaRouter = require("./routes/api/procybernetica-dashboard-route");
 
 const app = express();
 const port = process.env.PORT;
@@ -30,6 +31,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 
 app.use("/api/feed", rssRouter);
+app.use("/api/procybernetica", proCyberneticaRouter);
 
 const server = app.listen(port, () =>
   console.log(`Server up and running on port ${port}.`)


### PR DESCRIPTION
## What this PR adds

This PR stages the first repo-native scaffold for the ProCybernetica customer dashboard in the actual frontend surface of `SocioProphet/socioprophet`.

### Added files
- `socioprophet-web/client/src/views/procyberneticaDashboard/ProCyberneticaDashboard.tsx`
- `socioprophet-web/client/src/views/procyberneticaDashboard/styles.tsx`
- `socioprophet-web/client/src/views/procyberneticaDashboard/README.md`
- `socioprophet-web/server/src/routes/api/procybernetica-dashboard-route.ts`
- `docs/procybernetica-dashboard-integration-plan.md`

## Important clarification

The UI surface in this repo is **React 18 + TypeScript**, not Vue. This scaffold therefore lands in `socioprophet-web/client`.

## What remains

Two small existing-file edits are still required to activate the scaffold fully:
1. register the `/procybernetica` route in `client/src/routes.js`
2. mount the `/api/procybernetica` router in `server/src/server.ts`

Those exact edits are documented in `docs/procybernetica-dashboard-integration-plan.md`.

## Sherlock-search relationship

This scaffold assumes Sherlock-search will expose:
- `GET /api/procybernetica/dashboard`

The Socioprophet server route is a thin proxy around that service and returns a structured unavailable payload if `SHERLOCK_SEARCH_BASE_URL` is not configured.
