### PR TITLE
Install ZoomInfo WebSights on marketing surface

### DIFF
--- a/marketing/public/assets/zoominfo-websights.js
+++ b/marketing/public/assets/zoominfo-websights.js
@@ -1,0 +1,19 @@
+window.ZIProjectKey = "35ad52d0251776107780";
+(function () {
+  var zi = document.createElement("script");
+  zi.type = "text/javascript";
+  zi.async = true;
+  zi.src = "https://js.zi-scripts.com/zi-tag.js";
+
+  function attach() {
+    if (document.body && !document.querySelector('script[src="https://js.zi-scripts.com/zi-tag.js"]')) {
+      document.body.appendChild(zi);
+    }
+  }
+
+  if (document.readyState === "complete") {
+    attach();
+  } else {
+    window.addEventListener("load", attach, { once: true });
+  }
+})();

--- a/marketing/public/index.html
+++ b/marketing/public/index.html
@@ -17,6 +17,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/assets/site.css">
     <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
+    <script src="/assets/zoominfo-websights.js"></script>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-GL5Y2786Z6"></script>
     <script>


### PR DESCRIPTION
## Summary
- add a dedicated `marketing/public/assets/zoominfo-websights.js` helper that loads the vendor WebSights tag using the literal ZoomInfo project key supplied by ZoomInfo support
- include that helper on the marketing home page in `marketing/public/index.html`
- leave existing GA4 wiring in place and scope the first repair to the root marketing surface only

## Why
ZoomInfo confirmed that `socioprophet.com` already exists in Admin Portal and that WebSights is toggled on, but the public site was missing the browser-side script install, so ZoomInfo could not detect visits.

## Validation to run after merge/deploy
- deploy the site with the existing production path in `scripts/deploy-prod.sh`
- refresh ZoomInfo Domains and confirm `socioprophet.com` connection changes to `On`
- visit `https://socioprophet.com/` and confirm a test visit appears in WebSights

## Scope notes
- this PR intentionally does not touch docs yet
- this PR intentionally does not enable Website Personalization or GTM
