### PR TITLE
Wire map workbench to GAIA layer catalog API

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/MapPage.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MapPage.smoke.test.ts
@@ -1,7 +1,8 @@
 /**
  * Smoke tests for the /map route (MapPage.vue).
  *
- * Covers the seven smoke-test criteria from the staging-readiness issue:
+ * Covers the seven smoke-test criteria from the staging-readiness issue and
+ * the GAIA layer-catalog integration guardrails:
  *  1. /map route loads (component mounts without throwing)
  *  2. Map canvas element is rendered
  *  3. Fallback mode renders when the API is unavailable
@@ -9,6 +10,7 @@
  *  5. H3 lookup path does not blank the page
  *  6. Evidence / governance / runtime panels render
  *  7. App displays live / fallback backend status clearly
+ *  8. GAIA layer catalog panel renders attribution/provenance/non-production tile metadata
  *
  * MapLibre-GL is stubbed via src/__tests__/setup.ts so tests run without WebGL.
  * The gaiaMap API module is mocked so tests are fully offline.
@@ -17,7 +19,11 @@ import { mount, flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRouter, createWebHashHistory } from 'vue-router';
 import MapPage from '../pages/MapPage.vue';
-import { demoGaiaMapSnapshot } from '../api/gaiaMap';
+import {
+  demoGaiaLayerCatalog,
+  demoGaiaMapSnapshot,
+  demoGaiaTileManifest,
+} from '../api/gaiaMap';
 
 // ──────────────────────────────────────────────────────────────
 // Mock the gaiaMap API module
@@ -29,11 +35,15 @@ vi.mock('../api/gaiaMap', async (importOriginal) => {
     ...actual,
     fetchGaiaMapSnapshotWithFallback: vi.fn(),
     fetchFeaturesByH3WithFallback: vi.fn(),
+    fetchGaiaLayerCatalogWithFallback: vi.fn(),
+    fetchGaiaTileManifestWithFallback: vi.fn(),
   };
 });
 
 import {
+  fetchGaiaLayerCatalogWithFallback,
   fetchGaiaMapSnapshotWithFallback,
+  fetchGaiaTileManifestWithFallback,
   fetchFeaturesByH3WithFallback,
 } from '../api/gaiaMap';
 
@@ -68,6 +78,38 @@ function liveModeResult() {
   };
 }
 
+function demoLayerCatalogResult() {
+  return {
+    catalog: demoGaiaLayerCatalog(),
+    mode: 'demo' as const,
+    warning: 'Using demo GAIA layer catalog because the catalog API is unavailable: Network Error',
+  };
+}
+
+function liveLayerCatalogResult() {
+  return {
+    catalog: demoGaiaLayerCatalog(),
+    mode: 'live' as const,
+    warning: undefined,
+  };
+}
+
+function demoTileManifestResult() {
+  return {
+    manifest: demoGaiaTileManifest(),
+    mode: 'demo' as const,
+    warning: undefined,
+  };
+}
+
+function liveTileManifestResult() {
+  return {
+    manifest: demoGaiaTileManifest(),
+    mode: 'live' as const,
+    warning: undefined,
+  };
+}
+
 function demoH3FallbackResult() {
   const snap = demoGaiaMapSnapshot();
   return {
@@ -77,10 +119,22 @@ function demoH3FallbackResult() {
   };
 }
 
+async function mountMapPage() {
+  const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
+  await flushPromises();
+  await flushPromises();
+  return wrapper;
+}
+
 async function clickH3InspectButton(wrapper: ReturnType<typeof mount>) {
   const btn = wrapper.find('[data-testid="h3-inspect-button"]');
   if (btn.exists()) await btn.trigger('click');
 }
+
+beforeEach(() => {
+  vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(demoLayerCatalogResult());
+  vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(demoTileManifestResult());
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -102,8 +156,7 @@ describe('Criterion 1 – /map route loads', () => {
   it('resolves to a rendered DOM', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.element).toBeDefined();
   });
@@ -117,8 +170,7 @@ describe('Criterion 2 – map canvas renders', () => {
   it('contains an element with aria-label "GAIA map canvas"', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('[aria-label="GAIA map canvas"]').exists()).toBe(true);
   });
@@ -126,8 +178,7 @@ describe('Criterion 2 – map canvas renders', () => {
   it('contains the map-canvas class', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('.map-canvas').exists()).toBe(true);
   });
@@ -141,8 +192,7 @@ describe('Criterion 3 – fallback mode when API is unavailable', () => {
   it('shows fallback warning message', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.text()).toMatch(/demo fallback/i);
   });
@@ -150,8 +200,7 @@ describe('Criterion 3 – fallback mode when API is unavailable', () => {
   it('still renders the map grid (not a blank screen)', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('.map-grid').exists()).toBe(true);
   });
@@ -159,8 +208,7 @@ describe('Criterion 3 – fallback mode when API is unavailable', () => {
   it('displays the demo fallback status tag', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.text()).toMatch(/demo fallback/i);
   });
@@ -173,20 +221,22 @@ describe('Criterion 3 – fallback mode when API is unavailable', () => {
 describe('Criterion 4 – live API mode', () => {
   it('shows "live API" label when API responds successfully', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.text()).toMatch(/live api/i);
+    expect(wrapper.text()).toMatch(/live catalog/i);
   });
 
   it('does not show a fallback warning in live mode', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
-    // No warning card should appear
     expect(wrapper.find('.state-card.warning').exists()).toBe(false);
   });
 });
@@ -203,8 +253,7 @@ describe('Criterion 5 – H3 lookup path does not blank the page', () => {
   it('page grid is still visible after a successful H3 lookup (fallback)', async () => {
     vi.mocked(fetchFeaturesByH3WithFallback).mockResolvedValue(demoH3FallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     await clickH3InspectButton(wrapper);
     await flushPromises();
@@ -215,8 +264,7 @@ describe('Criterion 5 – H3 lookup path does not blank the page', () => {
   it('page grid is still visible when H3 lookup fails', async () => {
     vi.mocked(fetchFeaturesByH3WithFallback).mockRejectedValue(new Error('H3 network error'));
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     await clickH3InspectButton(wrapper);
     await flushPromises();
@@ -227,13 +275,11 @@ describe('Criterion 5 – H3 lookup path does not blank the page', () => {
   it('shows lookup status after H3 inspect', async () => {
     vi.mocked(fetchFeaturesByH3WithFallback).mockResolvedValue(demoH3FallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     await clickH3InspectButton(wrapper);
     await flushPromises();
 
-    // Either a lookup status message or the map-grid is visible
     const hasStatus = wrapper.find('.lookup-status').exists();
     const hasGrid = wrapper.find('.map-grid').exists();
     expect(hasStatus || hasGrid).toBe(true);
@@ -248,8 +294,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('renders the evidence panel', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('#evidence-panel').exists()).toBe(true);
   });
@@ -257,8 +302,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('renders the governance panel', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('#governance-panel').exists()).toBe(true);
   });
@@ -266,8 +310,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('renders the feature inspector panel', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.find('#feature-panel').exists()).toBe(true);
   });
@@ -275,8 +318,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('shows at least one runtime posture entry', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     expect(wrapper.findAll('.runtime-row').length).toBeGreaterThan(0);
   });
@@ -284,8 +326,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('shows at least one governance validation lane', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     const governancePanel = wrapper.find('#governance-panel');
     expect(governancePanel.find('ul').exists()).toBe(true);
@@ -295,8 +336,7 @@ describe('Criterion 6 – evidence, governance, runtime panels', () => {
   it('shows at least one evidence reference', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     const evidencePanel = wrapper.find('#evidence-panel');
     expect(evidencePanel.exists()).toBe(true);
@@ -312,18 +352,15 @@ describe('Criterion 7 – backend status is displayed', () => {
   it('shows a status tag in the header', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
-    // The header contains a tag element
     expect(wrapper.find('.tag').exists()).toBe(true);
   });
 
   it('shows "demo fallback" label in fallback mode', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     const tags = wrapper.findAll('.tag');
     const tagTexts = tags.map((t) => t.text().toLowerCase());
@@ -332,9 +369,10 @@ describe('Criterion 7 – backend status is displayed', () => {
 
   it('shows "live api" label in live mode', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     const tags = wrapper.findAll('.tag');
     const tagTexts = tags.map((t) => t.text().toLowerCase());
@@ -344,11 +382,88 @@ describe('Criterion 7 – backend status is displayed', () => {
   it('shows a last-loaded timestamp after data is loaded', async () => {
     vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
 
-    const wrapper = mount(MapPage, { global: { plugins: [makeRouter()] } });
-    await flushPromises();
+    const wrapper = await mountMapPage();
 
     const tags = wrapper.findAll('.tag');
     const tagTexts = tags.map((t) => t.text().toLowerCase());
     expect(tagTexts.some((t) => t.includes('last loaded'))).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// Criterion 8 — GAIA layer catalog integration
+// ──────────────────────────────────────────────────────────────
+
+describe('Criterion 8 – GAIA layer catalog and tile-manifest metadata', () => {
+  it('renders the GAIA layer catalog panel', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
+
+    const wrapper = await mountMapPage();
+
+    expect(wrapper.find('[data-testid="gaia-layer-catalog-panel"]').exists()).toBe(true);
+    expect(wrapper.text()).toMatch(/GAIA layer catalog/i);
+  });
+
+  it('renders bounded OSM layer metadata from the catalog', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
+
+    const wrapper = await mountMapPage();
+
+    expect(wrapper.text()).toMatch(/Lower Manhattan Bounded Extract/i);
+    expect(wrapper.text()).toMatch(/© OpenStreetMap contributors/i);
+    expect(wrapper.text()).toMatch(/ODbL-1.0|OpenStreetMap/i);
+  });
+
+  it('fetches and displays tile manifest metadata when selecting a layer', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
+
+    const wrapper = await mountMapPage();
+    const layerButton = wrapper.find('[data-testid="gaia-layer-button"]');
+    await layerButton.trigger('click');
+    await flushPromises();
+
+    expect(fetchGaiaTileManifestWithFallback).toHaveBeenCalled();
+    expect(wrapper.find('[data-testid="gaia-tile-manifest-panel"]').exists()).toBe(true);
+    expect(wrapper.text()).toMatch(/fixture-placeholder-not-production/i);
+  });
+
+  it('shows placeholder tile guard and does not treat placeholder URLs as production tiles', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
+
+    const wrapper = await mountMapPage();
+
+    expect(wrapper.find('[data-testid="placeholder-tile-guard"]').text()).toMatch(/placeholder tile metadata only/i);
+    expect(wrapper.text()).toMatch(/production_tile_serving=false/i);
+    expect(wrapper.text()).toMatch(/never added as production MapLibre tile sources/i);
+  });
+
+  it('keeps catalog fallback mode visible when the catalog API is unavailable', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(demoFallbackResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(demoLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(demoTileManifestResult());
+
+    const wrapper = await mountMapPage();
+
+    expect(wrapper.text()).toMatch(/demo catalog/i);
+    expect(wrapper.find('[data-testid="gaia-layer-catalog-warning"]').exists()).toBe(true);
+    expect(wrapper.text()).toMatch(/Catalog mode remains advisory and fixture-backed/i);
+  });
+
+  it('renders attribution, provenance, and source receipt references', async () => {
+    vi.mocked(fetchGaiaMapSnapshotWithFallback).mockResolvedValue(liveModeResult());
+    vi.mocked(fetchGaiaLayerCatalogWithFallback).mockResolvedValue(liveLayerCatalogResult());
+    vi.mocked(fetchGaiaTileManifestWithFallback).mockResolvedValue(liveTileManifestResult());
+
+    const wrapper = await mountMapPage();
+
+    expect(wrapper.text()).toMatch(/osm-source-receipt\.v1\.json/i);
+    expect(wrapper.text()).toMatch(/sha256:e5baba/i);
+    expect(wrapper.text()).toMatch(/8928308280fffff/i);
   });
 });

--- a/socioprophet-web/client-vue/src/api/gaiaMap.ts
+++ b/socioprophet-web/client-vue/src/api/gaiaMap.ts
@@ -1,5 +1,10 @@
 import type {
+  GaiaLayerCatalog,
+  GaiaLayerCatalogLoadResult,
+  GaiaLayerEntry,
   GaiaMapSnapshot,
+  GaiaTileManifest,
+  GaiaTileManifestLoadResult,
   GovernanceState,
   H3FeatureLayerSearch,
   MapLayer,
@@ -15,6 +20,7 @@ const API_BASE = (import.meta as any).env?.VITE_GAIA_MAP_API_BASE || '/api';
 const DEFAULT_OSM_TYPE = 'way';
 const DEFAULT_OSM_ID = '424242';
 const DEFAULT_H3_CELL = '8928308280fffff';
+const DEFAULT_GAIA_LAYER_ID = 'osm-layer-manifest-candidate-lower-manhattan-bounded-extract-2026-04-26';
 
 export type GaiaMapDataMode = 'live' | 'demo';
 
@@ -57,6 +63,80 @@ function demoReceipt(responseKind: string, routeSafetyStatus: ResponseReceipt['r
     },
   };
 }
+
+const DEMO_GAIA_LAYER: GaiaLayerEntry = {
+  manifest_version: 'v1',
+  layer_id: DEFAULT_GAIA_LAYER_ID,
+  layer_type: 'vector',
+  title: 'GAIA OSM Bounded Ingest Layer – Lower Manhattan Bounded Extract',
+  description: 'Bounded OSM ingest layer manifest candidate. Fixture-backed catalog surface. Not production tile-serving. Advisory only.',
+  sources: [
+    {
+      source_id: 'osm-source-envelope-lower-manhattan-bounded-extract-2026-04-26',
+      source_type: 'OpenStreetMap extract',
+      source_refs: [
+        'osm-extract://bounded/lower-manhattan/2026-04-26',
+        'osm-source-receipt.v1.json',
+        'osm-feature-bindings.v1.json',
+      ],
+    },
+  ],
+  tiles: {
+    url_template: 'placeholder://tiles/gaia/osm-bounded/{z}/{x}/{y}.mvt',
+    min_zoom: 0,
+    max_zoom: 14,
+    format: 'mvt',
+  },
+  spatial: {
+    bbox: [-74.012, 40.705, -73.998, 40.718],
+    h3_cells: ['89283082807ffff', DEFAULT_H3_CELL, '8928308281fffff'],
+    crs: 'EPSG:4326',
+  },
+  attribution: {
+    attribution_text: '© OpenStreetMap contributors',
+    license_refs: ['ODbL-1.0'],
+    source_urls: ['https://www.openstreetmap.org'],
+  },
+  provenance: {
+    source_refs: [
+      'osm-source-receipt.v1.json',
+      'osm-feature-bindings.v1.json',
+      'osm-extract://bounded/lower-manhattan/2026-04-26',
+    ],
+    fixture_digest: 'sha256:e5baba1a98e0e59887bf19fe840b0544904f23d05e5fb9989a9f53f86d1b360b',
+    runtime_refs: ['gaia-bounded-osm-ingest-runner@v1'],
+    created_at: '2026-04-27T06:10:00Z',
+    content_hash: 'sha256:ae4f4d078e81de81fd413ad2f243f250af99bc268580143801fa18875214c5d9',
+  },
+  classification: {
+    data_class: 'public',
+    handling_tags: ['demo', 'osm', 'bounded-extract', 'geospatial', 'advisory'],
+  },
+  response_receipt: demoReceipt('gaia-layer', 'advisory'),
+};
+
+const DEMO_GAIA_CATALOG: GaiaLayerCatalog = {
+  layers: [DEMO_GAIA_LAYER],
+  catalog_mode: 'fixture-backed',
+  production_tile_serving: false,
+  response_receipt: demoReceipt('gaia-layer-list', 'advisory'),
+};
+
+const DEMO_GAIA_TILE_MANIFEST: GaiaTileManifest = {
+  manifest_version: DEMO_GAIA_LAYER.manifest_version,
+  layer_id: DEMO_GAIA_LAYER.layer_id,
+  layer_type: DEMO_GAIA_LAYER.layer_type,
+  title: DEMO_GAIA_LAYER.title,
+  description: DEMO_GAIA_LAYER.description,
+  tile_serving_status: 'fixture-placeholder-not-production',
+  production_tile_serving: false,
+  tiles: DEMO_GAIA_LAYER.tiles,
+  spatial: DEMO_GAIA_LAYER.spatial,
+  attribution: DEMO_GAIA_LAYER.attribution,
+  provenance: DEMO_GAIA_LAYER.provenance,
+  classification: DEMO_GAIA_LAYER.classification,
+  response_receipt: demoReceipt('gaia-tile-manifest', 'advisory'),
+};
 
 const DEMO_LAYER: MapLayer = {
   manifest_version: 'v1',
@@ -258,8 +338,59 @@ export function demoGaiaMapSnapshot(): GaiaMapSnapshot {
   return cloneDemo(DEMO_SNAPSHOT);
 }
 
+export function demoGaiaLayerCatalog(): GaiaLayerCatalog {
+  return cloneDemo(DEMO_GAIA_CATALOG);
+}
+
+export function demoGaiaTileManifest(layerId = DEFAULT_GAIA_LAYER_ID): GaiaTileManifest {
+  const manifest = cloneDemo(DEMO_GAIA_TILE_MANIFEST);
+  manifest.layer_id = layerId;
+  return manifest;
+}
+
+export function isPlaceholderTileUrl(urlTemplate?: string | null): boolean {
+  if (!urlTemplate) return true;
+  return urlTemplate.startsWith('placeholder://') || urlTemplate.startsWith('demo://');
+}
+
 export async function fetchMapLayers(): Promise<MapLayerList> {
   return getJson<MapLayerList>('/map-layers');
+}
+
+export async function fetchGaiaLayers(): Promise<GaiaLayerCatalog> {
+  return getJson<GaiaLayerCatalog>('/gaia/layers');
+}
+
+export async function fetchGaiaLayerById(layerId: string): Promise<GaiaLayerEntry> {
+  return getJson<GaiaLayerEntry>(`/gaia/layers/${encodeURIComponent(layerId)}`);
+}
+
+export async function fetchGaiaTileManifest(layerId: string): Promise<GaiaTileManifest> {
+  return getJson<GaiaTileManifest>(`/gaia/tile-manifests/${encodeURIComponent(layerId)}`);
+}
+
+export async function fetchGaiaLayerCatalogWithFallback(): Promise<GaiaLayerCatalogLoadResult> {
+  try {
+    return { catalog: await fetchGaiaLayers(), mode: 'live' };
+  } catch (err) {
+    return {
+      catalog: demoGaiaLayerCatalog(),
+      mode: 'demo',
+      warning: `Using demo GAIA layer catalog because the catalog API is unavailable: ${errorMessage(err)}`,
+    };
+  }
+}
+
+export async function fetchGaiaTileManifestWithFallback(layerId: string): Promise<GaiaTileManifestLoadResult> {
+  try {
+    return { manifest: await fetchGaiaTileManifest(layerId), mode: 'live' };
+  } catch (err) {
+    return {
+      manifest: demoGaiaTileManifest(layerId),
+      mode: 'demo',
+      warning: `Using demo GAIA tile manifest because the catalog API did not return layer metadata: ${errorMessage(err)}`,
+    };
+  }
 }
 
 export async function fetchFeatureByOsm(

--- a/socioprophet-web/client-vue/src/pages/MapPage.vue
+++ b/socioprophet-web/client-vue/src/pages/MapPage.vue
@@ -2,16 +2,18 @@
   <section class="map-page">
     <header class="map-page-header">
       <div>
-        <p class="eyebrow">Maps &amp; Analytics · {{ dataModeLabel }}</p>
+        <p class="eyebrow">Maps &amp; Analytics · {{ dataModeLabel }} · {{ catalogModeLabel }}</p>
         <h1>OpenStreetMap × GAIA world model</h1>
         <p class="map-subtitle">
           Read-only map workbench for OSM identity, GAIA bindings, H3 lookup, advisory routing,
-          Sherlock evidence, provenance, and governance state.
+          Sherlock evidence, provenance, governance state, and fixture-backed layer catalog metadata.
         </p>
       </div>
       <div class="status-stack">
         <span :class="['tag', dataMode === 'live' ? 'tag-green' : 'tag-blue']">{{ dataModeLabel }}</span>
+        <span :class="['tag', catalogMode === 'live' ? 'tag-green' : 'tag-blue']">{{ catalogModeLabel }}</span>
         <span class="tag tag-blue">advisory routing</span>
+        <span class="tag tag-blue">non-production tiles</span>
         <span class="tag">last loaded · {{ lastLoadedAtLabel }}</span>
         <span class="tag">/map</span>
       </div>
@@ -20,6 +22,9 @@
     <div v-if="loading" class="state-card">Loading GAIA map state…</div>
     <div v-if="warning" class="state-card warning">
       {{ warning }} This mode is for product demonstration only and is not a production data plane.
+    </div>
+    <div v-if="catalogWarning" class="state-card warning" data-testid="gaia-layer-catalog-warning">
+      {{ catalogWarning }} Catalog mode remains advisory and fixture-backed.
     </div>
     <div v-if="error && !snapshot" class="state-card error">{{ error }}</div>
 
@@ -34,12 +39,14 @@
             <button class="secondary" type="button" @click="jumpToPanel('feature-panel')">Feature</button>
             <button class="secondary" type="button" @click="jumpToPanel('evidence-panel')">Evidence</button>
             <button class="secondary" type="button" @click="jumpToPanel('governance-panel')">Governance</button>
+            <button class="secondary" type="button" @click="jumpToPanel('layer-catalog-panel')">Layer catalog</button>
           </div>
           <p class="lookup-status">{{ refreshStatus || `Current data mode: ${dataModeLabel}` }}</p>
+          <p class="lookup-status">Layer catalog: {{ layerCatalogStatus || catalogModeLabel }}</p>
         </section>
 
         <section class="panel-section">
-          <div class="section-title">Layers</div>
+          <div class="section-title">Legacy map layers</div>
           <button
             v-for="layer in layers"
             :key="layer.layer_id"
@@ -50,6 +57,23 @@
             <div class="layer-title">{{ layer.title }}</div>
             <div class="layer-meta">{{ layer.layer_type }} · {{ layer.tiles?.format || 'metadata' }}</div>
             <div class="layer-attribution">{{ layer.attribution?.attribution_text }}</div>
+          </button>
+        </section>
+
+        <section id="layer-catalog-panel" class="panel-section" data-testid="gaia-layer-catalog-panel">
+          <div class="section-title">GAIA layer catalog</div>
+          <p class="lookup-status">{{ catalogModeLabel }} · production_tile_serving={{ catalogProductionTileServing }}</p>
+          <button
+            v-for="layer in gaiaCatalogLayers"
+            :key="layer.layer_id"
+            :class="['layer-card', { selected: selectedGaiaLayerId === layer.layer_id }]"
+            type="button"
+            data-testid="gaia-layer-button"
+            @click="selectGaiaLayer(layer.layer_id)"
+          >
+            <div class="layer-title">{{ layer.title }}</div>
+            <div class="layer-meta">{{ layer.layer_id }}</div>
+            <div class="layer-attribution">{{ layer.attribution?.attribution_text || 'Attribution required' }}</div>
           </button>
         </section>
 
@@ -75,12 +99,13 @@
       <main class="map-stage">
         <div ref="mapContainer" class="map-canvas" aria-label="GAIA map canvas"></div>
         <div class="map-overlay top-left">
-          <strong>{{ selectedLayer?.title || 'GAIA OSM Demo Road Layer' }}</strong>
+          <strong>{{ selectedGaiaLayer?.title || selectedLayer?.title || 'GAIA OSM Demo Road Layer' }}</strong>
           <span>{{ selectedFeature?.gaia_ref?.entity_type || 'GAIA feature' }}</span>
         </div>
         <div class="map-overlay bottom-left">
           <span>OSM {{ selectedFeature?.osm_ref?.osm_type }}/{{ selectedFeature?.osm_ref?.osm_id }}</span>
           <span>{{ selectedFeature?.routing?.safety_status || routeSafetyStatus }}</span>
+          <span>{{ placeholderTileNotice }}</span>
         </div>
       </main>
 
@@ -101,6 +126,25 @@
           </div>
         </section>
 
+        <section id="gaia-tile-manifest-panel" class="panel-section" data-testid="gaia-tile-manifest-panel">
+          <div class="section-title">Tile manifest metadata</div>
+          <h2>{{ selectedTileManifest?.title || selectedGaiaLayer?.title || 'No GAIA layer selected' }}</h2>
+          <div class="detail-grid">
+            <span>Layer</span><strong>{{ selectedTileManifest?.layer_id || selectedGaiaLayer?.layer_id || '—' }}</strong>
+            <span>Status</span><strong>{{ selectedTileManifest?.tile_serving_status || 'metadata-only' }}</strong>
+            <span>Production tiles</span><strong>{{ selectedTileManifest?.production_tile_serving === true ? 'true' : 'false' }}</strong>
+            <span>Tile URL</span><strong>{{ selectedTileManifest?.tiles?.url_template || '—' }}</strong>
+            <span>Placeholder guard</span><strong data-testid="placeholder-tile-guard">{{ placeholderTileNotice }}</strong>
+            <span>Fixture digest</span><strong>{{ selectedTileManifest?.provenance?.fixture_digest || selectedGaiaLayer?.provenance?.fixture_digest || '—' }}</strong>
+          </div>
+          <p class="lookup-status">
+            Placeholder tile URLs are displayed as governed metadata only and are never added as production MapLibre tile sources.
+          </p>
+          <div class="tag-row">
+            <span v-for="cell in selectedCatalogH3Cells" :key="cell" class="tag">{{ cell }}</span>
+          </div>
+        </section>
+
         <section id="evidence-panel" class="panel-section">
           <div class="section-title">Evidence</div>
           <h2>{{ sherlockResult?.title || 'Sherlock evidence' }}</h2>
@@ -114,12 +158,15 @@
           <div class="section-title">Governance</div>
           <div class="detail-grid">
             <span>Attribution</span><strong>{{ governance?.attribution_required ? 'required' : 'not required' }}</strong>
+            <span>Layer attribution</span><strong>{{ selectedGaiaLayer?.attribution?.attribution_text || '—' }}</strong>
+            <span>Layer source refs</span><strong>{{ selectedLayerSourceRefs.length }}</strong>
             <span>Lanes</span><strong>{{ governance?.validation_lanes?.length || 0 }}</strong>
             <span>Receipt</span><strong>{{ selectedReceipt?.integrity?.digest ? 'digest' : 'unsigned' }}</strong>
-            <span>Mode</span><strong>{{ dataModeLabel }}</strong>
+            <span>Mode</span><strong>{{ dataModeLabel }} · {{ catalogModeLabel }}</strong>
           </div>
           <ul class="evidence-list">
             <li v-for="lane in governance?.validation_lanes || []" :key="lane.id">{{ lane.id }} · {{ lane.state || 'unknown' }}</li>
+            <li v-for="ref in selectedLayerSourceRefs" :key="ref">{{ ref }}</li>
           </ul>
         </section>
       </aside>
@@ -133,40 +180,64 @@ import maplibregl from 'maplibre-gl';
 import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue';
 import {
   fetchFeaturesByH3WithFallback,
+  fetchGaiaLayerCatalogWithFallback,
   fetchGaiaMapSnapshotWithFallback,
+  fetchGaiaTileManifestWithFallback,
+  isPlaceholderTileUrl,
   type GaiaMapDataMode,
 } from '../api/gaiaMap';
-import type { GaiaMapSnapshot, H3FeatureLayerSearch, MapLayer, ResponseReceipt } from '../types/gaiaMap';
+import type {
+  GaiaLayerCatalog,
+  GaiaLayerEntry,
+  GaiaMapSnapshot,
+  GaiaTileManifest,
+  H3FeatureLayerSearch,
+  MapLayer,
+  ResponseReceipt,
+} from '../types/gaiaMap';
 
 const loading = ref(true);
 const refreshing = ref(false);
 const h3Loading = ref(false);
+const tileManifestLoading = ref(false);
 const error = ref<string | null>(null);
 const warning = ref<string | null>(null);
+const catalogWarning = ref<string | null>(null);
 const refreshStatus = ref<string | null>(null);
+const layerCatalogStatus = ref<string | null>(null);
 const lookupStatus = ref<string | null>(null);
 const lastLoadedAt = ref<Date | null>(null);
 const dataMode = ref<GaiaMapDataMode>('live');
+const catalogMode = ref<GaiaMapDataMode>('live');
 const snapshot = ref<GaiaMapSnapshot | null>(null);
 const h3Result = ref<H3FeatureLayerSearch | null>(null);
+const gaiaCatalog = ref<GaiaLayerCatalog | null>(null);
+const selectedTileManifest = ref<GaiaTileManifest | null>(null);
 const selectedLayerId = ref<string | null>(null);
+const selectedGaiaLayerId = ref<string | null>(null);
 const h3Cell = ref('8928308280fffff');
 const mapContainer = ref<HTMLElement | null>(null);
 let map: maplibregl.Map | null = null;
 let marker: maplibregl.Marker | null = null;
 
 const dataModeLabel = computed(() => (dataMode.value === 'live' ? 'live API' : 'demo fallback'));
+const catalogModeLabel = computed(() => (catalogMode.value === 'live' ? 'live catalog' : 'demo catalog'));
 const lastLoadedAtLabel = computed(() => lastLoadedAt.value?.toLocaleString() || 'not loaded');
 const layers = computed(() => snapshot.value?.layers.layers || []);
 const selectedLayer = computed<MapLayer | undefined>(() => layers.value.find((layer) => layer.layer_id === selectedLayerId.value) || layers.value[0]);
+const gaiaCatalogLayers = computed<GaiaLayerEntry[]>(() => gaiaCatalog.value?.layers || []);
+const selectedGaiaLayer = computed<GaiaLayerEntry | undefined>(() => gaiaCatalogLayers.value.find((layer) => layer.layer_id === selectedGaiaLayerId.value) || gaiaCatalogLayers.value[0]);
 const selectedFeature = computed(() => h3Result.value?.features?.[0] || snapshot.value?.feature || null);
 const governance = computed(() => snapshot.value?.governance || null);
 const sherlockResult = computed(() => snapshot.value?.search || null);
 const runtimes = computed(() => snapshot.value?.runtimeBoundaries.runtimes || []);
 const routeSafetyStatus = computed(() => snapshot.value?.routes.default_safety_status || 'advisory');
-const selectedReceipt = computed<ResponseReceipt | undefined>(() => selectedFeature.value?.response_receipt || selectedLayer.value?.response_receipt);
+const selectedReceipt = computed<ResponseReceipt | undefined>(() => selectedFeature.value?.response_receipt || selectedGaiaLayer.value?.response_receipt || selectedLayer.value?.response_receipt);
 const featureH3Cells = computed(() => selectedFeature.value?.spatial?.h3_cells || []);
-const evidenceRefs = computed(() => sherlockResult.value?.evidence_refs || selectedFeature.value?.provenance?.source_refs || []);
+const selectedCatalogH3Cells = computed(() => selectedTileManifest.value?.spatial?.h3_cells || selectedGaiaLayer.value?.spatial?.h3_cells || []);
+const selectedLayerSourceRefs = computed(() => selectedTileManifest.value?.provenance?.source_refs || selectedGaiaLayer.value?.provenance?.source_refs || []);
+const catalogProductionTileServing = computed(() => gaiaCatalog.value?.production_tile_serving === true ? 'true' : 'false');
+const placeholderTileNotice = computed(() => (isPlaceholderTileUrl(selectedTileManifest.value?.tiles?.url_template || selectedGaiaLayer.value?.tiles?.url_template) ? 'placeholder tile metadata only' : 'non-placeholder tile metadata'));
 
 function featureCenter(): [number, number] {
   const bbox = selectedFeature.value?.spatial?.bbox;
@@ -214,6 +285,44 @@ function jumpToPanel(panelId: string) {
   document.getElementById(panelId)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
+async function loadTileManifest(layerId: string | null, reason: 'initial' | 'manual' = 'initial') {
+  if (!layerId) {
+    selectedTileManifest.value = null;
+    return;
+  }
+  tileManifestLoading.value = true;
+  layerCatalogStatus.value = reason === 'manual' ? 'Fetching tile manifest metadata…' : layerCatalogStatus.value;
+  const result = await fetchGaiaTileManifestWithFallback(layerId);
+  selectedTileManifest.value = result.manifest;
+  if (result.mode === 'demo') {
+    catalogMode.value = 'demo';
+  }
+  if (result.warning) {
+    catalogWarning.value = result.warning;
+  }
+  layerCatalogStatus.value = isPlaceholderTileUrl(result.manifest.tiles?.url_template)
+    ? 'Tile manifest loaded as placeholder metadata only; no production tile request was made.'
+    : 'Tile manifest metadata loaded; review before enabling any production tile source.';
+  tileManifestLoading.value = false;
+}
+
+async function loadLayerCatalog() {
+  const result = await fetchGaiaLayerCatalogWithFallback();
+  gaiaCatalog.value = result.catalog;
+  catalogMode.value = result.mode;
+  catalogWarning.value = result.warning || null;
+  selectedGaiaLayerId.value = result.catalog.layers[0]?.layer_id || null;
+  layerCatalogStatus.value = result.mode === 'live'
+    ? 'Layer catalog loaded from live GAIA API.'
+    : 'Layer catalog loaded from deterministic demo fallback.';
+  await loadTileManifest(selectedGaiaLayerId.value, 'initial');
+}
+
+async function selectGaiaLayer(layerId: string) {
+  selectedGaiaLayerId.value = layerId;
+  await loadTileManifest(layerId, 'manual');
+}
+
 async function loadSnapshot(reason: 'initial' | 'manual' = 'initial') {
   const initialLoad = snapshot.value === null;
   loading.value = initialLoad;
@@ -224,7 +333,10 @@ async function loadSnapshot(reason: 'initial' | 'manual' = 'initial') {
   }
 
   try {
-    const result = await fetchGaiaMapSnapshotWithFallback();
+    const [result] = await Promise.all([
+      fetchGaiaMapSnapshotWithFallback(),
+      loadLayerCatalog(),
+    ]);
     snapshot.value = result.snapshot;
     h3Result.value = result.snapshot.h3;
     dataMode.value = result.mode;

--- a/socioprophet-web/client-vue/src/pages/MapPage.vue
+++ b/socioprophet-web/client-vue/src/pages/MapPage.vue
@@ -234,6 +234,7 @@ const runtimes = computed(() => snapshot.value?.runtimeBoundaries.runtimes || []
 const routeSafetyStatus = computed(() => snapshot.value?.routes.default_safety_status || 'advisory');
 const selectedReceipt = computed<ResponseReceipt | undefined>(() => selectedFeature.value?.response_receipt || selectedGaiaLayer.value?.response_receipt || selectedLayer.value?.response_receipt);
 const featureH3Cells = computed(() => selectedFeature.value?.spatial?.h3_cells || []);
+const evidenceRefs = computed(() => sherlockResult.value?.evidence_refs || selectedFeature.value?.provenance?.source_refs || []);
 const selectedCatalogH3Cells = computed(() => selectedTileManifest.value?.spatial?.h3_cells || selectedGaiaLayer.value?.spatial?.h3_cells || []);
 const selectedLayerSourceRefs = computed(() => selectedTileManifest.value?.provenance?.source_refs || selectedGaiaLayer.value?.provenance?.source_refs || []);
 const catalogProductionTileServing = computed(() => gaiaCatalog.value?.production_tile_serving === true ? 'true' : 'false');

--- a/socioprophet-web/client-vue/src/types/gaiaMap.ts
+++ b/socioprophet-web/client-vue/src/types/gaiaMap.ts
@@ -50,6 +50,95 @@ export type MapLayerList = {
   response_receipt: ResponseReceipt;
 };
 
+export type GaiaLayerEntry = {
+  manifest_version: string;
+  layer_id: string;
+  layer_type: string;
+  title: string;
+  description?: string;
+  sources?: Array<{
+    source_id?: string;
+    source_type?: string;
+    source_refs?: string[];
+    [key: string]: unknown;
+  }>;
+  tiles?: {
+    url_template: string;
+    min_zoom?: number;
+    max_zoom?: number;
+    format?: string;
+  };
+  spatial?: {
+    bbox?: number[];
+    h3_cells?: string[];
+    crs?: string;
+  };
+  attribution?: {
+    attribution_text?: string;
+    license_ref?: string;
+    license_refs?: string[];
+    source_url?: string;
+    source_urls?: string[];
+  };
+  provenance?: {
+    source_refs?: string[];
+    fixture_digest?: string;
+    runtime_refs?: string[];
+    created_at?: string;
+    content_hash?: string;
+  };
+  classification?: {
+    data_class?: string;
+    handling_tags?: string[];
+    [key: string]: unknown;
+  };
+  response_receipt?: ResponseReceipt;
+};
+
+export type GaiaLayerCatalog = {
+  layers: GaiaLayerEntry[];
+  catalog_mode?: string;
+  production_tile_serving?: boolean;
+  response_receipt?: ResponseReceipt;
+};
+
+export type GaiaTileManifest = {
+  manifest_version?: string;
+  layer_id: string;
+  layer_type?: string;
+  title?: string;
+  description?: string;
+  tile_serving_status?: string;
+  production_tile_serving?: boolean;
+  tiles?: {
+    url_template: string;
+    min_zoom?: number;
+    max_zoom?: number;
+    format?: string;
+  };
+  spatial?: {
+    bbox?: number[];
+    h3_cells?: string[];
+    crs?: string;
+  };
+  attribution?: GaiaLayerEntry['attribution'];
+  provenance?: GaiaLayerEntry['provenance'];
+  classification?: GaiaLayerEntry['classification'];
+  response_receipt?: ResponseReceipt;
+};
+
+export type GaiaLayerCatalogLoadResult = {
+  catalog: GaiaLayerCatalog;
+  mode: 'live' | 'demo';
+  warning?: string;
+};
+
+export type GaiaTileManifestLoadResult = {
+  manifest: GaiaTileManifest;
+  mode: 'live' | 'demo';
+  warning?: string;
+};
+
 export type OsmFeatureBinding = {
   binding_version: string;
   binding_id: string;


### PR DESCRIPTION
## Summary

Materializes issue #305 because Copilot WIP PR #306 remained an empty placeholder.

Adds a bounded Vue `/map` integration with the new Prophet Platform GAIA layer catalog/tile-manifest API from `prophet-platform#311`:

- adds GAIA layer catalog and tile-manifest types;
- adds `fetchGaiaLayers`, `fetchGaiaLayerById`, `fetchGaiaTileManifest`, fallback helpers, and `isPlaceholderTileUrl`;
- adds a `/map` GAIA layer catalog panel showing layer id/title, attribution, bbox/H3 metadata, source receipt refs, fixture digest, and non-production tile state;
- adds a tile-manifest metadata panel that explicitly shows `production_tile_serving=false` and guards placeholder tile URLs;
- preserves existing map fallback/live behavior and does not load `placeholder://` tile URLs as MapLibre sources;
- extends smoke tests for live/fallback catalog mode, layer selection, placeholder tile safety, and attribution/provenance rendering.

## Guardrails

- No production tile serving.
- No placeholder tile fetches.
- No live OSM ingestion.
- No `/feed` changes.
- No cross-repo edits.
- No claim of GAIA World Model v1 completion.

## Validation expected

```bash
cd socioprophet-web/client-vue
npm run typecheck
npm test
npm run build
```

## Known gaps

- This is catalog/tile-manifest UI integration only. It does not add production tiles or live ingestion.

Closes #305.