### PR TITLE
Validate GRLPlus exports in CI with positive and adversarial fixtures

### DIFF
--- a/.github/workflows/validate-grlplus-export-snapshots.yml
+++ b/.github/workflows/validate-grlplus-export-snapshots.yml
@@ -1,0 +1,38 @@
+name: Validate GRLPlus export snapshots
+
+on:
+  pull_request:
+    paths:
+      - 'standards/grlplus/**'
+      - 'scripts/export_grlplus_worklist.py'
+      - 'scripts/export_grlplus_worklist_report.py'
+      - 'scripts/validate_grlplus_exports.py'
+      - 'scripts/validate_grlplus_export_snapshots.py'
+      - 'ci/validate_grlplus_*.sh'
+      - '.github/workflows/validate-grlplus-export-snapshots.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'standards/grlplus/**'
+      - 'scripts/export_grlplus_worklist.py'
+      - 'scripts/export_grlplus_worklist_report.py'
+      - 'scripts/validate_grlplus_exports.py'
+      - 'scripts/validate_grlplus_export_snapshots.py'
+      - 'ci/validate_grlplus_*.sh'
+      - '.github/workflows/validate-grlplus-export-snapshots.yml'
+
+jobs:
+  validate-grlplus-export-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate GRLPlus export snapshots
+        run: bash ci/validate_grlplus_export_snapshots.sh

--- a/.github/workflows/validate-grlplus-exports.yml
+++ b/.github/workflows/validate-grlplus-exports.yml
@@ -1,0 +1,36 @@
+name: Validate GRLPlus exports
+
+on:
+  pull_request:
+    paths:
+      - 'standards/grlplus/**'
+      - 'scripts/export_grlplus_worklist.py'
+      - 'scripts/export_grlplus_worklist_report.py'
+      - 'scripts/validate_grlplus_exports.py'
+      - 'ci/validate_grlplus_*.sh'
+      - '.github/workflows/validate-grlplus-exports.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - 'standards/grlplus/**'
+      - 'scripts/export_grlplus_worklist.py'
+      - 'scripts/export_grlplus_worklist_report.py'
+      - 'scripts/validate_grlplus_exports.py'
+      - 'ci/validate_grlplus_*.sh'
+      - '.github/workflows/validate-grlplus-exports.yml'
+
+jobs:
+  validate-grlplus-exports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate all GRLPlus export paths
+        run: bash ci/validate_grlplus_all.sh

--- a/ci/validate_grlplus_all.sh
+++ b/ci/validate_grlplus_all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bash ci/validate_grlplus_exports.sh
+bash ci/validate_grlplus_worklist_report.sh
+bash ci/validate_grlplus_generated_worklist_report.sh
+bash ci/validate_grlplus_generated_valid_worklist_report.sh
+
+printf '[grlplus-all-ci] OK\n'

--- a/ci/validate_grlplus_export_snapshots.sh
+++ b/ci/validate_grlplus_export_snapshots.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install "jsonschema>=4,<5"
+python3 scripts/validate_grlplus_export_snapshots.py
+
+printf '[grlplus-export-snapshot-ci] OK\n'

--- a/ci/validate_grlplus_generated_valid_worklist_report.sh
+++ b/ci/validate_grlplus_generated_valid_worklist_report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install "jsonschema>=4,<5"
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json \
+  --platform github_issues \
+  --output /tmp/grlplus-generated-valid-github-issues.json
+
+python3 scripts/validate_grlplus_exports.py \
+  github_issues \
+  /tmp/grlplus-generated-valid-github-issues.json
+
+python3 scripts/export_grlplus_worklist_report.py \
+  --input standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json \
+  --platform ops_queue \
+  --output /tmp/grlplus-generated-valid-ops-queue.json
+
+python3 scripts/validate_grlplus_exports.py \
+  ops_queue \
+  /tmp/grlplus-generated-valid-ops-queue.json
+
+printf '[grlplus-generated-valid-worklist-report-ci] OK\n'

--- a/scripts/validate_grlplus_export_snapshots.py
+++ b/scripts/validate_grlplus_export_snapshots.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate stable GRLPlus export output invariants against snapshot expectations.
+
+This intentionally checks stable, reviewable invariants rather than comparing entire
+JSON files byte-for-byte. Full output can include ordering/formatting details that
+are less important than the platform contract, repo binding, item counts, and first
+item identity/intervention posture.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTATIONS = ROOT / "standards/grlplus/examples/export_snapshot_expectations.json"
+FIXTURES = {
+    "generated_semantic_contradictory": ROOT / "standards/grlplus/examples/semantic_worklist_report.generated_semantic_contradictory.json",
+    "generated_semantic_valid": ROOT / "standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json",
+}
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(f"[grlplus-export-snapshots] ERROR: {msg}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        die(f"failed to parse JSON {path}: {e}")
+    if not isinstance(data, dict):
+        die(f"{path} must parse to a JSON object")
+    return data
+
+
+def run_export(fixture: Path, platform: str, output: Path) -> Dict[str, Any]:
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts/export_grlplus_worklist_report.py"),
+        "--input",
+        str(fixture),
+        "--platform",
+        platform,
+        "--output",
+        str(output),
+    ]
+    subprocess.run(cmd, check=True)
+    return load_json(output)
+
+
+def assert_eq(label: str, actual: Any, expected: Any) -> None:
+    if actual != expected:
+        die(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def validate_github(name: str, payload: Dict[str, Any], expected: Dict[str, Any]) -> None:
+    assert_eq(f"{name}.github.repo_full_name", payload.get("repo_full_name"), expected.get("repo_full_name"))
+    items = payload.get("items")
+    if not isinstance(items, list):
+        die(f"{name}.github.items must be a list")
+    assert_eq(f"{name}.github.item_count", len(items), expected.get("items"))
+    if items:
+        first = items[0]
+        for field, value in (expected.get("first_item") or {}).items():
+            assert_eq(f"{name}.github.first_item.{field}", first.get(field), value)
+
+
+def validate_queue(name: str, payload: Dict[str, Any], expected: Dict[str, Any]) -> None:
+    items = payload.get("items")
+    if not isinstance(items, list):
+        die(f"{name}.ops_queue.items must be a list")
+    assert_eq(f"{name}.ops_queue.item_count", len(items), expected.get("items"))
+    if items:
+        first = items[0]
+        for field, value in (expected.get("first_item") or {}).items():
+            assert_eq(f"{name}.ops_queue.first_item.{field}", first.get(field), value)
+
+
+def main() -> int:
+    expectations = load_json(EXPECTATIONS).get("expectations")
+    if not isinstance(expectations, dict):
+        die("expectations file must contain an expectations object")
+
+    with tempfile.TemporaryDirectory(prefix="grlplus-export-snapshots-") as td:
+        tmp = Path(td)
+        for name, fixture in FIXTURES.items():
+            if name not in expectations:
+                die(f"missing expectation block for {name}")
+            if not fixture.exists():
+                die(f"missing fixture for {name}: {fixture}")
+            expected = expectations[name]
+            github_payload = run_export(fixture, "github_issues", tmp / f"{name}.github.json")
+            queue_payload = run_export(fixture, "ops_queue", tmp / f"{name}.queue.json")
+            validate_github(name, github_payload, expected["github_issues"])
+            validate_queue(name, queue_payload, expected["ops_queue"])
+
+    print("[grlplus-export-snapshots] OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/standards/grlplus/examples/export_snapshot_expectations.json
+++ b/standards/grlplus/examples/export_snapshot_expectations.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "grlplus-export-snapshot-expectations/0.1",
+  "expectations": {
+    "generated_semantic_contradictory": {
+      "profile": "strategy",
+      "github_issues": {
+        "repo_full_name": "SocioProphet/socioprophet",
+        "items": 5,
+        "first_item": {
+          "title": "[gather_evidence] goal.outcome",
+          "element_id": "goal.outcome",
+          "intervention_category": "gather_evidence",
+          "severity": "medium"
+        }
+      },
+      "ops_queue": {
+        "items": 5,
+        "first_item": {
+          "element_id": "goal.outcome",
+          "intervention": "gather_evidence",
+          "severity": "medium"
+        }
+      }
+    },
+    "generated_semantic_valid": {
+      "profile": "strategy",
+      "github_issues": {
+        "repo_full_name": "SocioProphet/socioprophet",
+        "items": 3,
+        "first_item": {
+          "title": "[add_direct_argument_coverage] goal.launch_viability",
+          "element_id": "goal.launch_viability",
+          "intervention_category": "add_direct_argument_coverage",
+          "severity": "medium"
+        }
+      },
+      "ops_queue": {
+        "items": 3,
+        "first_item": {
+          "element_id": "goal.launch_viability",
+          "intervention": "add_direct_argument_coverage",
+          "severity": "medium"
+        }
+      }
+    }
+  }
+}

--- a/standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json
+++ b/standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json
@@ -1,0 +1,92 @@
+{
+  "active_domain_profile": "strategy",
+  "min_criticality": 0.8,
+  "items": [
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "goal.launch_viability",
+      "criticality": 1.0,
+      "intervention_category": "add_direct_argument_coverage",
+      "reason_codes": [
+        "RC_DIRECT_ARGUMENT_COVERAGE_MISSING",
+        "RC_WIDE_INTERVAL"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": null,
+      "scalar_signal": 0.3,
+      "interval_low": 0.0,
+      "interval_high": 0.6,
+      "interval_width": 0.6,
+      "suggested_evidence_ask": "Attach direct strategy arguments and evidence links covering goal.launch_viability so propagated support is trace-backed.",
+      "task_payload": {
+        "title": "[add_direct_argument_coverage] goal.launch_viability",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_DIRECT_ARGUMENT_COVERAGE_MISSING",
+          "RC_WIDE_INTERVAL"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: add trace-linked arguments and evidence directly covering goal.launch_viability, then rerun GRLPlus validation to reduce interval width below warning threshold."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "goal.readiness",
+      "criticality": 0.9,
+      "intervention_category": "add_direct_argument_coverage",
+      "reason_codes": [
+        "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": null,
+      "scalar_signal": 1.0,
+      "interval_low": 1.0,
+      "interval_high": 1.0,
+      "interval_width": 0.0,
+      "suggested_evidence_ask": "Attach direct readiness evidence and rationale covering goal.readiness.",
+      "task_payload": {
+        "title": "[add_direct_argument_coverage] goal.readiness",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: add direct trace-linked arguments for goal.readiness so high propagated support is governance-backed."
+      }
+    },
+    {
+      "owner_actor_id": "actor.strategy",
+      "element_id": "goal.optional_reach",
+      "criticality": 0.85,
+      "intervention_category": "add_direct_argument_coverage",
+      "reason_codes": [
+        "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+      ],
+      "dependency_targets": [],
+      "cross_actor_dependency_count": 0,
+      "confidence": null,
+      "scalar_signal": 1.0,
+      "interval_low": 1.0,
+      "interval_high": 1.0,
+      "interval_width": 0.0,
+      "suggested_evidence_ask": "Attach optional-reach evidence and rationale covering goal.optional_reach.",
+      "task_payload": {
+        "title": "[add_direct_argument_coverage] goal.optional_reach",
+        "owner": "actor.strategy",
+        "reason_codes": [
+          "RC_DIRECT_ARGUMENT_COVERAGE_MISSING"
+        ],
+        "dependencies": [],
+        "next_action": "Owner actor.strategy: add direct trace-linked arguments for goal.optional_reach to align argument coverage with propagated support."
+      }
+    }
+  ],
+  "summary": {
+    "items": 3,
+    "owners": [
+      "actor.strategy"
+    ]
+  }
+}


### PR DESCRIPTION
This follow-up completes the first integration-hardening gap after #284.

Included:
- Adds `standards/grlplus/examples/semantic_worklist_report.generated_semantic_valid.json` as a positive generated fixture.
- Adds `ci/validate_grlplus_generated_valid_worklist_report.sh` to validate the positive fixture through both GitHub issue and ops queue export paths.
- Adds `ci/validate_grlplus_all.sh` to run all GRLPlus export validation helpers.
- Adds `.github/workflows/validate-grlplus-exports.yml` so GRLPlus export validation runs on relevant PRs and pushes to master.

This gives us both adversarial and positive generated report coverage:
- generic input fixture
- report-shape example fixture
- generated contradictory fixture
- generated positive fixture

The workflow runs the aggregate helper so the same command can be used locally and in CI:

```bash
bash ci/validate_grlplus_all.sh
```
