### PR TITLE
docs: bind architecture docs to cross-lane artifact canon

### DIFF
--- a/docs/guide/agent-plane-and-operator-workflows.md
+++ b/docs/guide/agent-plane-and-operator-workflows.md
@@ -4,6 +4,12 @@ This page is the public manual entry point for the operator workflow layer insid
 
 The Agent Plane explains how work moves from intent to bounded capability, from bounded capability to controlled execution, and from controlled execution to evidence, review, promotion, or reversal.
 
+The Agent Plane also participates in the platform-wide artifact canon: runtime evidence, replay records, promotion/reversal records, capability receipts, knowledge claims, and Entity Analytics proof artifacts are mapped through one shared cross-lane evidence vocabulary.
+
+Primary cross-lane reference:
+
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
+
 ## 1. Purpose
 
 The Agent Plane exists so institutions and operators can understand:
@@ -93,6 +99,7 @@ Relevant references:
 - [Governed AI and Cybernetics](/guide/governed-ai-and-cybernetics)
 - [Deterministic AI and Mathematical Safety](/guide/deterministic-ai-and-mathematical-safety)
 - [Provenance, Promotion, and Reversibility](/guide/provenance-promotion-and-reversibility)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ## 7. Relationship to Entity Analytics
 
@@ -112,6 +119,7 @@ Relevant references:
 - [Entity Analytics Reference](/guide/entity-analytics-reference)
 - [Identity Prime and Event-IR](/guide/identity-prime-and-event-ir)
 - [Worked Example: Michael Cross-Context](/guide/worked-example-michael-cross-context)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ## 8. Relationship to organizations
 

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -17,6 +17,11 @@ The platform is organized around a few core claims:
 
 This is not a chat-first architecture. It is a controlled systems architecture.
 
+Across all layers, the platform uses a shared cross-lane artifact canon that connects runtime artifacts, knowledge artifacts, Entity Analytics proof artifacts, Capability Fabric receipts, and public-safe product evidence into one governed evidence model.
+
+Primary reference:
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
+
 ## 2. Primary layers
 
 ### Organizations and institutional deployment
@@ -36,6 +41,7 @@ Key references:
 - [Governed AI and Cybernetics](/guide/governed-ai-and-cybernetics)
 - [Deterministic AI and Mathematical Safety](/guide/deterministic-ai-and-mathematical-safety)
 - [Provenance, Promotion, and Reversibility](/guide/provenance-promotion-and-reversibility)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ### Agent plane and operator workflows
 
@@ -47,6 +53,7 @@ Key references:
 - [Provider Capability Routing](/guide/provider-capability-routing)
 - [Provider Safety and Capability Eligibility](/guide/provider-safety-and-capability-eligibility)
 - [Auth Recovery and Connection Health](/guide/auth-recovery-and-connection-health)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ### Entity Analytics
 
@@ -60,6 +67,7 @@ Key references:
 - [Entity Graph and Safe Linkage](/guide/entity-graph-and-safe-linkage)
 - [Policy-Constrained Merging and Unmerge](/guide/policy-constrained-merging-and-unmerge)
 - [Marketer-Safe Outputs and Segment Proofs](/guide/marketer-safe-outputs-and-segment-proofs)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ### Authorized cyberdefense and simulation
 
@@ -125,6 +133,7 @@ Primary references:
 - [Deterministic AI and Mathematical Safety](/guide/deterministic-ai-and-mathematical-safety)
 - [Governed AI and Cybernetics](/guide/governed-ai-and-cybernetics)
 - [Provenance, Promotion, and Reversibility](/guide/provenance-promotion-and-reversibility)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ## 7. Public-safe versus restricted material
 
@@ -149,18 +158,21 @@ Primary reference:
 - [Organizations Governance and Institutional Safety](/guide/organizations-governance-and-institutional-safety)
 - [Deterministic AI and Mathematical Safety](/guide/deterministic-ai-and-mathematical-safety)
 - [Authorized Cyberdefense and Simulation](/guide/authorized-cyberdefense-and-simulation)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ### Operator and security path
 - [Governed AI and Cybernetics](/guide/governed-ai-and-cybernetics)
 - [Agent Plane and Operator Workflows](/guide/agent-plane-and-operator-workflows)
 - [Boundary-Centric Cyber Hypergraph](/guide/boundary-centric-cyber-hypergraph)
 - [Entity Analytics Reference](/guide/entity-analytics-reference)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ### Builder and researcher path
 - [Semantic Vector Stack](/guide/semantic-vector-stack)
 - [Hybrid Representation Builder](/guide/hybrid-representation-builder)
 - [Operating Modes: Learning and Defense](/guide/operating-modes-learning-and-defense)
 - [23-Topic Canon](/guide/twenty-three-topic-canon)
+- [Cross-Lane Artifact Canon](/guide/cross-lane-artifact-canon)
 
 ## 9. Use this page
 

--- a/docs/guide/cross-lane-artifact-canon.md
+++ b/docs/guide/cross-lane-artifact-canon.md
@@ -1,0 +1,145 @@
+# Cross-Lane Artifact Canon
+
+This page is the public architecture entry point for the shared artifact vocabulary across SocioProphet.
+
+The normative semantic standard lives in `SocioProphet/socioprophet-standards-knowledge`:
+
+- `045-cross-lane-artifact-canon.md`
+- `046-field-alias-matrix.md`
+
+This guide is the readable map for operators, reviewers, builders, and institutional readers.
+
+## 1. Purpose
+
+SocioProphet already has multiple evidence-producing lanes:
+
+- runtime execution artifacts;
+- knowledge artifacts;
+- Entity Analytics and legal-entity proof artifacts;
+- capability receipts and proof-strength semantics;
+- product and UI evidence surfaces.
+
+The goal of the canon is not to force those lanes into one serialization surface. The goal is to make them interoperable, replayable, reversible, and explainable as one governed system.
+
+## 2. The lanes
+
+### Runtime execution
+
+AgentPlane emits proof-bearing lifecycle artifacts such as validation, placement, run, replay, session, promotion, and reversal artifacts. It also carries domain-specific evidence objects such as Agent Machine mount evidence, Office artifact evidence, Network Door planning evidence, external model-provider route evidence, and Native Assistant bridge evidence.
+
+### Knowledge Context
+
+Knowledge Context standardizes notes, claims, annotations, relations, and provenance.
+
+### Entity Analytics and legal-entity proof
+
+Entity Analytics uses typed events, scopes, governed links, merge controls, proof artifacts, safe export, and reversibility. The legal-entity lane specializes the same pattern for source records, identifiers, statements, designation events, evidence objects, rights constraints, and freshness posture.
+
+### Capability Fabric
+
+Capability Fabric defines protocol-independent capability semantics, realization metadata, receipt semantics, controllability, and proof strength. It is the authority for how proof claims must degrade honestly when execution becomes weakly controlled or externalized.
+
+### Product and UI evidence surfaces
+
+Some user-facing surfaces also carry evidence semantics, such as source receipt refs, fixture digests, provenance, readiness state, freshness state, attribution, and placeholder/non-production markers.
+
+## 3. Shared semantic primitives
+
+The cross-lane canon uses the following shared nouns:
+
+- `Event`
+- `Claim`
+- `Entity`
+- `Relationship`
+- `DecisionArtifact`
+- `ProofPack`
+- `TemporalProfile`
+- `TrustProfile`
+
+## 4. Mandatory bridge refs
+
+The common bridge layer reuses:
+
+- `ActorRef`
+- `ArtifactRef`
+- `ProvenanceRef`
+- `ProvenanceRecord`
+
+New cross-lane work should reuse these bridge primitives unless there is a documented reason not to.
+
+## 5. Non-breaking field policy
+
+The canon is semantic first, not rename first.
+
+Released fields may remain named as they are today, for example:
+
+- `capturedAt`
+- `created_at`
+- `occurred_at`
+- `asserted_at`
+- `validated_at`
+- `effective_from`
+- `observed_at`
+
+The canon defines what those names mean and how they map. Field-name convergence can happen later through normal versioning.
+
+## 6. DecisionArtifact
+
+A `DecisionArtifact` is any proof-bearing artifact that records a consequential decision or lifecycle transition.
+
+Examples include:
+
+- validation
+- placement
+- run outcome
+- replay package
+- session lifecycle
+- promotion
+- reversal
+- merge / unmerge
+- export allow / block
+- suppression / coarsening
+- screening and adjudication decisions
+
+Each lane may serialize these differently, but they belong to one semantic family.
+
+## 7. ProofPack
+
+A `ProofPack` is a public-safe packaging profile for review, replay, disclosure, and audit.
+
+It is not a competing proof model. It packages:
+
+- Capability Fabric receipt/proof semantics
+- AgentPlane evidence and lifecycle artifacts
+- Knowledge Context claims and provenance
+- Entity Analytics proof explanations
+- bounded evidence, policy refs, replay refs, and safe summaries
+
+## 8. TemporalProfile and TrustProfile
+
+`TemporalProfile` normalizes time semantics such as capture time, occurrence time, assertion time, validation time, observation time, retrieval time, and validity windows.
+
+`TrustProfile` normalizes validation state, checks, confidence where applicable, review state, rights, freshness, controllability, proof strength, signatures, witnesses, and admissibility posture.
+
+Not every lane uses every slot. The point is shared meaning, not forced uniform density.
+
+## 9. Why this matters
+
+Without the canon, the platform reads like neighboring subsystems.
+
+With the canon, we can explain:
+
+- one evidence model
+- one replay model
+- one reversibility posture
+- one public-safe proof/export vocabulary
+- one bridge between runtime, knowledge, entity, capability, and product work
+
+## 10. Read next
+
+- [Architecture](./architecture)
+- [Agent Plane and Operator Workflows](./agent-plane-and-operator-workflows)
+- [Entity Analytics Reference](./entity-analytics-reference)
+- [Provenance, Promotion, and Reversibility](./provenance-promotion-and-reversibility)
+
+The separate `ProofPack` and entity-proof packaging guide should be read after those pages.

--- a/docs/guide/provenance-promotion-and-reversibility.md
+++ b/docs/guide/provenance-promotion-and-reversibility.md
@@ -2,6 +2,12 @@
 
 SocioProphet treats provenance, promotion, and reversibility as first-class system properties.
 
+The cross-lane artifact canon defines how runtime artifacts, knowledge claims, Entity Analytics proof artifacts, Capability Fabric receipts, and product-surface evidence share one public vocabulary for decisions, proof, time, and trust.
+
+Primary cross-lane reference:
+
+- [Cross-Lane Artifact Canon](./cross-lane-artifact-canon)
+
 ## 1. Provenance
 
 Every consequential action must be attributable.
@@ -51,6 +57,7 @@ We publish:
 - the logic of proof, promotion, and reversal
 - the fact of witness/quorum governance
 - the evidence and audit model
+- the public artifact vocabulary used to explain consequential transitions
 
 We do not publish:
 
@@ -61,6 +68,7 @@ We do not publish:
 
 ## 6. Related references
 
+- [Cross-Lane Artifact Canon](./cross-lane-artifact-canon)
 - [Deterministic AI and Mathematical Safety](./deterministic-ai-and-mathematical-safety)
 - [Governed AI and Cybernetics](./governed-ai-and-cybernetics)
 - [Authorized Cyberdefense and Simulation](./authorized-cyberdefense-and-simulation)


### PR DESCRIPTION
## Summary

Binds the active VitePress docs surface to the cross-lane artifact canon that landed in `socioprophet-standards-knowledge#64`.

Adds:
- `docs/guide/cross-lane-artifact-canon.md`

Updates:
- `docs/guide/architecture.md`
- `docs/guide/agent-plane-and-operator-workflows.md`
- `docs/guide/provenance-promotion-and-reversibility.md`

## Why

The standards repo now defines the shared semantic vocabulary for:
- runtime artifacts
- knowledge artifacts
- Entity Analytics proof artifacts
- Capability Fabric receipts and proof-strength semantics
- product/UI evidence surfaces

The public architecture docs should expose that canon as a readable operator/builder entry point rather than leaving it only in the standards repo.

## Scope

This PR is docs-only and intentionally narrow.

It does:
- add the public-readable guide page;
- link Architecture to the canon;
- link Agent Plane to the canon;
- link Provenance/Promotion/Reversibility to the canon.

It does **not**:
- change schemas;
- change VitePress sidebar/navigation in this tranche;
- add the separate ProofPack/entity-proof contract page;
- alter runtime, product, or deployment code.

## Validation performed

Connector-side branch validation:

```text
compare master...work/docs-cross-lane-artifact-canon-2026-05-05
status: ahead
commits ahead: 4
commits behind: 0
changed files: 4
```

Changed files:

```text
docs/guide/cross-lane-artifact-canon.md                  +145
docs/guide/architecture.md                                +12
docs/guide/agent-plane-and-operator-workflows.md            +8
docs/guide/provenance-promotion-and-reversibility.md        +8
```

Not run in local checkout from this connector session:

```bash
npm run docs:build
```

## Follow-ons

1. Add sidebar/nav discoverability once this readable entry point is accepted.
2. Add `ProofPack` / entity-proof public contract page.
3. Decide later whether `ProofPack` needs a versioned schema after semantic alignment is stable.

## Self-critique

Strong: this PR binds the public architecture docs to the newly merged standards canon without mixing in schema or product changes.

Weak: the sidebar is not changed here because the docs branch was moving quickly; keeping the PR narrower reduces conflict risk. Sidebar wiring can follow in a separate small docs PR.
