### PR TITLE
docs: add cross-lane artifact canon to sidebar

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
           items: [
             { text: "Getting Started", link: "/guide/getting-started" },
             { text: "Architecture", link: "/guide/architecture" },
+            { text: "Cross-Lane Artifact Canon", link: "/guide/cross-lane-artifact-canon" },
             { text: "Canonical Platform Direction", link: "/guide/canonical-platform-direction" },
             { text: "Event-Native Orchestration Workbench", link: "/guide/event-native-orchestration-workbench" },
             { text: "Surface Inventory", link: "/guide/surface-inventory" },
@@ -77,6 +78,7 @@ export default defineConfig({
           items: [
             { text: "Entity Analytics Overview", link: "/guide/entity-analytics-overview" },
             { text: "Entity Analytics Reference", link: "/guide/entity-analytics-reference" },
+            { text: "Cross-Lane Artifact Canon", link: "/guide/cross-lane-artifact-canon" },
             { text: "Legal Entity Reference Fabric", link: "/guide/legal-entity-reference-fabric" },
             { text: "Entity Graph and Safe Linkage", link: "/guide/entity-graph-and-safe-linkage" },
             { text: "Identity Prime and Event IR", link: "/guide/identity-prime-and-event-ir" },
@@ -105,6 +107,7 @@ export default defineConfig({
           text: "Trust Center",
           items: [
             { text: "Trust Center", link: "/guide/trust-center" },
+            { text: "Cross-Lane Artifact Canon", link: "/guide/cross-lane-artifact-canon" },
             { text: "Reporting and Disclosure", link: "/guide/reporting-and-disclosure" },
             { text: "Deployment Modes and Data Boundaries", link: "/guide/deployment-modes-and-data-boundaries" },
             { text: "System Cards and Assurance", link: "/guide/system-cards-and-assurance" },


### PR DESCRIPTION
## Summary

Adds sidebar discoverability for the newly merged Cross-Lane Artifact Canon guide.

Updated:
- `docs/.vitepress/config.ts`

Adds the page under:
- Start Here
- Entity Analytics & Identity
- Trust Center

## Why

`#316` added the public-readable guide and linked it from Architecture, Agent Plane, and Provenance. This follow-up makes the page directly discoverable from the active VitePress sidebar.

## Scope

Docs navigation only.

This PR does **not**:
- alter guide content;
- alter standards files;
- change schemas;
- change runtime/product/deployment code;
- add the ProofPack/entity-proof contract page.

## Validation performed

Connector-side branch validation:

```text
compare master...work/docs-cross-lane-sidebar-2026-05-07
status: ahead
commits ahead: 1
commits behind: 0
changed files: 1
```

Changed files:

```text
docs/.vitepress/config.ts +3
```

Not run in local checkout from this connector session:

```bash
npm run docs:build
```

## Follow-on

Next tranche: add the `ProofPack` / entity-proof public contract page and link it from Entity Analytics, Legal Entity Reference Fabric, and the Michael cross-context worked example.
