### PR TITLE
Add OntologyClient E1 fixture tests

### DIFF
--- a/socioprophet-web/client-vue/src/runtime-adapters/knowledgeGraphClient.test.ts
+++ b/socioprophet-web/client-vue/src/runtime-adapters/knowledgeGraphClient.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createFixtureKnowledgeGraphClient,
+  KnowledgeGraphAccessError,
+  knowledgeGraphE1Fixture,
+} from './knowledgeGraphClient'
+
+describe('KnowledgeGraphClient E1 fixture contract', () => {
+  it('returns the happy-path summary response from explicit summary operation response', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+
+    await expect(client.summary()).resolves.toEqual(
+      knowledgeGraphE1Fixture.responses['knowledge_graph.summary.get'],
+    )
+  })
+
+  it('searches nodes using service operation semantics, not generic SPARQL', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+
+    const nodes = await client.searchNodes('graph')
+
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]).toMatchObject({
+      id: 'kg:node:graph-universe-explorer',
+      label: 'Graph Universe Explorer',
+      kind: 'ui-feature',
+    })
+    expect(nodes[0].provenance_refs).toContain('urn:kg:prov:graph-universe-explorer')
+  })
+
+  it('returns a node by stable NodeId with provenance refs', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+
+    const node = await client.getNode('kg:node:agentplane')
+
+    expect(node).not.toBeNull()
+    expect(node?.properties.owner_repo).toBe('SocioProphet/agentplane')
+    expect(node?.provenance_refs).toEqual(['urn:kg:prov:agentplane-runtime'])
+  })
+
+  it('expands neighborhood subgraphs with operation-scoped provenance and stable EdgeIds', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+
+    const subgraph = await client.getNeighbors('kg:node:socioprophet')
+
+    expect(subgraph.operation).toBe('knowledge_graph.neighborhood.expand')
+    expect(subgraph.nodes.map((node) => node.id)).toEqual([
+      'kg:node:socioprophet',
+      'kg:node:graph-universe-explorer',
+      'kg:node:agentplane',
+    ])
+    expect(subgraph.edges.map((edge) => edge.id)).toEqual([
+      'kg:edge:socioprophet-owns-graph-universe-explorer',
+      'kg:edge:graph-universe-explorer-uses-agentplane',
+    ])
+    expect(subgraph.provenance.operation).toBe('knowledge_graph.neighborhood.expand')
+  })
+
+  it('returns null for the missing_node negative case', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+
+    const missing = await client.getNode(knowledgeGraphE1Fixture.negative_cases.missing_node.node_id)
+
+    expect(missing).toBeNull()
+  })
+
+  it('raises an access-control error for the denied_provenance negative case', async () => {
+    const client = createFixtureKnowledgeGraphClient()
+    const deniedRef = knowledgeGraphE1Fixture.negative_cases.denied_provenance.provenance_ref
+
+    await expect(client.getProvenance(deniedRef)).rejects.toBeInstanceOf(KnowledgeGraphAccessError)
+    await expect(client.getProvenance(deniedRef)).rejects.toMatchObject({
+      code: 'access_denied',
+      provenance_ref: deniedRef,
+    })
+  })
+
+  it('returns a degraded summary for the degraded_backend negative case', async () => {
+    const client = createFixtureKnowledgeGraphClient(knowledgeGraphE1Fixture, {
+      summaryMode: 'degraded_backend',
+    })
+
+    const summary = await client.summary()
+
+    expect(summary).toEqual(knowledgeGraphE1Fixture.negative_cases.degraded_backend.response)
+    expect(summary.health).toBe('degraded')
+    expect(summary.mockBoundary).toBe(true)
+    expect(summary.evidence_level).toBe('E1')
+  })
+})

--- a/socioprophet-web/client-vue/src/runtime-adapters/knowledgeGraphClient.ts
+++ b/socioprophet-web/client-vue/src/runtime-adapters/knowledgeGraphClient.ts
@@ -1,0 +1,300 @@
+export type NodeId = string
+export type EdgeId = string
+
+export type KnowledgeGraphOperation =
+  | 'knowledge_graph.summary.get'
+  | 'knowledge_graph.nodes.search'
+  | 'knowledge_graph.node.get'
+  | 'knowledge_graph.edge.get'
+  | 'knowledge_graph.neighborhood.expand'
+  | 'knowledge_graph.provenance.get'
+
+export type KnowledgeGraphHealth = 'ok' | 'degraded' | 'unavailable'
+
+export interface KGNode {
+  id: NodeId
+  label: string
+  kind: string
+  properties: Record<string, string | number | boolean>
+  provenance_refs: string[]
+}
+
+export interface KGEdge {
+  id: EdgeId
+  source: NodeId
+  target: NodeId
+  predicate: string
+  label: string
+  properties: Record<string, string | number | boolean>
+  provenance_refs: string[]
+}
+
+export interface KGSummary {
+  operation: Extract<KnowledgeGraphOperation, 'knowledge_graph.summary.get'>
+  health: KnowledgeGraphHealth
+  node_count: number
+  edge_count: number
+  mockBoundary: true
+  evidence_level: 'E1'
+  degraded_reason?: string
+}
+
+export interface KGProvenance {
+  operation: KnowledgeGraphOperation
+  refs: string[]
+  source: string
+  evidence_level: 'E1'
+  access: 'allowed' | 'denied'
+}
+
+export interface KGSubgraph {
+  operation: Extract<KnowledgeGraphOperation, 'knowledge_graph.neighborhood.expand'>
+  center: NodeId
+  nodes: KGNode[]
+  edges: KGEdge[]
+  provenance: KGProvenance
+}
+
+export interface KnowledgeGraphFixture {
+  summary: KGSummary
+  nodes: KGNode[]
+  edges: KGEdge[]
+  provenance: Record<string, KGProvenance>
+  responses: {
+    'knowledge_graph.summary.get': KGSummary
+    'knowledge_graph.nodes.search': Record<string, NodeId[]>
+    'knowledge_graph.neighborhood.expand': Record<NodeId, { node_ids: NodeId[]; edge_ids: EdgeId[] }>
+  }
+  negative_cases: {
+    missing_node: { node_id: NodeId; expected: null }
+    denied_provenance: { provenance_ref: string; error: { code: 'access_denied'; message: string } }
+    degraded_backend: { operation: Extract<KnowledgeGraphOperation, 'knowledge_graph.summary.get'>; response: KGSummary }
+  }
+}
+
+export interface KnowledgeGraphClient {
+  summary(): Promise<KGSummary>
+  searchNodes(query: string): Promise<KGNode[]>
+  getNode(id: NodeId): Promise<KGNode | null>
+  getEdge(id: EdgeId): Promise<KGEdge | null>
+  getNeighbors(id: NodeId): Promise<KGSubgraph>
+  getProvenance(ref: string): Promise<KGProvenance>
+}
+
+export class KnowledgeGraphAccessError extends Error {
+  readonly code = 'access_denied'
+  readonly provenance_ref: string
+
+  constructor(provenanceRef: string, message: string) {
+    super(message)
+    this.name = 'KnowledgeGraphAccessError'
+    this.provenance_ref = provenanceRef
+  }
+}
+
+export const knowledgeGraphE1Fixture: KnowledgeGraphFixture = {
+  summary: {
+    operation: 'knowledge_graph.summary.get',
+    health: 'ok',
+    node_count: 3,
+    edge_count: 2,
+    mockBoundary: true,
+    evidence_level: 'E1',
+  },
+  nodes: [
+    {
+      id: 'kg:node:socioprophet',
+      label: 'SocioProphet',
+      kind: 'platform',
+      properties: { owner_repo: 'SocioProphet/socioprophet', surface: 'Graph Universe Explorer' },
+      provenance_refs: ['urn:kg:prov:socioprophet-platform'],
+    },
+    {
+      id: 'kg:node:agentplane',
+      label: 'AgentPlane',
+      kind: 'runtime-control-plane',
+      properties: { owner_repo: 'SocioProphet/agentplane', adapter: 'AgentPlaneClient' },
+      provenance_refs: ['urn:kg:prov:agentplane-runtime'],
+    },
+    {
+      id: 'kg:node:graph-universe-explorer',
+      label: 'Graph Universe Explorer',
+      kind: 'ui-feature',
+      properties: { adapter: 'KnowledgeGraphClient', route: '/map' },
+      provenance_refs: ['urn:kg:prov:graph-universe-explorer'],
+    },
+  ],
+  edges: [
+    {
+      id: 'kg:edge:socioprophet-owns-graph-universe-explorer',
+      source: 'kg:node:socioprophet',
+      target: 'kg:node:graph-universe-explorer',
+      predicate: 'owns_surface',
+      label: 'owns surface',
+      properties: { contract: 'ui-runtime-adapter-v0' },
+      provenance_refs: ['urn:kg:prov:graph-universe-explorer'],
+    },
+    {
+      id: 'kg:edge:graph-universe-explorer-uses-agentplane',
+      source: 'kg:node:graph-universe-explorer',
+      target: 'kg:node:agentplane',
+      predicate: 'uses_runtime_boundary',
+      label: 'uses runtime boundary',
+      properties: { runtime_state: 'fixture' },
+      provenance_refs: ['urn:kg:prov:agentplane-runtime'],
+    },
+  ],
+  provenance: {
+    'urn:kg:prov:socioprophet-platform': {
+      operation: 'knowledge_graph.node.get',
+      refs: ['SocioProphet/socioprophet', 'SocioProphet/sociosphere#333'],
+      source: 'fixture',
+      evidence_level: 'E1',
+      access: 'allowed',
+    },
+    'urn:kg:prov:agentplane-runtime': {
+      operation: 'knowledge_graph.neighborhood.expand',
+      refs: ['SocioProphet/agentplane', 'SocioProphet/agentplane#161'],
+      source: 'fixture',
+      evidence_level: 'E1',
+      access: 'allowed',
+    },
+    'urn:kg:prov:graph-universe-explorer': {
+      operation: 'knowledge_graph.nodes.search',
+      refs: ['protocol/ui-runtime-adapter/v0/README.md'],
+      source: 'fixture',
+      evidence_level: 'E1',
+      access: 'allowed',
+    },
+  },
+  responses: {
+    'knowledge_graph.summary.get': {
+      operation: 'knowledge_graph.summary.get',
+      health: 'ok',
+      node_count: 3,
+      edge_count: 2,
+      mockBoundary: true,
+      evidence_level: 'E1',
+    },
+    'knowledge_graph.nodes.search': {
+      agent: ['kg:node:agentplane'],
+      graph: ['kg:node:graph-universe-explorer'],
+      socioprophet: ['kg:node:socioprophet'],
+    },
+    'knowledge_graph.neighborhood.expand': {
+      'kg:node:socioprophet': {
+        node_ids: ['kg:node:socioprophet', 'kg:node:graph-universe-explorer', 'kg:node:agentplane'],
+        edge_ids: [
+          'kg:edge:socioprophet-owns-graph-universe-explorer',
+          'kg:edge:graph-universe-explorer-uses-agentplane',
+        ],
+      },
+    },
+  },
+  negative_cases: {
+    missing_node: { node_id: 'kg:node:missing', expected: null },
+    denied_provenance: {
+      provenance_ref: 'urn:kg:prov:restricted',
+      error: { code: 'access_denied', message: 'Provenance ref is denied by fixture access policy.' },
+    },
+    degraded_backend: {
+      operation: 'knowledge_graph.summary.get',
+      response: {
+        operation: 'knowledge_graph.summary.get',
+        health: 'degraded',
+        node_count: 3,
+        edge_count: 2,
+        mockBoundary: true,
+        evidence_level: 'E1',
+        degraded_reason: 'Fixture backend degraded negative case.',
+      },
+    },
+  },
+}
+
+interface FixtureClientOptions {
+  summaryMode?: 'ok' | 'degraded_backend'
+}
+
+export function createFixtureKnowledgeGraphClient(
+  fixture: KnowledgeGraphFixture = knowledgeGraphE1Fixture,
+  options: FixtureClientOptions = {},
+): KnowledgeGraphClient {
+  const nodesById = new Map(fixture.nodes.map((node) => [node.id, node]))
+  const edgesById = new Map(fixture.edges.map((edge) => [edge.id, edge]))
+
+  return {
+    async summary() {
+      if (options.summaryMode === 'degraded_backend') {
+        return fixture.negative_cases.degraded_backend.response
+      }
+      return fixture.responses['knowledge_graph.summary.get']
+    },
+
+    async searchNodes(query: string) {
+      const normalized = query.trim().toLowerCase()
+      const responseIds = fixture.responses['knowledge_graph.nodes.search'][normalized] || []
+      return responseIds.map((id) => nodesById.get(id)).filter((node): node is KGNode => Boolean(node))
+    },
+
+    async getNode(id: NodeId) {
+      return nodesById.get(id) || null
+    },
+
+    async getEdge(id: EdgeId) {
+      return edgesById.get(id) || null
+    },
+
+    async getNeighbors(id: NodeId) {
+      const response = fixture.responses['knowledge_graph.neighborhood.expand'][id]
+      if (!response) {
+        return {
+          operation: 'knowledge_graph.neighborhood.expand',
+          center: id,
+          nodes: [],
+          edges: [],
+          provenance: {
+            operation: 'knowledge_graph.neighborhood.expand',
+            refs: [],
+            source: 'fixture',
+            evidence_level: 'E1',
+            access: 'allowed',
+          },
+        }
+      }
+
+      return {
+        operation: 'knowledge_graph.neighborhood.expand',
+        center: id,
+        nodes: response.node_ids.map((nodeId) => nodesById.get(nodeId)).filter((node): node is KGNode => Boolean(node)),
+        edges: response.edge_ids.map((edgeId) => edgesById.get(edgeId)).filter((edge): edge is KGEdge => Boolean(edge)),
+        provenance: {
+          operation: 'knowledge_graph.neighborhood.expand',
+          refs: response.edge_ids,
+          source: 'fixture',
+          evidence_level: 'E1',
+          access: 'allowed',
+        },
+      }
+    },
+
+    async getProvenance(ref: string) {
+      if (ref === fixture.negative_cases.denied_provenance.provenance_ref) {
+        throw new KnowledgeGraphAccessError(ref, fixture.negative_cases.denied_provenance.error.message)
+      }
+
+      const provenance = fixture.provenance[ref]
+      if (!provenance) {
+        return {
+          operation: 'knowledge_graph.provenance.get',
+          refs: [ref],
+          source: 'fixture',
+          evidence_level: 'E1',
+          access: 'allowed',
+        }
+      }
+
+      return provenance
+    },
+  }
+}

--- a/socioprophet-web/client-vue/src/runtime-adapters/ontologyClient.test.ts
+++ b/socioprophet-web/client-vue/src/runtime-adapters/ontologyClient.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createFixtureOntologyClient,
+  ontologyE1Fixture,
+  OntologyCapabilityError,
+} from './ontologyClient'
+
+describe('OntologyClient E1 fixture contract', () => {
+  it('lists ontology namespaces with owner, policy, and provenance refs', async () => {
+    const client = createFixtureOntologyClient()
+
+    const namespaces = await client.listNamespaces()
+
+    expect(namespaces).toEqual(ontologyE1Fixture.responses['ontology.namespaces.list'])
+    expect(namespaces[0]).toMatchObject({
+      id: 'domain-ontology-workbench',
+      owner_repo: 'SocioProphet/ontogenesis',
+      policy_ref: 'SocioProphet/ontogenesis#88',
+    })
+    expect(namespaces[0].provenance_refs).toContain(
+      'urn:ontology:prov:namespace:domain-ontology-workbench',
+    )
+  })
+
+  it('reads the active ontology graph with KGNode and KGEdge identity intact', async () => {
+    const client = createFixtureOntologyClient()
+
+    const graph = await client.getGraph('domain-ontology-workbench')
+
+    expect(graph).not.toBeNull()
+    expect(graph?.mockBoundary).toBe(true)
+    expect(graph?.evidence_level).toBe('E1')
+    expect(graph?.classes[0]).toMatchObject({
+      id: 'kg:node:ontology:domain-surface',
+      kind: 'ontology-class',
+    })
+    expect(graph?.relationships[0]).toMatchObject({
+      id: 'kg:edge:ontology:domain-surface-runtime-adapter',
+      source: 'kg:node:ontology:domain-surface',
+      target: 'kg:node:ontology:runtime-adapter',
+    })
+  })
+
+  it('searches ontology terms through service-operation semantics', async () => {
+    const client = createFixtureOntologyClient()
+
+    const terms = await client.searchTerms('adapter')
+
+    expect(terms).toHaveLength(1)
+    expect(terms[0]).toMatchObject({
+      id: 'kg:node:ontology:runtime-adapter',
+      label: 'Runtime Adapter',
+      kind: 'ontology-property',
+    })
+    expect(terms[0].provenance_refs).toEqual(['urn:ontology:prov:runtime-adapter'])
+  })
+
+  it('validates a class edit proposal as fixture-backed E1', async () => {
+    const client = createFixtureOntologyClient()
+
+    const result = await client.validateEdit({
+      namespace_id: 'domain-ontology-workbench',
+      term_id: 'kg:node:ontology:new-domain-class',
+      action: 'create_class',
+      label: 'New Domain Class',
+      parent_id: 'kg:node:ontology:domain-surface',
+    })
+
+    expect(result.operation).toBe('ontology.edit.validate')
+    expect(result.status).toBe('valid')
+    expect(result.mockBoundary).toBe(true)
+    expect(result.evidence_level).toBe('E1')
+  })
+
+  it('validates a relationship proposal as fixture-backed E1', async () => {
+    const client = createFixtureOntologyClient()
+
+    const result = await client.validateRelationship({
+      namespace_id: 'domain-ontology-workbench',
+      source: 'kg:node:ontology:domain-surface',
+      target: 'kg:node:ontology:runtime-adapter',
+      predicate: 'has_property',
+      action: 'add',
+    })
+
+    expect(result.operation).toBe('ontology.relationship.validate')
+    expect(result.status).toBe('valid')
+    expect(result.diagnostics[0]).toMatchObject({
+      code: 'ontology.relationship.valid_shape',
+      edge_id: 'kg:edge:ontology:domain-surface-runtime-adapter',
+    })
+  })
+
+  it('returns the invalid_edit negative validation case', async () => {
+    const client = createFixtureOntologyClient(ontologyE1Fixture, {
+      editValidationKey: ontologyE1Fixture.negative_cases.invalid_edit.proposal_key,
+    })
+
+    const result = await client.validateEdit({
+      namespace_id: 'domain-ontology-workbench',
+      term_id: 'kg:node:ontology:orphan-property',
+      action: 'create_property',
+      label: 'Orphan Property',
+    })
+
+    expect(result.status).toBe(ontologyE1Fixture.negative_cases.invalid_edit.status)
+    expect(result.diagnostics[0].code).toBe(
+      ontologyE1Fixture.negative_cases.invalid_edit.diagnostic_code,
+    )
+  })
+
+  it('creates a promotion candidate without approving canonical ontology changes', async () => {
+    const client = createFixtureOntologyClient()
+
+    const candidate = await client.createPromotionCandidate({
+      namespace_id: 'domain-ontology-workbench',
+      term_id: 'kg:node:ontology:new-domain-class',
+      action: 'create_class',
+      label: 'New Domain Class',
+      parent_id: 'kg:node:ontology:domain-surface',
+    })
+
+    expect(candidate).toEqual(
+      ontologyE1Fixture.responses['ontology.promotion.candidate.create'],
+    )
+    expect(candidate.mockBoundary).toBe(true)
+    expect(candidate.required_capability).toBe('capability://ontology.promote.candidate.create')
+  })
+
+  it('rejects promotion approval without the required capability', async () => {
+    const client = createFixtureOntologyClient()
+    const negative = ontologyE1Fixture.negative_cases.promotion_without_capability
+
+    await expect(
+      client.approvePromotion({
+        candidate_id: negative.candidate_id,
+        approved_by: 'fixture-user',
+      }),
+    ).rejects.toBeInstanceOf(OntologyCapabilityError)
+
+    await expect(
+      client.approvePromotion({
+        candidate_id: negative.candidate_id,
+        approved_by: 'fixture-user',
+      }),
+    ).rejects.toMatchObject({
+      code: 'capability_required',
+      required_capability: negative.required_capability,
+    })
+  })
+
+  it('exports fixture bundle metadata without producing a live ontology promotion', async () => {
+    const client = createFixtureOntologyClient()
+
+    const bundle = await client.exportBundle('domain-ontology-workbench')
+
+    expect(bundle).toEqual(
+      ontologyE1Fixture.responses['ontology.export.bundle']['domain-ontology-workbench'],
+    )
+    expect(bundle?.formats).toEqual(['jsonld', 'shacl'])
+    expect(bundle?.mockBoundary).toBe(true)
+    expect(bundle?.evidence_level).toBe('E1')
+  })
+
+  it('returns null for the missing_graph negative case', async () => {
+    const client = createFixtureOntologyClient()
+
+    const graph = await client.getGraph(ontologyE1Fixture.negative_cases.missing_graph.namespace_id)
+
+    expect(graph).toBeNull()
+  })
+})

--- a/socioprophet-web/client-vue/src/runtime-adapters/ontologyClient.ts
+++ b/socioprophet-web/client-vue/src/runtime-adapters/ontologyClient.ts
@@ -1,0 +1,368 @@
+import type { EdgeId, KGEdge, KGNode, NodeId } from './knowledgeGraphClient'
+
+export type OntologyNamespaceId = string
+export type OntologyGraphId = string
+export type OntologyTermId = NodeId
+export type OntologyPromotionCandidateId = string
+
+export type OntologyOperation =
+  | 'ontology.namespaces.list'
+  | 'ontology.graph.get'
+  | 'ontology.term.search'
+  | 'ontology.edit.validate'
+  | 'ontology.relationship.validate'
+  | 'ontology.promotion.candidate.create'
+  | 'ontology.promotion.approve'
+  | 'ontology.export.bundle'
+
+export type OntologyValidationStatus = 'valid' | 'invalid' | 'requires_capability'
+
+export interface OntologyNamespace {
+  id: OntologyNamespaceId
+  label: string
+  owner_repo: string
+  active_graph_id: OntologyGraphId
+  policy_ref: string
+  provenance_refs: string[]
+}
+
+export interface OntologyGraph {
+  id: OntologyGraphId
+  namespace_id: OntologyNamespaceId
+  label: string
+  classes: KGNode[]
+  properties: KGNode[]
+  relationships: KGEdge[]
+  mockBoundary: true
+  evidence_level: 'E1'
+  provenance_refs: string[]
+}
+
+export interface OntologyDiagnostic {
+  code: string
+  severity: 'info' | 'warning' | 'error'
+  message: string
+  term_id?: OntologyTermId
+  edge_id?: EdgeId
+}
+
+export interface OntologyValidationResult {
+  operation: Extract<OntologyOperation, 'ontology.edit.validate' | 'ontology.relationship.validate'>
+  status: OntologyValidationStatus
+  diagnostics: OntologyDiagnostic[]
+  mockBoundary: true
+  evidence_level: 'E1'
+  required_capability?: string
+}
+
+export interface OntologyEditProposal {
+  namespace_id: OntologyNamespaceId
+  term_id: OntologyTermId
+  action: 'create_class' | 'create_property' | 'rename' | 'deprecate'
+  label: string
+  parent_id?: OntologyTermId
+}
+
+export interface OntologyRelationshipProposal {
+  namespace_id: OntologyNamespaceId
+  source: OntologyTermId
+  target: OntologyTermId
+  predicate: string
+  action: 'add' | 'remove'
+}
+
+export interface OntologyPromotionCandidate {
+  id: OntologyPromotionCandidateId
+  operation: Extract<OntologyOperation, 'ontology.promotion.candidate.create'>
+  namespace_id: OntologyNamespaceId
+  validation_status: OntologyValidationStatus
+  required_capability: string
+  mockBoundary: true
+  evidence_level: 'E1'
+  provenance_refs: string[]
+}
+
+export interface OntologyPromotionApproval {
+  candidate_id: OntologyPromotionCandidateId
+  approved_by: string
+  capability_ref?: string
+}
+
+export interface OntologyPromotionApprovalResult {
+  operation: Extract<OntologyOperation, 'ontology.promotion.approve'>
+  candidate_id: OntologyPromotionCandidateId
+  status: 'approved' | 'denied'
+  mockBoundary: true
+  evidence_level: 'E1'
+  denial_reason?: string
+}
+
+export interface OntologyExportBundle {
+  operation: Extract<OntologyOperation, 'ontology.export.bundle'>
+  namespace_id: OntologyNamespaceId
+  formats: Array<'jsonld' | 'rdf' | 'owl' | 'shacl'>
+  artifact_refs: string[]
+  mockBoundary: true
+  evidence_level: 'E1'
+}
+
+export interface OntologyClient {
+  listNamespaces(): Promise<OntologyNamespace[]>
+  getGraph(namespaceId: OntologyNamespaceId): Promise<OntologyGraph | null>
+  searchTerms(query: string, namespaceId?: OntologyNamespaceId): Promise<KGNode[]>
+  validateEdit(proposal: OntologyEditProposal): Promise<OntologyValidationResult>
+  validateRelationship(proposal: OntologyRelationshipProposal): Promise<OntologyValidationResult>
+  createPromotionCandidate(proposal: OntologyEditProposal): Promise<OntologyPromotionCandidate>
+  approvePromotion(approval: OntologyPromotionApproval): Promise<OntologyPromotionApprovalResult>
+  exportBundle(namespaceId: OntologyNamespaceId): Promise<OntologyExportBundle | null>
+}
+
+export class OntologyCapabilityError extends Error {
+  readonly code = 'capability_required'
+  readonly required_capability: string
+
+  constructor(requiredCapability: string, message: string) {
+    super(message)
+    this.name = 'OntologyCapabilityError'
+    this.required_capability = requiredCapability
+  }
+}
+
+export interface OntologyFixture {
+  namespaces: OntologyNamespace[]
+  graphs: Record<OntologyNamespaceId, OntologyGraph>
+  responses: {
+    'ontology.namespaces.list': OntologyNamespace[]
+    'ontology.term.search': Record<string, OntologyTermId[]>
+    'ontology.edit.validate': Record<string, OntologyValidationResult>
+    'ontology.relationship.validate': Record<string, OntologyValidationResult>
+    'ontology.promotion.candidate.create': OntologyPromotionCandidate
+    'ontology.export.bundle': Record<OntologyNamespaceId, OntologyExportBundle>
+  }
+  negative_cases: {
+    missing_graph: { namespace_id: OntologyNamespaceId; expected: null }
+    invalid_edit: { proposal_key: string; status: 'invalid'; diagnostic_code: string }
+    promotion_without_capability: {
+      candidate_id: OntologyPromotionCandidateId
+      required_capability: string
+      error: { code: 'capability_required'; message: string }
+    }
+  }
+}
+
+const domainClass: KGNode = {
+  id: 'kg:node:ontology:domain-surface',
+  label: 'Domain Surface',
+  kind: 'ontology-class',
+  properties: { namespace: 'domain-ontology-workbench', iri: 'sp:DomainSurface' },
+  provenance_refs: ['urn:ontology:prov:domain-surface'],
+}
+
+const adapterProperty: KGNode = {
+  id: 'kg:node:ontology:runtime-adapter',
+  label: 'Runtime Adapter',
+  kind: 'ontology-property',
+  properties: { namespace: 'domain-ontology-workbench', iri: 'sp:runtimeAdapter' },
+  provenance_refs: ['urn:ontology:prov:runtime-adapter'],
+}
+
+const adapterRelationship: KGEdge = {
+  id: 'kg:edge:ontology:domain-surface-runtime-adapter',
+  source: domainClass.id,
+  target: adapterProperty.id,
+  predicate: 'has_property',
+  label: 'has property',
+  properties: { namespace: 'domain-ontology-workbench' },
+  provenance_refs: ['urn:ontology:prov:domain-surface-runtime-adapter'],
+}
+
+export const ontologyE1Fixture: OntologyFixture = {
+  namespaces: [
+    {
+      id: 'domain-ontology-workbench',
+      label: 'Domain Ontology Workbench',
+      owner_repo: 'SocioProphet/ontogenesis',
+      active_graph_id: 'graph:domain-ontology-workbench:e1',
+      policy_ref: 'SocioProphet/ontogenesis#88',
+      provenance_refs: ['urn:ontology:prov:namespace:domain-ontology-workbench'],
+    },
+  ],
+  graphs: {
+    'domain-ontology-workbench': {
+      id: 'graph:domain-ontology-workbench:e1',
+      namespace_id: 'domain-ontology-workbench',
+      label: 'Domain Ontology Workbench E1 Fixture Graph',
+      classes: [domainClass],
+      properties: [adapterProperty],
+      relationships: [adapterRelationship],
+      mockBoundary: true,
+      evidence_level: 'E1',
+      provenance_refs: ['urn:ontology:prov:graph:domain-ontology-workbench:e1'],
+    },
+  },
+  responses: {
+    'ontology.namespaces.list': [
+      {
+        id: 'domain-ontology-workbench',
+        label: 'Domain Ontology Workbench',
+        owner_repo: 'SocioProphet/ontogenesis',
+        active_graph_id: 'graph:domain-ontology-workbench:e1',
+        policy_ref: 'SocioProphet/ontogenesis#88',
+        provenance_refs: ['urn:ontology:prov:namespace:domain-ontology-workbench'],
+      },
+    ],
+    'ontology.term.search': {
+      domain: [domainClass.id],
+      adapter: [adapterProperty.id],
+    },
+    'ontology.edit.validate': {
+      valid_class_create: {
+        operation: 'ontology.edit.validate',
+        status: 'valid',
+        diagnostics: [
+          {
+            code: 'ontology.edit.valid_shape',
+            severity: 'info',
+            message: 'Class creation proposal conforms to the E1 fixture contract.',
+          },
+        ],
+        mockBoundary: true,
+        evidence_level: 'E1',
+      },
+      invalid_orphan_property: {
+        operation: 'ontology.edit.validate',
+        status: 'invalid',
+        diagnostics: [
+          {
+            code: 'ontology.edit.parent_required',
+            severity: 'error',
+            message: 'Property creation requires a parent class or domain term.',
+          },
+        ],
+        mockBoundary: true,
+        evidence_level: 'E1',
+      },
+    },
+    'ontology.relationship.validate': {
+      valid_relationship_add: {
+        operation: 'ontology.relationship.validate',
+        status: 'valid',
+        diagnostics: [
+          {
+            code: 'ontology.relationship.valid_shape',
+            severity: 'info',
+            message: 'Relationship addition conforms to the E1 fixture contract.',
+            edge_id: adapterRelationship.id,
+          },
+        ],
+        mockBoundary: true,
+        evidence_level: 'E1',
+      },
+    },
+    'ontology.promotion.candidate.create': {
+      id: 'ontology-promotion-candidate:e1:domain-surface-extension',
+      operation: 'ontology.promotion.candidate.create',
+      namespace_id: 'domain-ontology-workbench',
+      validation_status: 'valid',
+      required_capability: 'capability://ontology.promote.candidate.create',
+      mockBoundary: true,
+      evidence_level: 'E1',
+      provenance_refs: ['urn:ontology:prov:promotion-candidate:e1'],
+    },
+    'ontology.export.bundle': {
+      'domain-ontology-workbench': {
+        operation: 'ontology.export.bundle',
+        namespace_id: 'domain-ontology-workbench',
+        formats: ['jsonld', 'shacl'],
+        artifact_refs: [
+          'fixture://ontology/domain-ontology-workbench/export.jsonld',
+          'fixture://ontology/domain-ontology-workbench/export.shacl',
+        ],
+        mockBoundary: true,
+        evidence_level: 'E1',
+      },
+    },
+  },
+  negative_cases: {
+    missing_graph: { namespace_id: 'missing-namespace', expected: null },
+    invalid_edit: {
+      proposal_key: 'invalid_orphan_property',
+      status: 'invalid',
+      diagnostic_code: 'ontology.edit.parent_required',
+    },
+    promotion_without_capability: {
+      candidate_id: 'ontology-promotion-candidate:e1:domain-surface-extension',
+      required_capability: 'capability://ontology.promote.approve',
+      error: {
+        code: 'capability_required',
+        message: 'Ontology promotion approval requires capability://ontology.promote.approve.',
+      },
+    },
+  },
+}
+
+interface FixtureOntologyClientOptions {
+  editValidationKey?: keyof OntologyFixture['responses']['ontology.edit.validate']
+  relationshipValidationKey?: keyof OntologyFixture['responses']['ontology.relationship.validate']
+}
+
+export function createFixtureOntologyClient(
+  fixture: OntologyFixture = ontologyE1Fixture,
+  options: FixtureOntologyClientOptions = {},
+): OntologyClient {
+  const termsById = new Map<NodeId, KGNode>()
+  for (const graph of Object.values(fixture.graphs)) {
+    for (const term of [...graph.classes, ...graph.properties]) {
+      termsById.set(term.id, term)
+    }
+  }
+
+  return {
+    async listNamespaces() {
+      return fixture.responses['ontology.namespaces.list']
+    },
+
+    async getGraph(namespaceId: OntologyNamespaceId) {
+      return fixture.graphs[namespaceId] || null
+    },
+
+    async searchTerms(query: string) {
+      const normalized = query.trim().toLowerCase()
+      const ids = fixture.responses['ontology.term.search'][normalized] || []
+      return ids.map((id) => termsById.get(id)).filter((term): term is KGNode => Boolean(term))
+    },
+
+    async validateEdit() {
+      const key = options.editValidationKey || 'valid_class_create'
+      return fixture.responses['ontology.edit.validate'][key]
+    },
+
+    async validateRelationship() {
+      const key = options.relationshipValidationKey || 'valid_relationship_add'
+      return fixture.responses['ontology.relationship.validate'][key]
+    },
+
+    async createPromotionCandidate() {
+      return fixture.responses['ontology.promotion.candidate.create']
+    },
+
+    async approvePromotion(approval: OntologyPromotionApproval) {
+      const negative = fixture.negative_cases.promotion_without_capability
+      if (approval.candidate_id === negative.candidate_id && approval.capability_ref !== negative.required_capability) {
+        throw new OntologyCapabilityError(negative.required_capability, negative.error.message)
+      }
+
+      return {
+        operation: 'ontology.promotion.approve',
+        candidate_id: approval.candidate_id,
+        status: 'approved',
+        mockBoundary: true,
+        evidence_level: 'E1',
+      }
+    },
+
+    async exportBundle(namespaceId: OntologyNamespaceId) {
+      return fixture.responses['ontology.export.bundle'][namespaceId] || null
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Adds the E1 fixture-backed `OntologyClient` harness for the Domain Ontology Workbench runtime-adapter surface.

This PR is intentionally stacked behind #325 because it reuses `NodeId`, `EdgeId`, `KGNode`, and `KGEdge` from the KnowledgeGraphClient boundary.

## Contract shape

Implements service-operation methods aligned to `SocioProphet/ontogenesis#88`:

- `ontology.namespaces.list`
- `ontology.graph.get`
- `ontology.term.search`
- `ontology.edit.validate`
- `ontology.relationship.validate`
- `ontology.promotion.candidate.create`
- `ontology.promotion.approve`
- `ontology.export.bundle`

## Tests

Adds fixture-backed E1 tests for:

1. namespace listing;
2. active graph read;
3. term search;
4. edit validation;
5. relationship validation;
6. invalid edit negative case;
7. promotion candidate creation;
8. promotion approval denial without capability;
9. export bundle metadata;
10. missing graph returns `null`.

## Non-goals

- No live Ontogenesis backend connection.
- No canonical ontology promotion approval.
- No E2/E3 promotion claim.
- No `mockBoundary` flip.

## Validation

CI should run the existing client-vue workflow because this PR touches `socioprophet-web/client-vue/**`:

```bash
npm run typecheck
npm test
npm run build
```

Closes #326.