### PR TITLE
feat(client-vue): replay Professional Intelligence dashboard

### DIFF
--- a/socioprophet-web/client-vue/fixtures/professional-intelligence/dashboard-control-state.json
+++ b/socioprophet-web/client-vue/fixtures/professional-intelligence/dashboard-control-state.json
@@ -1,0 +1,32 @@
+{
+  "sourceMode": "fixture",
+  "generatedAt": "2026-05-05T20:40:00-04:00",
+  "overallAlignment": 72,
+  "headline": "SocioProphet operating dashboard",
+  "lede": "Closed-loop control surface for Professional Intelligence OS.",
+  "verificationPassed": true,
+  "metrics": [
+    { "name": "Architecture spine", "value": 42, "note": "Platform manifest, orchestration object, and topology are established." },
+    { "name": "DelEx governance", "value": 48, "note": "Delivery model, control register, and Gate 4 addenda are live." },
+    { "name": "Platform contracts", "value": 50, "note": "Core contracts, fixtures, orchestration, and validators are merged." },
+    { "name": "Playbooks", "value": 35, "note": "Seed InnerSource playbooks validate and feed the demo path." },
+    { "name": "Workrooms", "value": 25, "note": "Professional Workroom contract and fixture are merged." },
+    { "name": "Governance loops", "value": 52, "note": "Policy, obligation, topology, routing, controls, and evidence loops are connected." },
+    { "name": "Cybernetic controls", "value": 54, "note": "Sense/compare/act gates now include a Gate 4 verification runner." },
+    { "name": "Runtime implementation", "value": 48, "note": "Agentplane bundle and platform Gate 4 verifier are merged." },
+    { "name": "Demo readiness", "value": 76, "note": "The demo path is locally verifiable but still needs generated dashboard ingestion." }
+  ],
+  "gates": [
+    { "name": "Gate 1 — alignment docs and seed contracts", "status": "complete", "summary": "Platform, DelEx automation, playbooks, workspace, policy, obligations, topology, and UI definitions are seeded." },
+    { "name": "Gate 2 — validation fixtures", "status": "complete", "summary": "Platform, DelEx automation, playbooks, workrooms, policy decisions, obligations, search packets, context packs, context queries, routing decisions, guardrails, and ledger records validate." },
+    { "name": "Gate 3 — recordable demo slice", "status": "complete", "summary": "Agentplane bundle, context/query/search/memory, policy/obligation, routing, guardrail, model-governance, workroom, and evidence/adoption surfaces exist." },
+    { "name": "Gate 4 — integrated demo", "status": "active", "summary": "The platform orchestration object and local Gate 4 verifier are merged; dashboard state ingestion and board rollup remain." }
+  ],
+  "nextMoves": [
+    "Generate this dashboard fixture from DelEx register and Prophet Platform verification output.",
+    "Add DelEx board rollup for Gate 4 status.",
+    "Add global-devsecops-intelligence governance/control-plane assessment.",
+    "Extend the platform runner to optionally execute Agentplane host smoke and include its report.",
+    "Promote the local verification report into an operator-facing artifact surface."
+  ]
+}

--- a/socioprophet-web/client-vue/scripts/generate-pi-dashboard-state.mjs
+++ b/socioprophet-web/client-vue/scripts/generate-pi-dashboard-state.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const input = process.argv[2] || 'fixtures/professional-intelligence/dashboard-control-state.json';
+const output = process.argv[3] || 'src/data/professionalIntelligenceControlState.ts';
+
+const source = JSON.parse(fs.readFileSync(input, 'utf8'));
+for (const key of ['overallAlignment', 'metrics', 'gates', 'nextMoves']) {
+  if (!(key in source)) throw new Error(`missing required field: ${key}`);
+}
+
+const state = {
+  sourceMode: 'fixture',
+  generatedAt: source.generatedAt || new Date().toISOString(),
+  overallAlignment: source.overallAlignment,
+  headline: source.headline || 'SocioProphet operating dashboard',
+  lede: source.lede || 'Closed-loop control surface for Professional Intelligence OS.',
+  boundaryNotice:
+    source.boundaryNotice ||
+    'Fixture-backed dashboard state. This page renders product-control evidence only; it is not live telemetry and does not authorize runtime, backend, device, or release-management actions.',
+  sourceRefs: source.sourceRefs || [
+    'fixtures/professional-intelligence/dashboard-control-state.json',
+  ],
+  metrics: source.metrics,
+  gates: source.gates,
+  controls: source.controls || [
+    {
+      name: 'Gate 4 verification',
+      signal: source.verificationPassed ? 'Verification passed.' : 'Verification incomplete.',
+      action: 'Use the platform report as the dashboard control signal.',
+    },
+  ],
+  prs: source.prs || [
+    { repo: 'SocioProphet/prophet-platform', pr: '#430', capability: 'Dashboard control-state export', status: 'merged' },
+  ],
+  completed: source.completed || ['Platform dashboard control-state export.', 'Typed dashboard fixture seam.'],
+  nextMoves: source.nextMoves,
+  integrationRule:
+    source.integrationRule ||
+    'Integration requires contracts, runtime or workflow touchpoints, governance ownership, evidence, feedback, and corrective controls.',
+};
+
+const moduleText = `export type CompletionMetric = { name: string; value: number; note: string; };
+export type GateState = { name: string; status: 'complete' | 'active' | 'pending'; summary: string; };
+export type CyberneticControl = { name: string; signal: string; action: string; };
+export type PullRequestState = { repo: string; pr: string; capability: string; status: 'merged' | 'open'; };
+export type ProfessionalIntelligenceControlState = { sourceMode: 'fixture'; generatedAt: string; overallAlignment: number; headline: string; lede: string; boundaryNotice: string; sourceRefs: string[]; metrics: CompletionMetric[]; gates: GateState[]; controls: CyberneticControl[]; prs: PullRequestState[]; completed: string[]; nextMoves: string[]; integrationRule: string; };
+
+export const professionalIntelligenceControlState: ProfessionalIntelligenceControlState = ${JSON.stringify(state, null, 2)};
+`;
+
+fs.mkdirSync(path.dirname(output), { recursive: true });
+fs.writeFileSync(output, moduleText, 'utf8');
+console.log(`Wrote ${output}`);

--- a/socioprophet-web/client-vue/src/App.vue
+++ b/socioprophet-web/client-vue/src/App.vue
@@ -4,6 +4,7 @@
       <RouterLink class="sp-brand" to="/news">SocioProphet</RouterLink>
       <nav class="sp-domain-nav" aria-label="Primary domains">
         <RouterLink to="/news">News &amp; Events</RouterLink>
+        <RouterLink to="/professional-intelligence">Professional Intelligence</RouterLink>
         <RouterLink to="/law/international-law">Law &amp; Regulation</RouterLink>
         <RouterLink to="/people/search">People &amp; Society</RouterLink>
         <RouterLink to="/economy/macro-economics">Economy &amp; Industry</RouterLink>
@@ -23,6 +24,7 @@
     <div class="sp-workspace">
       <aside class="sp-left-rail" aria-label="Workspace rail">
         <RouterLink to="/news" title="News">☷</RouterLink>
+        <RouterLink to="/professional-intelligence" title="Professional Intelligence">PI</RouterLink>
         <RouterLink to="/reader" title="Reader">▤</RouterLink>
         <RouterLink to="/map" title="Maps">⌖</RouterLink>
         <RouterLink to="/people/search" title="People">◫</RouterLink>
@@ -74,6 +76,7 @@ const route = useRoute();
 
 const surface = computed(() => surfaceForRoute(route.path));
 const activeDomain = computed(() => {
+  if (route.path.startsWith('/professional-intelligence')) return 'Professional Intelligence';
   if (route.path.startsWith('/map')) return 'Maps & Analytics';
   if (surface.value?.domain) return surface.value.domain;
   if (route.path.startsWith('/analytics')) return 'Maps & Analytics';
@@ -81,6 +84,16 @@ const activeDomain = computed(() => {
 });
 
 const tabLinks = computed(() => {
+  if (activeDomain.value === 'Professional Intelligence') {
+    return [
+      { label: 'Operating Dashboard', to: '/professional-intelligence' },
+      { label: 'Gates', to: '/gates' },
+      { label: 'Policies', to: '/policies' },
+      { label: 'Runs', to: '/runs' },
+      { label: 'Attestations', to: '/attestations' },
+    ];
+  }
+
   const surfaces = surfacesForDomain(activeDomain.value).slice(0, 6);
   if (activeDomain.value === 'Maps & Analytics') {
     return [
@@ -92,6 +105,7 @@ const tabLinks = computed(() => {
 });
 
 const breadcrumbs = computed(() => {
+  if (route.path.startsWith('/professional-intelligence')) return ['Professional Intelligence OS', 'Operating dashboard'];
   if (route.path.startsWith('/map')) return ['Maps & Analytics', 'OpenStreetMap', 'GAIA world model'];
   if (surface.value) return [surface.value.domain, surface.value.item];
   const fallback = domainSurfaces.find((item) => route.path.startsWith(item.route));

--- a/socioprophet-web/client-vue/src/__tests__/ProfessionalIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/ProfessionalIntelligence.smoke.test.ts
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ProfessionalIntelligence from '../pages/ProfessionalIntelligence.vue';
+
+describe('ProfessionalIntelligence', () => {
+  it('renders the fixture-backed dashboard and boundary notice', () => {
+    const wrapper = mount(ProfessionalIntelligence);
+
+    expect(wrapper.text()).toContain('SocioProphet operating dashboard');
+    expect(wrapper.text()).toContain('Professional Intelligence OS');
+    expect(wrapper.text()).toContain('read-only evidence surface');
+    expect(wrapper.text()).toContain('Fixture-backed dashboard state');
+  });
+
+  it('renders gate status, controls, and source references', () => {
+    const wrapper = mount(ProfessionalIntelligence);
+
+    expect(wrapper.text()).toContain('Gate 4 — integrated demo');
+    expect(wrapper.text()).toContain('Cybernetic controls');
+    expect(wrapper.text()).toContain('mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b');
+  });
+});

--- a/socioprophet-web/client-vue/src/data/professionalIntelligenceControlState.ts
+++ b/socioprophet-web/client-vue/src/data/professionalIntelligenceControlState.ts
@@ -1,0 +1,146 @@
+export type CompletionMetric = {
+  name: string;
+  value: number;
+  note: string;
+};
+
+export type GateState = {
+  name: string;
+  status: 'complete' | 'active' | 'pending';
+  summary: string;
+};
+
+export type CyberneticControl = {
+  name: string;
+  signal: string;
+  action: string;
+};
+
+export type PullRequestState = {
+  repo: string;
+  pr: string;
+  capability: string;
+  status: 'merged' | 'open';
+};
+
+export type ProfessionalIntelligenceControlState = {
+  sourceMode: 'fixture';
+  generatedAt: string;
+  overallAlignment: number;
+  headline: string;
+  lede: string;
+  boundaryNotice: string;
+  sourceRefs: string[];
+  metrics: CompletionMetric[];
+  gates: GateState[];
+  controls: CyberneticControl[];
+  prs: PullRequestState[];
+  completed: string[];
+  nextMoves: string[];
+  integrationRule: string;
+};
+
+export const professionalIntelligenceControlState: ProfessionalIntelligenceControlState = {
+  sourceMode: 'fixture',
+  generatedAt: '2026-05-05T20:40:00-04:00',
+  overallAlignment: 72,
+  headline: 'SocioProphet operating dashboard',
+  lede:
+    'Closed-loop control surface for the Professional Intelligence OS alignment wave: contracts, playbooks, workrooms, policy, obligations, topology, evidence, adoption, runtime controls, and demo readiness.',
+  boundaryNotice:
+    'Fixture-backed dashboard state replayed from mdheller/socioprophet-web. This page renders product-control evidence only; it is not live telemetry and does not authorize runtime, backend, device, or release-management actions.',
+  sourceRefs: [
+    'mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/pages/ProfessionalIntelligence.vue',
+    'mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/data/professionalIntelligenceControlState.ts',
+    'SocioProphet/socioprophet:socioprophet-web/docs/MDHELLER_SOCIOPROPHET_WEB_CONSOLIDATION_AUDIT.md',
+  ],
+  metrics: [
+    { name: 'Architecture spine', value: 42, note: 'Platform manifest, orchestration object, and topology are established.' },
+    { name: 'DelEx governance', value: 48, note: 'Delivery model, control register, and Gate 4 addenda are live.' },
+    { name: 'Platform contracts', value: 50, note: 'Core contracts, fixtures, orchestration, and validators are merged.' },
+    { name: 'Playbooks', value: 35, note: 'Seed InnerSource playbooks validate and feed the demo path.' },
+    { name: 'Workrooms', value: 25, note: 'Professional Workroom contract and fixture are merged.' },
+    { name: 'Governance loops', value: 52, note: 'Policy, obligation, topology, routing, controls, and evidence loops are connected.' },
+    { name: 'Cybernetic controls', value: 54, note: 'Sense/compare/act gates now include a Gate 4 verification runner.' },
+    { name: 'Runtime implementation', value: 48, note: 'Agentplane bundle and platform Gate 4 verifier are merged.' },
+    { name: 'Demo readiness', value: 76, note: 'The demo path is locally verifiable but still needs generated dashboard ingestion.' },
+  ],
+  gates: [
+    {
+      name: 'Gate 1 — alignment docs and seed contracts',
+      status: 'complete',
+      summary: 'Platform, DelEx automation, playbooks, workspace, policy, obligations, topology, and UI definitions are seeded.',
+    },
+    {
+      name: 'Gate 2 — validation fixtures',
+      status: 'complete',
+      summary: 'Platform, DelEx automation, playbooks, workrooms, policy decisions, obligations, search packets, context packs, context queries, routing decisions, guardrails, and ledger records validate.',
+    },
+    {
+      name: 'Gate 3 — recordable demo slice',
+      status: 'complete',
+      summary: 'Agentplane bundle, context/query/search/memory, policy/obligation, routing, guardrail, model-governance, workroom, and evidence/adoption surfaces exist.',
+    },
+    {
+      name: 'Gate 4 — integrated demo',
+      status: 'active',
+      summary: 'The platform orchestration object and local Gate 4 verifier are merged; dashboard state ingestion and board rollup remain.',
+    },
+  ],
+  controls: [
+    { name: 'Repo readiness', signal: 'Missing docs, schema, validation, CI, owner, or integration map.', action: 'Open or block work order until green.' },
+    { name: 'Demo readiness', signal: 'Missing playbook, context, policy, evidence, workroom, route, guardrail, Agentplane, or adoption reference.', action: 'Block demo credit and create corrective issue.' },
+    { name: 'Policy coverage', signal: 'Governed step lacks policy decision.', action: 'Block runtime/demo credit.' },
+    { name: 'Evidence coverage', signal: 'Workflow step lacks evidence reference.', action: 'Fail demo acceptance.' },
+    { name: 'Agent authority', signal: 'Agent lacks tool grant, scope, revocation, or session authority.', action: 'Block agent execution.' },
+    { name: 'Gate 4 verification', signal: 'Gate 4 orchestration lacks required refs or step evidence.', action: 'Fail local verifier and withhold demo acceptance.' },
+  ],
+  prs: [
+    { repo: 'SocioProphet/prophet-platform', pr: '#263', capability: 'Platform contracts', status: 'merged' },
+    { repo: 'SocioProphet/prophet-platform', pr: '#424', capability: 'Gate 4 orchestration', status: 'merged' },
+    { repo: 'SocioProphet/prophet-platform', pr: '#427', capability: 'Gate 4 verifier', status: 'merged' },
+    { repo: 'SocioProphet/delivery-excellence', pr: '#5', capability: 'Control register', status: 'merged' },
+    { repo: 'SocioProphet/delivery-excellence', pr: '#18', capability: 'Gate 4 status', status: 'merged' },
+    { repo: 'SocioProphet/delivery-excellence-automation', pr: '#4', capability: 'Automation schemas', status: 'merged' },
+    { repo: 'SocioProphet/delivery-excellence-innersource', pr: '#5', capability: 'Playbooks', status: 'merged' },
+    { repo: 'SocioProphet/prophet-workspace', pr: '#7', capability: 'Workrooms', status: 'merged' },
+    { repo: 'SocioProphet/policy-fabric', pr: '#33', capability: 'Policy decisions', status: 'merged' },
+    { repo: 'SocioProphet/contractforge', pr: '#3', capability: 'Obligation ledger', status: 'merged' },
+    { repo: 'SocioProphet/agentplane', pr: '#73', capability: 'Workflow bundle', status: 'merged' },
+    { repo: 'SocioProphet/agent-registry', pr: '#6', capability: 'Agent authority', status: 'merged' },
+    { repo: 'SocioProphet/memory-mesh', pr: '#12', capability: 'Context pack', status: 'merged' },
+    { repo: 'SocioProphet/sherlock-search', pr: '#23', capability: 'Search packet', status: 'merged' },
+    { repo: 'SocioProphet/prophet-core-query', pr: '#4', capability: 'Context query', status: 'merged' },
+    { repo: 'SocioProphet/model-router', pr: '#10', capability: 'Routing decisions', status: 'merged' },
+    { repo: 'SocioProphet/guardrail-fabric', pr: '#10', capability: 'Runtime controls', status: 'merged' },
+    { repo: 'SocioProphet/model-governance-ledger', pr: '#10', capability: 'Evidence ledger', status: 'merged' },
+    { repo: 'SocioProphet/sociosphere', pr: '#221', capability: 'Topology', status: 'merged' },
+    { repo: 'SocioProphet/socioprophet', pr: '#300', capability: 'Dashboard definition', status: 'merged' },
+    { repo: 'mdheller/socioprophet-web', pr: '#18', capability: 'Dashboard MVP source replay', status: 'merged' },
+  ],
+  completed: [
+    'Professional Intelligence platform manifest, seed contracts, and Gate 4 orchestration.',
+    'DelEx work item, repo readiness, demo acceptance, and status addenda.',
+    'Validated InnerSource playbooks.',
+    'Validated Professional Workroom fixture.',
+    'Professional Policy Decision schema with allow/review/deny examples.',
+    'ContractForge obligation schema and examples.',
+    'Sociosphere topology registration.',
+    'Agentplane workflow bundle and replayable artifact path.',
+    'Agent Registry tool grants, session authority, and revocation records.',
+    'Memory Mesh context pack and Sherlock search packet.',
+    'Prophet Core Query context query.',
+    'Model Router route decisions and Guardrail Fabric runtime controls.',
+    'Model Governance Ledger route/model/promotion/rollback records.',
+    'Platform Gate 4 local verification runner.',
+  ],
+  nextMoves: [
+    'Generate this dashboard fixture from DelEx register and Prophet Platform verification output.',
+    'Add DelEx board rollup for Gate 4 status.',
+    'Add global-devsecops-intelligence governance/control-plane assessment.',
+    'Extend the platform runner to optionally execute Agentplane host smoke and include its report.',
+    'Promote the local verification report into an operator-facing artifact surface.',
+  ],
+  integrationRule:
+    'A subsystem is not integrated because it is referenced. It is integrated only when it has a contract or manifest entry, a runtime/workflow/validation touchpoint, a governance owner, evidence output or evidence reference, feedback into DelEx controls, and corrective action when telemetry or validation shows drift.',
+};

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -5,6 +5,7 @@ import { domainSurfaces } from './config/domainRoutes';
 import DomainSurfacePage from './pages/DomainSurfacePage.vue';
 import FeedPage from './pages/FeedPage.vue';
 import MapPage from './pages/MapPage.vue';
+import ProfessionalIntelligence from './pages/ProfessionalIntelligence.vue';
 import './styles.css';
 
 const mockedSurfaceRoutes = domainSurfaces
@@ -13,6 +14,7 @@ const mockedSurfaceRoutes = domainSurfaces
 
 const routes = [
   { path: '/', redirect: '/news' },
+  { path: '/professional-intelligence', component: ProfessionalIntelligence },
   { path: '/map', component: MapPage },
   { path: '/feed', component: FeedPage },
   ...mockedSurfaceRoutes,

--- a/socioprophet-web/client-vue/src/pages/ProfessionalIntelligence.vue
+++ b/socioprophet-web/client-vue/src/pages/ProfessionalIntelligence.vue
@@ -1,0 +1,359 @@
+<template>
+  <section class="pi-page" aria-labelledby="pi-title">
+    <header class="pi-hero">
+      <div>
+        <p class="pi-kicker">Professional Intelligence OS · {{ state.sourceMode }}</p>
+        <h1 id="pi-title">{{ state.headline }}</h1>
+        <p class="pi-lede">{{ state.lede }}</p>
+        <p class="pi-generated">Control state generated: {{ state.generatedAt }}</p>
+      </div>
+      <div class="pi-scorecard" aria-label="Overall completion">
+        <span class="pi-score">{{ state.overallAlignment }}%</span>
+        <span class="pi-score-label">overall alignment</span>
+      </div>
+    </header>
+
+    <section class="pi-card pi-boundary" aria-label="Professional Intelligence boundary">
+      <span class="pi-pill">read-only evidence surface</span>
+      <p>{{ state.boundaryNotice }}</p>
+    </section>
+
+    <section class="pi-grid pi-grid--metrics" aria-label="Workstream completion">
+      <article v-for="metric in state.metrics" :key="metric.name" class="pi-card pi-metric">
+        <div class="pi-metric-head">
+          <span>{{ metric.name }}</span>
+          <strong>{{ metric.value }}%</strong>
+        </div>
+        <div class="pi-bar" aria-hidden="true">
+          <span :style="{ width: `${metric.value}%` }" />
+        </div>
+        <p>{{ metric.note }}</p>
+      </article>
+    </section>
+
+    <section class="pi-grid pi-grid--two">
+      <article class="pi-card">
+        <h2>Gate status</h2>
+        <ol class="pi-gates">
+          <li v-for="gate in state.gates" :key="gate.name" :class="`pi-gate pi-gate--${gate.status}`">
+            <span class="pi-gate-status">{{ gate.status }}</span>
+            <div>
+              <strong>{{ gate.name }}</strong>
+              <p>{{ gate.summary }}</p>
+            </div>
+          </li>
+        </ol>
+      </article>
+
+      <article class="pi-card">
+        <h2>Cybernetic controls</h2>
+        <div class="pi-control-list">
+          <div v-for="control in state.controls" :key="control.name" class="pi-control">
+            <strong>{{ control.name }}</strong>
+            <p><b>Sense:</b> {{ control.signal }}</p>
+            <p><b>Act:</b> {{ control.action }}</p>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="pi-card">
+      <div class="pi-section-head">
+        <div>
+          <h2>Active PR wave</h2>
+          <p>Fixture-backed work records anchoring the replayed alignment wave.</p>
+        </div>
+        <span class="pi-pill">{{ state.prs.length }} tracked PRs</span>
+      </div>
+      <div class="pi-table-wrap">
+        <table class="pi-table">
+          <thead>
+            <tr>
+              <th>Repo</th>
+              <th>PR</th>
+              <th>Capability</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in state.prs" :key="`${item.repo}-${item.pr}`">
+              <td>{{ item.repo }}</td>
+              <td>{{ item.pr }}</td>
+              <td>{{ item.capability }}</td>
+              <td><span :class="`pi-status pi-status--${item.status}`">{{ item.status }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="pi-grid pi-grid--two">
+      <article class="pi-card">
+        <h2>Completed controls</h2>
+        <ul class="pi-list">
+          <li v-for="item in state.completed" :key="item">{{ item }}</li>
+        </ul>
+      </article>
+      <article class="pi-card">
+        <h2>Next control moves</h2>
+        <ul class="pi-list">
+          <li v-for="item in state.nextMoves" :key="item">{{ item }}</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="pi-grid pi-grid--two">
+      <article class="pi-card pi-callout">
+        <h2>Integration rule</h2>
+        <p>{{ state.integrationRule }}</p>
+      </article>
+      <article class="pi-card">
+        <h2>Source refs</h2>
+        <ul class="pi-list pi-source-list">
+          <li v-for="ref in state.sourceRefs" :key="ref">{{ ref }}</li>
+        </ul>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { professionalIntelligenceControlState as state } from '../data/professionalIntelligenceControlState';
+</script>
+
+<style scoped>
+.pi-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: var(--text, #f4f4f4);
+}
+
+.pi-hero,
+.pi-card {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  background: rgba(20, 24, 31, 0.82);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
+}
+
+.pi-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.5rem;
+}
+
+.pi-kicker {
+  margin: 0 0 0.4rem;
+  color: var(--accent, #78a9ff);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.7rem;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+}
+
+h2 {
+  margin-bottom: 0.85rem;
+  font-size: 1.15rem;
+}
+
+.pi-lede,
+.pi-generated {
+  max-width: 760px;
+  color: rgba(255, 255, 255, 0.72);
+  line-height: 1.55;
+}
+
+.pi-generated {
+  margin: 0.7rem 0 0;
+  font-size: 0.82rem;
+}
+
+.pi-scorecard {
+  min-width: 180px;
+  align-self: stretch;
+  display: grid;
+  place-content: center;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(120, 169, 255, 0.22), rgba(36, 161, 72, 0.18));
+  text-align: center;
+}
+
+.pi-score {
+  display: block;
+  font-size: 3.2rem;
+  font-weight: 800;
+}
+
+.pi-score-label {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pi-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.pi-grid--metrics {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.pi-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.pi-card {
+  padding: 1rem;
+}
+
+.pi-boundary {
+  border-color: rgba(241, 194, 27, 0.45);
+  background: rgba(241, 194, 27, 0.08);
+}
+
+.pi-metric-head,
+.pi-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pi-metric strong {
+  font-size: 1.35rem;
+}
+
+.pi-metric p,
+.pi-control p,
+.pi-section-head p,
+.pi-callout p,
+.pi-gate p,
+.pi-boundary p,
+.pi-source-list {
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.pi-bar {
+  height: 0.55rem;
+  margin: 0.75rem 0;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.pi-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent, #78a9ff);
+}
+
+.pi-gates,
+.pi-list {
+  padding-left: 1.2rem;
+}
+
+.pi-gate {
+  margin-bottom: 0.9rem;
+}
+
+.pi-gate-status,
+.pi-status,
+.pi-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.18rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.pi-gate-status,
+.pi-pill {
+  margin-bottom: 0.35rem;
+  background: rgba(120, 169, 255, 0.15);
+  color: var(--accent, #78a9ff);
+}
+
+.pi-gate--complete .pi-gate-status,
+.pi-status--merged {
+  background: rgba(36, 161, 72, 0.18);
+  color: #42be65;
+}
+
+.pi-gate--active .pi-gate-status,
+.pi-status--open {
+  background: rgba(241, 194, 27, 0.18);
+  color: #f1c21b;
+}
+
+.pi-gate--pending .pi-gate-status {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.pi-control {
+  padding: 0.8rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.pi-control:last-child {
+  border-bottom: 0;
+}
+
+.pi-table-wrap {
+  overflow-x: auto;
+}
+
+.pi-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.pi-table th,
+.pi-table td {
+  padding: 0.7rem 0.55rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  text-align: left;
+}
+
+.pi-table th {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pi-source-list {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+  .pi-hero {
+    flex-direction: column;
+  }
+
+  .pi-scorecard {
+    min-height: 150px;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

Replays the Professional Intelligence dashboard from `mdheller/socioprophet-web` into the canonical org Vue shell under `socioprophet-web/client-vue`.

## What changed

- Adds `src/pages/ProfessionalIntelligence.vue` as a fixture-backed, read-only dashboard surface.
- Adds typed dashboard state at `src/data/professionalIntelligenceControlState.ts`.
- Adds source fixture JSON under `fixtures/professional-intelligence/dashboard-control-state.json`.
- Adds `scripts/generate-pi-dashboard-state.mjs` for regenerating the typed state module from the fixture/control-state export shape.
- Adds `/professional-intelligence` route wiring.
- Adds top-nav, left-rail, breadcrumbs, and tab-row affordances for Professional Intelligence.
- Adds `ProfessionalIntelligence.smoke.test.ts` covering dashboard render, boundary notice, gate status, controls, and source refs.

## Boundary posture

This PR intentionally keeps the surface fixture-backed and read-only. It does not claim live telemetry, backend authority, device authority, release-management authority, or real runtime execution. The page renders product-control evidence and source references only.

## Source replay refs

- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/pages/ProfessionalIntelligence.vue`
- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/data/professionalIntelligenceControlState.ts`
- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:scripts/generate-pi-dashboard-state.mjs`

## Validation

Not run locally in this connector session. Expected CI/local gate:

```bash
cd socioprophet-web/client-vue
npm run typecheck
npm test
npm run build
```

## Next tranche

Replay SourceOS lifecycle and NLBoot evidence dashboards into `client-vue` with the same read-only/evidence-only posture.