### PR TITLE
feat(client-vue): replay mock adapter seams

### DIFF
--- a/socioprophet-web/client-vue/src/App.vue
+++ b/socioprophet-web/client-vue/src/App.vue
@@ -6,6 +6,7 @@
         <RouterLink to="/news">News &amp; Events</RouterLink>
         <RouterLink to="/professional-intelligence">Professional Intelligence</RouterLink>
         <RouterLink to="/control-plane">SourceOS</RouterLink>
+        <RouterLink to="/journal">Adapter Seams</RouterLink>
         <RouterLink to="/law/international-law">Law &amp; Regulation</RouterLink>
         <RouterLink to="/people/search">People &amp; Society</RouterLink>
         <RouterLink to="/economy/macro-economics">Economy &amp; Industry</RouterLink>
@@ -29,6 +30,8 @@
         <RouterLink to="/control-plane" title="SourceOS Control Plane">CP</RouterLink>
         <RouterLink to="/nlboot" title="NLBoot Evidence">NB</RouterLink>
         <RouterLink to="/reader" title="Reader">▤</RouterLink>
+        <RouterLink to="/journal" title="Journal">J</RouterLink>
+        <RouterLink to="/code" title="Code Search">CS</RouterLink>
         <RouterLink to="/map" title="Maps">⌖</RouterLink>
         <RouterLink to="/people/search" title="People">◫</RouterLink>
         <RouterLink to="/economy/macro-economics" title="Economy">◔</RouterLink>
@@ -82,6 +85,8 @@ const activeDomain = computed(() => {
   if (route.path.startsWith('/professional-intelligence')) return 'Professional Intelligence';
   if (route.path.startsWith('/control-plane')) return 'SourceOS Lifecycle';
   if (route.path.startsWith('/nlboot')) return 'SourceOS Lifecycle';
+  if (route.path.startsWith('/journal')) return 'Adapter Seams';
+  if (route.path.startsWith('/code')) return 'Adapter Seams';
   if (route.path.startsWith('/map')) return 'Maps & Analytics';
   if (surface.value?.domain) return surface.value.domain;
   if (route.path.startsWith('/analytics')) return 'Maps & Analytics';
@@ -108,6 +113,14 @@ const tabLinks = computed(() => {
     ];
   }
 
+  if (activeDomain.value === 'Adapter Seams') {
+    return [
+      { label: 'Journal', to: '/journal' },
+      { label: 'Code Search', to: '/code' },
+      { label: 'Reader', to: '/reader' },
+    ];
+  }
+
   const surfaces = surfacesForDomain(activeDomain.value).slice(0, 6);
   if (activeDomain.value === 'Maps & Analytics') {
     return [
@@ -122,6 +135,8 @@ const breadcrumbs = computed(() => {
   if (route.path.startsWith('/professional-intelligence')) return ['Professional Intelligence OS', 'Operating dashboard'];
   if (route.path.startsWith('/control-plane')) return ['SourceOS Lifecycle', 'Control-plane evidence'];
   if (route.path.startsWith('/nlboot')) return ['SourceOS Lifecycle', 'NLBoot evidence'];
+  if (route.path.startsWith('/journal')) return ['Adapter Seams', 'Journal stream'];
+  if (route.path.startsWith('/code')) return ['Adapter Seams', 'Code search'];
   if (route.path.startsWith('/map')) return ['Maps & Analytics', 'OpenStreetMap', 'GAIA world model'];
   if (surface.value) return [surface.value.domain, surface.value.item];
   const fallback = domainSurfaces.find((item) => route.path.startsWith(item.route));

--- a/socioprophet-web/client-vue/src/__tests__/MockAdapterSeams.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MockAdapterSeams.smoke.test.ts
@@ -1,0 +1,33 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import CodeSearch from '../pages/CodeSearch.vue';
+import Journal from '../pages/Journal.vue';
+
+describe('Journal mock adapter seam', () => {
+  it('renders the mock-only Journal boundary and fixture event stream', async () => {
+    const wrapper = mount(Journal);
+    await flushPromises();
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Journal stream');
+    expect(wrapper.text()).toContain('mock only');
+    expect(wrapper.text()).toContain('No writeback, authorization, or backend stream is declared here');
+  });
+});
+
+describe('Code Search mock adapter seam', () => {
+  it('renders the mock-only Code Search boundary and fixture results', async () => {
+    const wrapper = mount(CodeSearch);
+
+    expect(wrapper.text()).toContain('Code Search');
+    expect(wrapper.text()).toContain('mock only');
+    expect(wrapper.text()).toContain('does not query GitHub, Sourcegraph, or any live code index');
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('socioprophet:socioprophet-web/client-vue/src/main.ts');
+    expect(wrapper.text()).toContain('Mock result only');
+  });
+});

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -2,9 +2,11 @@ import { createApp } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import App from './App.vue';
 import { domainSurfaces } from './config/domainRoutes';
+import CodeSearch from './pages/CodeSearch.vue';
 import ControlPlaneLifecycle from './pages/ControlPlaneLifecycle.vue';
 import DomainSurfacePage from './pages/DomainSurfacePage.vue';
 import FeedPage from './pages/FeedPage.vue';
+import Journal from './pages/Journal.vue';
 import MapPage from './pages/MapPage.vue';
 import NLBootEvidence from './pages/NLBootEvidence.vue';
 import ProfessionalIntelligence from './pages/ProfessionalIntelligence.vue';
@@ -21,6 +23,8 @@ const routes = [
   { path: '/control-plane', component: ControlPlaneLifecycle },
   { path: '/nlboot', component: NLBootEvidence },
   { path: '/reader', component: Reader },
+  { path: '/journal', component: Journal },
+  { path: '/code', component: CodeSearch },
   { path: '/map', component: MapPage },
   { path: '/feed', component: FeedPage },
   ...mockedSurfaceRoutes,

--- a/socioprophet-web/client-vue/src/pages/CodeSearch.vue
+++ b/socioprophet-web/client-vue/src/pages/CodeSearch.vue
@@ -1,0 +1,62 @@
+<template>
+  <section class="adapter-page" aria-labelledby="code-search-title">
+    <header class="adapter-hero">
+      <div>
+        <p class="adapter-kicker">Code Search · TriRPC fixture seam</p>
+        <h1 id="code-search-title">Code Search</h1>
+        <p>
+          Fixture-backed code-search surface. This page exercises the UI contract only and does not
+          query GitHub, Sourcegraph, or any live code index.
+        </p>
+      </div>
+      <span class="adapter-pill adapter-pill--warn">mock only</span>
+    </header>
+
+    <section class="adapter-card search-row">
+      <input v-model="query" placeholder="query" @keyup.enter="run" />
+      <button type="button" @click="run">Search</button>
+    </section>
+
+    <section class="adapter-card adapter-boundary">
+      <strong>Boundary</strong>
+      <p>Results come from the local mock adapter. No repository indexing, credential access, or remote search is declared here.</p>
+    </section>
+
+    <section class="adapter-grid">
+      <article v-for="result in results" :key="result.repo + result.path" class="adapter-card">
+        <strong>{{ result.repo }}:{{ result.path }}</strong>
+        <p>{{ result.preview }}</p>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { triRpc, type CodeSearchResult } from '../services/triRpc';
+
+const query = ref('main');
+const results = ref<CodeSearchResult[]>([]);
+
+async function run() {
+  const response = await triRpc.code.search({ query: query.value });
+  results.value = response.results || [];
+}
+</script>
+
+<style scoped>
+.adapter-page { display: grid; gap: 1rem; color: var(--text, #f4f4f4); }
+.adapter-hero, .adapter-card { border: 1px solid rgba(255,255,255,.14); border-radius: 18px; background: rgba(20,24,31,.82); box-shadow: 0 18px 48px rgba(0,0,0,.22); }
+.adapter-hero { display: flex; justify-content: space-between; gap: 1rem; padding: 1.5rem; }
+.adapter-kicker { margin: 0 0 .4rem; color: var(--accent, #78a9ff); font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+h1, p { margin-top: 0; }
+p { color: rgba(255,255,255,.70); }
+.adapter-card { padding: 1rem; }
+.adapter-boundary { border-color: rgba(241,194,27,.45); background: rgba(241,194,27,.08); }
+.adapter-pill { display: inline-flex; align-items: center; height: fit-content; border-radius: 999px; padding: .2rem .55rem; font-size: .72rem; font-weight: 800; text-transform: uppercase; background: rgba(120,169,255,.15); color: var(--accent, #78a9ff); }
+.adapter-pill--warn { background: rgba(241,194,27,.18); color: #f1c21b; }
+.adapter-grid { display: grid; gap: 1rem; }
+.search-row { display: flex; gap: .75rem; }
+input { flex: 1; min-width: 0; border: 1px solid rgba(255,255,255,.24); border-radius: 12px; padding: .75rem; background: rgba(255,255,255,.08); color: var(--text, #f4f4f4); }
+button { border: 0; border-radius: 12px; padding: .75rem 1rem; background: var(--accent, #78a9ff); color: #06111f; font-weight: 800; cursor: pointer; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/Journal.vue
+++ b/socioprophet-web/client-vue/src/pages/Journal.vue
@@ -1,0 +1,72 @@
+<template>
+  <section class="adapter-page" aria-labelledby="journal-title">
+    <header class="adapter-hero">
+      <div>
+        <p class="adapter-kicker">Journal · TriRPC fixture seam</p>
+        <h1 id="journal-title">Journal stream</h1>
+        <p>
+          Fixture-backed journal event stream. Set <code>VITE_MOCK=1</code> for local demo mode.
+          This page does not connect to a live TriRPC backend.
+        </p>
+      </div>
+      <span class="adapter-pill adapter-pill--warn">mock only</span>
+    </header>
+
+    <section class="adapter-card adapter-boundary">
+      <strong>Boundary</strong>
+      <p>Events are generated from the local mock adapter. No writeback, authorization, or backend stream is declared here.</p>
+    </section>
+
+    <section class="adapter-grid">
+      <article v-for="event in events" :key="event.ts + event.kind" class="adapter-card">
+        <div class="adapter-row">
+          <strong>{{ event.kind }}</strong>
+          <span>{{ event.ts }}</span>
+        </div>
+        <p>{{ event.space }} / {{ event.ns }} · {{ event.actor.id }}</p>
+        <pre>{{ event.body }}</pre>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { triRpc, type EventEnvelope } from '../services/triRpc';
+
+const events = ref<EventEnvelope[]>([]);
+
+onMounted(async () => {
+  try {
+    for await (const event of triRpc.journal.subscribe()) {
+      events.value.push(event);
+      if (events.value.length > 100) events.value.shift();
+    }
+  } catch (error) {
+    events.value.push({
+      ts: new Date().toISOString(),
+      space: 'client-vue',
+      ns: 'journal',
+      actor: { id: 'adapter-boundary', pk: 'none' },
+      kind: 'adapter.unavailable',
+      body: { error: error instanceof Error ? error.message : String(error) },
+    });
+  }
+});
+</script>
+
+<style scoped>
+.adapter-page { display: grid; gap: 1rem; color: var(--text, #f4f4f4); }
+.adapter-hero, .adapter-card { border: 1px solid rgba(255,255,255,.14); border-radius: 18px; background: rgba(20,24,31,.82); box-shadow: 0 18px 48px rgba(0,0,0,.22); }
+.adapter-hero { display: flex; justify-content: space-between; gap: 1rem; padding: 1.5rem; }
+.adapter-kicker { margin: 0 0 .4rem; color: var(--accent, #78a9ff); font-size: .78rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+h1, p { margin-top: 0; }
+p, pre, code, .adapter-row span { color: rgba(255,255,255,.70); }
+.adapter-card { padding: 1rem; }
+.adapter-boundary { border-color: rgba(241,194,27,.45); background: rgba(241,194,27,.08); }
+.adapter-pill { display: inline-flex; align-items: center; height: fit-content; border-radius: 999px; padding: .2rem .55rem; font-size: .72rem; font-weight: 800; text-transform: uppercase; background: rgba(120,169,255,.15); color: var(--accent, #78a9ff); }
+.adapter-pill--warn { background: rgba(241,194,27,.18); color: #f1c21b; }
+.adapter-grid { display: grid; gap: 1rem; }
+.adapter-row { display: flex; justify-content: space-between; gap: 1rem; }
+pre { white-space: pre-wrap; overflow-wrap: anywhere; padding: .75rem; border-radius: 12px; background: rgba(255,255,255,.06); }
+</style>

--- a/socioprophet-web/client-vue/src/services/triRpc.ts
+++ b/socioprophet-web/client-vue/src/services/triRpc.ts
@@ -1,0 +1,79 @@
+export type EventEnvelope = {
+  ts: string;
+  space: string;
+  ns: string;
+  actor: { id: string; pk: string };
+  kind: string;
+  body: Record<string, unknown>;
+};
+
+export type CodeSearchResult = {
+  repo: string;
+  path: string;
+  preview: string;
+};
+
+const mockEnabled = (import.meta as any).env.VITE_MOCK === '1' || (import.meta as any).env.MODE === 'test';
+const now = () => new Date().toISOString();
+
+const mockEvents: EventEnvelope[] = [
+  {
+    ts: now(),
+    space: 'twin',
+    ns: 'default',
+    actor: { id: 'usr', pk: 'ed25519:fixture' },
+    kind: 'ai.message',
+    body: { role: 'user', text: 'Hello from fixture-backed TriRPC.' },
+  },
+  {
+    ts: now(),
+    space: 'control',
+    ns: 'client-vue',
+    actor: { id: 'system', pk: 'ed25519:fixture' },
+    kind: 'boundary.notice',
+    body: { text: 'Mock-only adapter seam. No live backend is wired here.' },
+  },
+];
+
+async function* stream<T>(items: T[], delayMs = 25): AsyncGenerator<T> {
+  for (const item of items) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    yield item;
+  }
+}
+
+function requireMock() {
+  if (!mockEnabled) {
+    throw new Error('TriRPC live adapter is not wired. Set VITE_MOCK=1 for fixture mode.');
+  }
+}
+
+export const triRpc = {
+  journal: {
+    async append(event: EventEnvelope) {
+      requireMock();
+      mockEvents.push(event);
+      return { feed: 'fixture-feed-0', offset: mockEvents.length, sig: 'fixture-signature' };
+    },
+    async snapshot() {
+      requireMock();
+      return { entries: mockEvents.slice(-50) };
+    },
+    subscribe() {
+      requireMock();
+      return stream(mockEvents, 25);
+    },
+  },
+  code: {
+    async search(params: { query: string }) {
+      requireMock();
+      const query = params.query || 'main';
+      const results: CodeSearchResult[] = [
+        { repo: 'socioprophet', path: 'socioprophet-web/client-vue/src/main.ts', preview: `Route registry mention for ${query}` },
+        { repo: 'prophet-platform', path: 'apps/osm-map-api/README.md', preview: 'Fixture-backed API contract reference.' },
+        { repo: 'memory-mesh', path: 'docs/context-pack.md', preview: 'Mock result only; no live code index is queried.' },
+      ];
+      return { results };
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Replays the remaining small adapter seams from `mdheller/socioprophet-web` into the canonical org Vue shell as explicit mock-only surfaces.

## What changed

- Adds `src/services/triRpc.ts` as a typed mock TriRPC adapter seam.
- Adds `src/pages/Journal.vue` for fixture-backed journal events.
- Adds `src/pages/CodeSearch.vue` for fixture-backed code-search UI.
- Wires `/journal` and `/code` routes.
- Adds navigation affordances for Adapter Seams.
- Adds `MockAdapterSeams.smoke.test.ts` asserting mock boundary language and fixture results.

## Boundary posture

This PR intentionally keeps the adapter seams mock-only. It does not wire live TriRPC, GitHub search, Sourcegraph, backend event streams, writeback, authorization, credential access, or repository indexing. The mock adapter fails closed outside mock/test mode.

## Source replay refs

- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/services/triRpc.ts`
- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/pages/Journal.vue`
- `mdheller/socioprophet-web@67cff37b3da44395757c9095e1cbc081ca73333b:src/pages/CodeSearch.vue`

## Validation

Not run locally in this connector session. Expected CI/local gate:

```bash
cd socioprophet-web/client-vue
npm run typecheck
npm test
npm run build
```

## Next tranche

Transfer design docs and scoped app-shell operating instructions, then prepare mdheller issue/PR retirement notes.