### PR TITLE
feat(client-vue): add route registry and nav maturity labels

### DIFF
--- a/socioprophet-web/client-vue/src/App.vue
+++ b/socioprophet-web/client-vue/src/App.vue
@@ -3,17 +3,7 @@
     <header class="sp-topbar">
       <RouterLink class="sp-brand" to="/news">SocioProphet</RouterLink>
       <nav class="sp-domain-nav" aria-label="Primary domains">
-        <RouterLink to="/news">News &amp; Events</RouterLink>
-        <RouterLink to="/professional-intelligence">Professional Intelligence</RouterLink>
-        <RouterLink to="/control-plane">SourceOS</RouterLink>
-        <RouterLink to="/journal">Adapter Seams</RouterLink>
-        <RouterLink to="/law/international-law">Law &amp; Regulation</RouterLink>
-        <RouterLink to="/people/search">People &amp; Society</RouterLink>
-        <RouterLink to="/economy/macro-economics">Economy &amp; Industry</RouterLink>
-        <RouterLink to="/markets/indices-funds">Capital &amp; Markets</RouterLink>
-        <RouterLink to="/weather/forecast">Weather &amp; Resources</RouterLink>
-        <RouterLink to="/map">Maps</RouterLink>
-        <RouterLink to="/feed">Feed</RouterLink>
+        <RouterLink v-for="item in topRoutes" :key="item.path" :to="item.path">{{ item.label }}</RouterLink>
       </nav>
       <div class="sp-profile-indicator" aria-hidden="true" />
     </header>
@@ -25,20 +15,14 @@
 
     <div class="sp-workspace">
       <aside class="sp-left-rail" aria-label="Workspace rail">
-        <RouterLink to="/news" title="News">☷</RouterLink>
-        <RouterLink to="/professional-intelligence" title="Professional Intelligence">PI</RouterLink>
-        <RouterLink to="/control-plane" title="SourceOS Control Plane">CP</RouterLink>
-        <RouterLink to="/nlboot" title="NLBoot Evidence">NB</RouterLink>
-        <RouterLink to="/reader" title="Reader">▤</RouterLink>
-        <RouterLink to="/journal" title="Journal">J</RouterLink>
-        <RouterLink to="/code" title="Code Search">CS</RouterLink>
-        <RouterLink to="/map" title="Maps">⌖</RouterLink>
-        <RouterLink to="/people/search" title="People">◫</RouterLink>
-        <RouterLink to="/economy/macro-economics" title="Economy">◔</RouterLink>
-        <RouterLink to="/analytics" title="Analytics">⌁</RouterLink>
-        <RouterLink to="/markets/indices-funds" title="Markets">▥</RouterLink>
-        <RouterLink to="/gates" title="Gates">◉</RouterLink>
-        <RouterLink to="/settings" title="Settings">⚙</RouterLink>
+        <RouterLink
+          v-for="item in railRoutes"
+          :key="item.path"
+          :to="item.path"
+          :title="`${item.label} · ${item.maturity} · ${item.stateMode}`"
+        >
+          {{ item.railLabel || item.label.slice(0, 2) }}
+        </RouterLink>
       </aside>
 
       <section class="sp-stage">
@@ -46,6 +30,9 @@
           <span v-for="(crumb, index) in breadcrumbs" :key="`${crumb}-${index}`">
             <span>{{ crumb }}</span>
             <span v-if="index < breadcrumbs.length - 1" class="sp-crumb-separator">/</span>
+          </span>
+          <span v-if="currentRouteEntry" class="sp-route-badge">
+            {{ currentRouteEntry.maturity }} · {{ currentRouteEntry.stateMode }}
           </span>
         </div>
         <RouterView />
@@ -74,52 +61,39 @@ import { computed } from 'vue';
 import { RouterLink, RouterView, useRoute } from 'vue-router';
 import RuntimeAdapterStatusBadge from './components/RuntimeAdapterStatusBadge.vue';
 import { domainSurfaces, surfaceForRoute, surfacesForDomain } from './config/domainRoutes';
+import {
+  entriesForDomain,
+  leftRailRoutes,
+  registryEntryForPath,
+  topNavRoutes,
+} from './config/routeRegistry';
 import { getRuntimeFeature } from './runtime-adapters';
 import { runtimeFeatureIdsForPath } from './runtime-adapters/routeRuntimeFeatures';
 import type { RuntimeAdapterFeature } from './runtime-adapters';
 
 const route = useRoute();
 
+const topRoutes = topNavRoutes();
+const railRoutes = leftRailRoutes();
+
+const currentRouteEntry = computed(() => registryEntryForPath(route.path));
 const surface = computed(() => surfaceForRoute(route.path));
 const activeDomain = computed(() => {
-  if (route.path.startsWith('/professional-intelligence')) return 'Professional Intelligence';
-  if (route.path.startsWith('/control-plane')) return 'SourceOS Lifecycle';
-  if (route.path.startsWith('/nlboot')) return 'SourceOS Lifecycle';
-  if (route.path.startsWith('/journal')) return 'Adapter Seams';
-  if (route.path.startsWith('/code')) return 'Adapter Seams';
-  if (route.path.startsWith('/map')) return 'Maps & Analytics';
+  if (currentRouteEntry.value?.domain) return currentRouteEntry.value.domain;
   if (surface.value?.domain) return surface.value.domain;
   if (route.path.startsWith('/analytics')) return 'Maps & Analytics';
   return 'News & Events';
 });
 
 const tabLinks = computed(() => {
-  if (activeDomain.value === 'Professional Intelligence') {
-    return [
-      { label: 'Operating Dashboard', to: '/professional-intelligence' },
-      { label: 'Gates', to: '/gates' },
-      { label: 'Policies', to: '/policies' },
-      { label: 'Runs', to: '/runs' },
-      { label: 'Attestations', to: '/attestations' },
-    ];
-  }
+  if (currentRouteEntry.value?.tabs?.length) return currentRouteEntry.value.tabs;
 
-  if (activeDomain.value === 'SourceOS Lifecycle') {
-    return [
-      { label: 'Lifecycle Control', to: '/control-plane' },
-      { label: 'NLBoot Evidence', to: '/nlboot' },
-      { label: 'Gates', to: '/gates' },
-      { label: 'Attestations', to: '/attestations' },
-    ];
-  }
+  const registered = entriesForDomain(activeDomain.value)
+    .filter((entry) => entry.navTier !== 'hidden')
+    .slice(0, 6)
+    .map((entry) => ({ label: entry.label, to: entry.path }));
 
-  if (activeDomain.value === 'Adapter Seams') {
-    return [
-      { label: 'Journal', to: '/journal' },
-      { label: 'Code Search', to: '/code' },
-      { label: 'Reader', to: '/reader' },
-    ];
-  }
+  if (registered.length > 0) return registered;
 
   const surfaces = surfacesForDomain(activeDomain.value).slice(0, 6);
   if (activeDomain.value === 'Maps & Analytics') {
@@ -132,12 +106,7 @@ const tabLinks = computed(() => {
 });
 
 const breadcrumbs = computed(() => {
-  if (route.path.startsWith('/professional-intelligence')) return ['Professional Intelligence OS', 'Operating dashboard'];
-  if (route.path.startsWith('/control-plane')) return ['SourceOS Lifecycle', 'Control-plane evidence'];
-  if (route.path.startsWith('/nlboot')) return ['SourceOS Lifecycle', 'NLBoot evidence'];
-  if (route.path.startsWith('/journal')) return ['Adapter Seams', 'Journal stream'];
-  if (route.path.startsWith('/code')) return ['Adapter Seams', 'Code search'];
-  if (route.path.startsWith('/map')) return ['Maps & Analytics', 'OpenStreetMap', 'GAIA world model'];
+  if (currentRouteEntry.value?.breadcrumbs?.length) return currentRouteEntry.value.breadcrumbs;
   if (surface.value) return [surface.value.domain, surface.value.item];
   const fallback = domainSurfaces.find((item) => route.path.startsWith(item.route));
   if (fallback) return [fallback.domain, fallback.item];
@@ -150,3 +119,16 @@ const activeRuntimeFeatures = computed<RuntimeAdapterFeature[]>(() => {
     .filter((feature): feature is RuntimeAdapterFeature => Boolean(feature));
 });
 </script>
+
+<style scoped>
+.sp-route-badge {
+  margin-left: auto;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+</style>

--- a/socioprophet-web/client-vue/src/__tests__/routeRegistry.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/routeRegistry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { leftRailRoutes, registryEntryForPath, routeRegistry, topNavRoutes } from '../config/routeRegistry';
+
+describe('routeRegistry', () => {
+  it('has unique route paths', () => {
+    const paths = routeRegistry.map((entry) => entry.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('keeps experimental adapter seams out of the top nav', () => {
+    const topPaths = topNavRoutes().map((entry) => entry.path);
+
+    expect(topPaths).not.toContain('/journal');
+    expect(topPaths).not.toContain('/code');
+    expect(topPaths).not.toContain('/nlboot');
+    expect(topPaths).not.toContain('/reader');
+  });
+
+  it('keeps core product entry points in top nav', () => {
+    const topPaths = topNavRoutes().map((entry) => entry.path);
+
+    expect(topPaths).toContain('/map');
+    expect(topPaths).toContain('/professional-intelligence');
+    expect(topPaths).toContain('/control-plane');
+    expect(topPaths).toContain('/news');
+  });
+
+  it('keeps operator shortcuts in the left rail', () => {
+    const railPaths = leftRailRoutes().map((entry) => entry.path);
+
+    expect(railPaths).toContain('/journal');
+    expect(railPaths).toContain('/code');
+    expect(railPaths).toContain('/reader');
+    expect(railPaths).toContain('/nlboot');
+  });
+
+  it('resolves entries by exact path and child path', () => {
+    expect(registryEntryForPath('/map')?.maturity).toBe('L4');
+    expect(registryEntryForPath('/professional-intelligence')?.stateMode).toBe('fixture');
+    expect(registryEntryForPath('/control-plane/device/demo')?.domain).toBe('SourceOS Lifecycle');
+  });
+});

--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -1,0 +1,255 @@
+export type RouteMaturity = 'L0' | 'L1' | 'L2' | 'L3' | 'L4' | 'L5';
+export type RouteStateMode = 'design' | 'fixture' | 'mock-adapter' | 'live-fallback' | 'live-only' | 'taxonomy';
+export type NavTier = 'top' | 'left-rail' | 'tab-only' | 'hidden';
+
+export type RouteRegistryEntry = {
+  path: string;
+  label: string;
+  domain: string;
+  maturity: RouteMaturity;
+  stateMode: RouteStateMode;
+  navTier: NavTier;
+  userJob: string;
+  ownerPlane: string;
+  boundary: string;
+  primaryObject: string;
+  breadcrumbs: string[];
+  railLabel?: string;
+  tabs?: Array<{ label: string; to: string }>;
+};
+
+export const routeRegistry: RouteRegistryEntry[] = [
+  {
+    path: '/news',
+    label: 'News & Events',
+    domain: 'News & Events',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the news and event intelligence taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live feed surface.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['News & Events'],
+    railLabel: '☷',
+  },
+  {
+    path: '/map',
+    label: 'Maps',
+    domain: 'Maps & Analytics',
+    maturity: 'L4',
+    stateMode: 'live-fallback',
+    navTier: 'top',
+    userJob: 'Review GAIA/OpenStreetMap world-model evidence and fallback posture.',
+    ownerPlane: 'Prophet Platform OSM Map API + client-vue shell',
+    boundary: 'Live API or deterministic demo fallback; no production tile serving or safety-critical navigation.',
+    primaryObject: 'map workbench',
+    breadcrumbs: ['Maps & Analytics', 'OpenStreetMap', 'GAIA world model'],
+    railLabel: '⌖',
+    tabs: [{ label: 'Map Workbench', to: '/map' }],
+  },
+  {
+    path: '/professional-intelligence',
+    label: 'Professional Intelligence',
+    domain: 'Professional Intelligence',
+    maturity: 'L2',
+    stateMode: 'fixture',
+    navTier: 'top',
+    userJob: 'Review operating alignment, gates, controls, and replayed evidence posture.',
+    ownerPlane: 'client-vue product-control fixture; future live source in Prophet Platform/DelEx',
+    boundary: 'Fixture-backed evidence surface; no live telemetry or runtime authority.',
+    primaryObject: 'operating dashboard state',
+    breadcrumbs: ['Professional Intelligence OS', 'Operating dashboard'],
+    railLabel: 'PI',
+    tabs: [
+      { label: 'Operating Dashboard', to: '/professional-intelligence' },
+      { label: 'Gates', to: '/gates' },
+      { label: 'Policies', to: '/policies' },
+      { label: 'Runs', to: '/runs' },
+      { label: 'Attestations', to: '/attestations' },
+    ],
+  },
+  {
+    path: '/control-plane',
+    label: 'SourceOS',
+    domain: 'SourceOS Lifecycle',
+    maturity: 'L2',
+    stateMode: 'fixture',
+    navTier: 'top',
+    userJob: 'Review SourceOS ReleaseSet and BootReleaseSet lifecycle posture.',
+    ownerPlane: 'client-vue evidence surface; contracts owned by SourceOS/NLBoot repos',
+    boundary: 'Evidence-only; no enrollment, device assignment, disk write, reboot, or host mutation.',
+    primaryObject: 'lifecycle evidence state',
+    breadcrumbs: ['SourceOS Lifecycle', 'Control-plane evidence'],
+    railLabel: 'CP',
+    tabs: [
+      { label: 'Lifecycle Control', to: '/control-plane' },
+      { label: 'NLBoot Evidence', to: '/nlboot' },
+      { label: 'Gates', to: '/gates' },
+      { label: 'Attestations', to: '/attestations' },
+    ],
+  },
+  {
+    path: '/nlboot',
+    label: 'NLBoot Evidence',
+    domain: 'SourceOS Lifecycle',
+    maturity: 'L2',
+    stateMode: 'fixture',
+    navTier: 'left-rail',
+    userJob: 'Inspect NLBoot plan, artifact cache, proof, adapter, and boot-entry records.',
+    ownerPlane: 'client-vue evidence surface; NLBoot owns executable contracts',
+    boundary: 'Evidence-only; no boot commands, EFI mutation, disk writes, reboots, or hardware contact.',
+    primaryObject: 'boot evidence records',
+    breadcrumbs: ['SourceOS Lifecycle', 'NLBoot evidence'],
+    railLabel: 'NB',
+  },
+  {
+    path: '/reader',
+    label: 'Reader',
+    domain: 'Feed Intelligence',
+    maturity: 'L2',
+    stateMode: 'fixture',
+    navTier: 'left-rail',
+    userJob: 'Review feed-intelligence item normalization, membrane, memory, and graph intent.',
+    ownerPlane: 'client-vue fixture; future contracts in BearBrowser, SlashTopics, New Hope, MemoryMesh, MeshRush',
+    boundary: 'UI-first fixture; no live feed fetching, ActivityPub, MemoryMesh writeback, MeshRush traversal, or browser bridge.',
+    primaryObject: 'canonical feed item',
+    breadcrumbs: ['Feed Intelligence', 'Reader'],
+    railLabel: '▤',
+  },
+  {
+    path: '/journal',
+    label: 'Adapter Seams',
+    domain: 'Adapter Seams',
+    maturity: 'L3',
+    stateMode: 'mock-adapter',
+    navTier: 'left-rail',
+    userJob: 'Inspect fixture-backed journal event stream shape.',
+    ownerPlane: 'client-vue mock TriRPC seam',
+    boundary: 'Mock/test mode only; no live backend stream, authorization, or writeback.',
+    primaryObject: 'journal event',
+    breadcrumbs: ['Adapter Seams', 'Journal stream'],
+    railLabel: 'J',
+    tabs: [
+      { label: 'Journal', to: '/journal' },
+      { label: 'Code Search', to: '/code' },
+      { label: 'Reader', to: '/reader' },
+    ],
+  },
+  {
+    path: '/code',
+    label: 'Code Search',
+    domain: 'Adapter Seams',
+    maturity: 'L3',
+    stateMode: 'mock-adapter',
+    navTier: 'left-rail',
+    userJob: 'Inspect fixture-backed code-search result shape.',
+    ownerPlane: 'client-vue mock TriRPC seam',
+    boundary: 'Mock/test mode only; no GitHub, Sourcegraph, credential access, or repository indexing.',
+    primaryObject: 'code search result',
+    breadcrumbs: ['Adapter Seams', 'Code search'],
+    railLabel: 'CS',
+  },
+  {
+    path: '/law/international-law',
+    label: 'Law & Regulation',
+    domain: 'Law & Regulation',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the law and regulation taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live legal intelligence feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['Law & Regulation', 'International Law'],
+  },
+  {
+    path: '/people/search',
+    label: 'People & Society',
+    domain: 'People & Society',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the people and society taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live people-search feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['People & Society', 'Search'],
+    railLabel: '◫',
+  },
+  {
+    path: '/economy/macro-economics',
+    label: 'Economy & Industry',
+    domain: 'Economy & Industry',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the economy and industry taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live economic-intelligence feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['Economy & Industry', 'Macro Economics'],
+    railLabel: '◔',
+  },
+  {
+    path: '/markets/indices-funds',
+    label: 'Capital & Markets',
+    domain: 'Capital & Markets',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the capital and markets taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live markets feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['Capital & Markets', 'Indices & Funds'],
+    railLabel: '▥',
+  },
+  {
+    path: '/weather/forecast',
+    label: 'Weather & Resources',
+    domain: 'Weather & Resources',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'top',
+    userJob: 'Enter the weather and resources taxonomy.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live weather feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['Weather & Resources', 'Forecast'],
+  },
+  {
+    path: '/analytics',
+    label: 'Analytics',
+    domain: 'Maps & Analytics',
+    maturity: 'L1',
+    stateMode: 'taxonomy',
+    navTier: 'left-rail',
+    userJob: 'Enter analytics scaffold.',
+    ownerPlane: 'client-vue taxonomy scaffold',
+    boundary: 'Mock taxonomy route; not a live analytics feature.',
+    primaryObject: 'domain route',
+    breadcrumbs: ['Maps & Analytics', 'Analytics'],
+    railLabel: '⌁',
+  },
+];
+
+export function routesForNavTier(tier: NavTier): RouteRegistryEntry[] {
+  return routeRegistry.filter((route) => route.navTier === tier);
+}
+
+export function registryEntryForPath(path: string): RouteRegistryEntry | undefined {
+  return routeRegistry.find((entry) => path === entry.path || path.startsWith(`${entry.path}/`));
+}
+
+export function entriesForDomain(domain: string): RouteRegistryEntry[] {
+  return routeRegistry.filter((entry) => entry.domain === domain);
+}
+
+export function topNavRoutes(): RouteRegistryEntry[] {
+  return routesForNavTier('top');
+}
+
+export function leftRailRoutes(): RouteRegistryEntry[] {
+  return routeRegistry.filter((entry) => entry.navTier === 'top' || entry.navTier === 'left-rail');
+}


### PR DESCRIPTION
## Summary

Adds a typed route registry/maturity ledger for `client-vue` and uses it to drive shell navigation, breadcrumbs, and route maturity labels.

## What changed

- Adds `src/config/routeRegistry.ts` with route path, label, domain, maturity level, state mode, nav tier, user job, owner plane, boundary, primary object, breadcrumbs, rail label, and tabs.
- Updates `src/App.vue` so top nav, left rail, tabs, and breadcrumbs are derived from the route registry instead of hard-coded route sprawl.
- Adds a breadcrumb route badge showing maturity and state mode.
- Adds `routeRegistry.test.ts` covering unique paths, top-nav discipline, left-rail operator shortcuts, and path resolution.

## Why

The quality plan requires route ownership, maturity labels, state modes, and navigation discipline before the shell can become a coherent product surface. This PR makes those route-level controls machine-readable and visible in the UI.

## Boundary posture

No backend behavior changed. This is shell IA/navigation governance plus tests. Experimental routes remain visible only according to their registry nav tier.

## Validation

Not run locally in this connector session. Expected CI/local gate:

```bash
cd socioprophet-web/client-vue
npm run typecheck
npm test
npm run build
```

## Next tranche

Extract SourceOS/NLBoot static arrays into typed feature fixtures and introduce shared boundary/mode components.