### PR TITLE
feat(client-vue): add route state panels to mock adapter pages

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/routeStatePanels.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/routeStatePanels.test.ts
@@ -1,0 +1,52 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import CodeSearch from '../pages/CodeSearch.vue';
+import Journal from '../pages/Journal.vue';
+import RouteStatePanel from '../components/RouteStatePanel.vue';
+
+describe('RouteStatePanel', () => {
+  it('renders state title and message', () => {
+    const wrapper = mount(RouteStatePanel, {
+      props: {
+        state: 'empty',
+        title: 'No results',
+        message: 'The fixture returned no rows.',
+      },
+    });
+
+    expect(wrapper.text()).toContain('empty');
+    expect(wrapper.text()).toContain('No results');
+    expect(wrapper.text()).toContain('fixture returned no rows');
+  });
+});
+
+describe('Journal route states', () => {
+  it('renders mock stream state after fixture events load', async () => {
+    const wrapper = mount(Journal);
+    expect(wrapper.text()).toContain('Loading fixture stream');
+
+    await flushPromises();
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Mock journal stream');
+    expect(wrapper.text()).toContain('fixture events loaded');
+    expect(wrapper.text()).toContain('mock boundary');
+  });
+});
+
+describe('Code Search route states', () => {
+  it('renders idle and ready states around mock search', async () => {
+    const wrapper = mount(CodeSearch);
+
+    expect(wrapper.text()).toContain('Search not started');
+    expect(wrapper.text()).toContain('No remote code index is contacted');
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Mock results ready');
+    expect(wrapper.text()).toContain('fixture results returned');
+    expect(wrapper.text()).toContain('mock boundary');
+  });
+});

--- a/socioprophet-web/client-vue/src/components/RouteStatePanel.vue
+++ b/socioprophet-web/client-vue/src/components/RouteStatePanel.vue
@@ -1,0 +1,73 @@
+<template>
+  <section :class="['route-state-panel', `route-state-panel--${state}`]" :aria-label="ariaLabel">
+    <ModeBadge :label="state" :tone="tone" />
+    <div>
+      <h3>{{ title }}</h3>
+      <p>{{ message }}</p>
+    </div>
+    <slot />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import ModeBadge from './ModeBadge.vue';
+
+const props = withDefaults(
+  defineProps<{
+    state: 'idle' | 'loading' | 'empty' | 'error' | 'mock' | 'ready';
+    title: string;
+    message: string;
+    ariaLabel?: string;
+  }>(),
+  { ariaLabel: 'Route state' },
+);
+
+const tone = computed(() => {
+  if (props.state === 'error') return 'danger';
+  if (props.state === 'loading' || props.state === 'idle' || props.state === 'mock') return 'warning';
+  if (props.state === 'ready') return 'success';
+  return 'muted';
+});
+</script>
+
+<style scoped>
+.route-state-panel {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 18px;
+  padding: 1rem;
+  background: rgba(20, 24, 31, 0.82);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.18);
+}
+
+.route-state-panel h3,
+.route-state-panel p {
+  margin: 0;
+}
+
+.route-state-panel h3 {
+  font-size: 1rem;
+}
+
+.route-state-panel p {
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.45;
+}
+
+.route-state-panel--error {
+  border-color: rgba(250, 77, 86, 0.38);
+}
+
+.route-state-panel--empty,
+.route-state-panel--idle,
+.route-state-panel--loading,
+.route-state-panel--mock {
+  border-color: rgba(241, 194, 27, 0.32);
+}
+
+.route-state-panel--ready {
+  border-color: rgba(36, 161, 72, 0.34);
+}
+</style>

--- a/socioprophet-web/client-vue/src/pages/CodeSearch.vue
+++ b/socioprophet-web/client-vue/src/pages/CodeSearch.vue
@@ -9,18 +9,24 @@
           query GitHub, Sourcegraph, or any live code index.
         </p>
       </div>
-      <span class="adapter-pill adapter-pill--warn">mock only</span>
+      <ModeBadge label="mock only" tone="warning" />
     </header>
 
     <section class="adapter-card search-row">
       <input v-model="query" placeholder="query" @keyup.enter="run" />
-      <button type="button" @click="run">Search</button>
+      <button type="button" :disabled="isLoading" @click="run">{{ isLoading ? 'Searching…' : 'Search' }}</button>
     </section>
 
-    <section class="adapter-card adapter-boundary">
-      <strong>Boundary</strong>
-      <p>Results come from the local mock adapter. No repository indexing, credential access, or remote search is declared here.</p>
-    </section>
+    <BoundaryNotice
+      label="mock boundary"
+      message="Results come from the local mock adapter. No repository indexing, credential access, or remote search is declared here."
+    />
+
+    <RouteStatePanel v-if="isLoading" state="loading" title="Searching fixture index" message="The local mock adapter is returning deterministic fixture results." />
+    <RouteStatePanel v-else-if="errorMessage" state="error" title="Search adapter unavailable" :message="errorMessage" />
+    <RouteStatePanel v-else-if="!hasSearched" state="idle" title="Search not started" message="Enter a query and run the mock adapter. No remote code index is contacted." />
+    <RouteStatePanel v-else-if="results.length === 0" state="empty" title="No mock results" message="The fixture adapter returned zero results for this query." />
+    <RouteStatePanel v-else state="ready" title="Mock results ready" :message="`${results.length} fixture results returned for '${query}'.`" />
 
     <section class="adapter-grid">
       <article v-for="result in results" :key="result.repo + result.path" class="adapter-card">
@@ -33,14 +39,31 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import BoundaryNotice from '../components/BoundaryNotice.vue';
+import ModeBadge from '../components/ModeBadge.vue';
+import RouteStatePanel from '../components/RouteStatePanel.vue';
 import { triRpc, type CodeSearchResult } from '../services/triRpc';
 
 const query = ref('main');
 const results = ref<CodeSearchResult[]>([]);
+const isLoading = ref(false);
+const hasSearched = ref(false);
+const errorMessage = ref('');
 
 async function run() {
-  const response = await triRpc.code.search({ query: query.value });
-  results.value = response.results || [];
+  isLoading.value = true;
+  errorMessage.value = '';
+  try {
+    const response = await triRpc.code.search({ query: query.value });
+    results.value = response.results || [];
+    hasSearched.value = true;
+  } catch (error) {
+    results.value = [];
+    hasSearched.value = true;
+    errorMessage.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    isLoading.value = false;
+  }
 }
 </script>
 
@@ -52,11 +75,9 @@ async function run() {
 h1, p { margin-top: 0; }
 p { color: rgba(255,255,255,.70); }
 .adapter-card { padding: 1rem; }
-.adapter-boundary { border-color: rgba(241,194,27,.45); background: rgba(241,194,27,.08); }
-.adapter-pill { display: inline-flex; align-items: center; height: fit-content; border-radius: 999px; padding: .2rem .55rem; font-size: .72rem; font-weight: 800; text-transform: uppercase; background: rgba(120,169,255,.15); color: var(--accent, #78a9ff); }
-.adapter-pill--warn { background: rgba(241,194,27,.18); color: #f1c21b; }
 .adapter-grid { display: grid; gap: 1rem; }
 .search-row { display: flex; gap: .75rem; }
 input { flex: 1; min-width: 0; border: 1px solid rgba(255,255,255,.24); border-radius: 12px; padding: .75rem; background: rgba(255,255,255,.08); color: var(--text, #f4f4f4); }
 button { border: 0; border-radius: 12px; padding: .75rem 1rem; background: var(--accent, #78a9ff); color: #06111f; font-weight: 800; cursor: pointer; }
+button:disabled { opacity: 0.6; cursor: wait; }
 </style>

--- a/socioprophet-web/client-vue/src/pages/Journal.vue
+++ b/socioprophet-web/client-vue/src/pages/Journal.vue
@@ -9,13 +9,18 @@
           This page does not connect to a live TriRPC backend.
         </p>
       </div>
-      <span class="adapter-pill adapter-pill--warn">mock only</span>
+      <ModeBadge label="mock only" tone="warning" />
     </header>
 
-    <section class="adapter-card adapter-boundary">
-      <strong>Boundary</strong>
-      <p>Events are generated from the local mock adapter. No writeback, authorization, or backend stream is declared here.</p>
-    </section>
+    <BoundaryNotice
+      label="mock boundary"
+      message="Events are generated from the local mock adapter. No writeback, authorization, or backend stream is declared here."
+    />
+
+    <RouteStatePanel v-if="isLoading" state="loading" title="Loading fixture stream" message="Reading mock TriRPC journal events from the local adapter." />
+    <RouteStatePanel v-else-if="errorMessage" state="error" title="Adapter unavailable" :message="errorMessage" />
+    <RouteStatePanel v-else-if="events.length === 0" state="empty" title="No journal events" message="The fixture stream returned no events. This is an empty mock state, not a backend outage." />
+    <RouteStatePanel v-else state="mock" title="Mock journal stream" :message="`${events.length} fixture events loaded from the mock adapter.`" />
 
     <section class="adapter-grid">
       <article v-for="event in events" :key="event.ts + event.kind" class="adapter-card">
@@ -32,9 +37,14 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
+import BoundaryNotice from '../components/BoundaryNotice.vue';
+import ModeBadge from '../components/ModeBadge.vue';
+import RouteStatePanel from '../components/RouteStatePanel.vue';
 import { triRpc, type EventEnvelope } from '../services/triRpc';
 
 const events = ref<EventEnvelope[]>([]);
+const isLoading = ref(true);
+const errorMessage = ref('');
 
 onMounted(async () => {
   try {
@@ -43,14 +53,9 @@ onMounted(async () => {
       if (events.value.length > 100) events.value.shift();
     }
   } catch (error) {
-    events.value.push({
-      ts: new Date().toISOString(),
-      space: 'client-vue',
-      ns: 'journal',
-      actor: { id: 'adapter-boundary', pk: 'none' },
-      kind: 'adapter.unavailable',
-      body: { error: error instanceof Error ? error.message : String(error) },
-    });
+    errorMessage.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    isLoading.value = false;
   }
 });
 </script>
@@ -63,9 +68,6 @@ onMounted(async () => {
 h1, p { margin-top: 0; }
 p, pre, code, .adapter-row span { color: rgba(255,255,255,.70); }
 .adapter-card { padding: 1rem; }
-.adapter-boundary { border-color: rgba(241,194,27,.45); background: rgba(241,194,27,.08); }
-.adapter-pill { display: inline-flex; align-items: center; height: fit-content; border-radius: 999px; padding: .2rem .55rem; font-size: .72rem; font-weight: 800; text-transform: uppercase; background: rgba(120,169,255,.15); color: var(--accent, #78a9ff); }
-.adapter-pill--warn { background: rgba(241,194,27,.18); color: #f1c21b; }
 .adapter-grid { display: grid; gap: 1rem; }
 .adapter-row { display: flex; justify-content: space-between; gap: 1rem; }
 pre { white-space: pre-wrap; overflow-wrap: anywhere; padding: .75rem; border-radius: 12px; background: rgba(255,255,255,.06); }


### PR DESCRIPTION
## Summary

Adds a shared route-state panel component and applies explicit idle/loading/error/empty/mock/ready states to the mock adapter pages.

## What changed

- Adds `src/components/RouteStatePanel.vue`.
- Updates `src/pages/Journal.vue` to show loading, error, empty, and mock-loaded states.
- Updates `src/pages/CodeSearch.vue` to show idle, loading, error, empty, and ready states.
- Adds `routeStatePanels.test.ts` covering the shared panel and mock adapter page state behavior.

## Why

The UI quality plan requires routes to avoid blank or implicit states. Mock and fixture routes should visibly disclose whether they are idle, loading, empty, error, mock, or ready instead of appearing live or silently failing.

## Boundary posture

No backend behavior changed. Journal and Code Search remain mock-only adapter seams. This PR does not add live TriRPC, GitHub search, Sourcegraph, credential access, backend streams, writeback, authorization, or repository indexing.

## Validation

Not run locally in this connector session. Expected CI/local gate:

```bash
cd socioprophet-web/client-vue
npm run typecheck
npm test
npm run build
```

## Next tranche

Apply route-state conventions to the remaining fixture routes and begin the visual/accessibility review pass.