### PR TITLE
Add contract surface registry for workroom substrate

### DIFF
--- a/socioprophet-web/client-vue/docs/CONTRACT_SURFACE_WORKROOM_PLAN.md
+++ b/socioprophet-web/client-vue/docs/CONTRACT_SURFACE_WORKROOM_PLAN.md
@@ -1,0 +1,67 @@
+# Contract Surface Workroom Plan
+
+## Purpose
+
+The Vue shell is the interface to the shared SocioProphet substrate. It is not the substrate by itself and it is not the authority plane.
+
+`ContractSurface` is the UI object model that makes NLBoot contracts, agent contracts, run contracts, workstation contracts, browser boundaries, model-carry boundaries, feed contracts, and workspace contracts legible in one workroom vocabulary.
+
+## Product posture
+
+The workroom should show:
+
+- contract kind and owning repo;
+- runtime state;
+- evidence level;
+- authority boundary;
+- admissible actions;
+- blocked actions;
+- admission requirements;
+- receipt refs;
+- audience: internal workroom, professional workroom, or client-visible.
+
+This keeps the UI from implying that fixture data, mock adapters, or evidence records are live executable substrate.
+
+## Boundary rule
+
+```text
+contract surface = UI/read/admission object
+owning repo = schema and source-of-truth owner
+runtime adapter = live or fixture integration boundary
+AgentPlane / Guardrail / Agent Registry / Ledger = execution, control, authority, and evidence planes
+```
+
+The Vue shell can render, validate, and request. It does not directly mutate host state, boot state, agent authority, credential state, browser runtime state, or model lifecycle state.
+
+## Workroom modes
+
+### Workroom
+
+Internal shared substrate view. It may show lower-maturity fixtures, mock seams, internal boundary records, and operator-only requirements.
+
+### Professional Workroom
+
+Client/project-safe substrate view. It may show only surfaces whose audience is `professional-workroom` or `client-visible`. These surfaces must be redacted, auditable, and clear about blocked or request-only actions.
+
+## Initial surfaces
+
+The first registry tranche includes:
+
+- NLBoot Evidence Contract Surface;
+- Agent Pre-Dispatch Contract Surface;
+- Browser Runtime Boundary Surface;
+- Model Carry Authorization Boundary.
+
+None of the initial surfaces is execution-authorized. This is intentional. The first tranche is substrate legibility, not live action.
+
+## Next route work
+
+Recommended next routes:
+
+- `/workroom` for internal substrate overview;
+- `/professional-workroom` for client/project-safe view;
+- route-level panels that import `contractSurfacesForRoute(route)` and render boundary/admission cards.
+
+## Non-goals
+
+This tranche does not wire live backend calls, create new contract schemas in the UI repo, dispatch agents, submit NLBoot actions, access credentials, execute browser automation, download models, or mutate workstation state.

--- a/socioprophet-web/client-vue/src/features/contract-surfaces/contractSurfaces.test.ts
+++ b/socioprophet-web/client-vue/src/features/contract-surfaces/contractSurfaces.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { contractSurfaceById, contractSurfaces, contractSurfacesForRoute } from './registry'
+import { canAppearInProfessionalWorkroom, isExecutionAuthorized, requiresAdmission } from './types'
+
+describe('contract surface registry', () => {
+  it('contains no live-execution-authorized surfaces in the initial workroom registry', () => {
+    expect(contractSurfaces.length).toBeGreaterThan(0)
+    expect(contractSurfaces.some(isExecutionAuthorized)).toBe(false)
+  })
+
+  it('keeps NLBoot evidence-only and blocks boot execution', () => {
+    const surface = contractSurfaceById('contract-surface:nlboot-evidence')
+    expect(surface).toBeDefined()
+    expect(surface?.authority).toBe('evidence-only')
+    expect(surface?.blockedActions.some((action) => action.id === 'nlboot.execute-boot')).toBe(true)
+    expect(surface?.boundaryNotice).toContain('cannot issue boot commands')
+  })
+
+  it('separates professional-workroom surfaces from internal-only surfaces', () => {
+    const professional = contractSurfaces.filter(canAppearInProfessionalWorkroom)
+    expect(professional.map((surface) => surface.id)).toContain('contract-surface:nlboot-evidence')
+    expect(professional.map((surface) => surface.id)).toContain('contract-surface:browser-runtime-boundary')
+    expect(professional.map((surface) => surface.id)).not.toContain('contract-surface:agent-pre-dispatch')
+  })
+
+  it('marks runtime-adjacent surfaces as requiring admission or runtime control', () => {
+    const agent = contractSurfaceById('contract-surface:agent-pre-dispatch')
+    const browser = contractSurfaceById('contract-surface:browser-runtime-boundary')
+    expect(agent && requiresAdmission(agent)).toBe(true)
+    expect(browser && requiresAdmission(browser)).toBe(true)
+  })
+
+  it('indexes contract surfaces by route', () => {
+    expect(contractSurfacesForRoute('/nlboot').map((surface) => surface.id)).toEqual([
+      'contract-surface:nlboot-evidence',
+    ])
+  })
+})

--- a/socioprophet-web/client-vue/src/features/contract-surfaces/registry.ts
+++ b/socioprophet-web/client-vue/src/features/contract-surfaces/registry.ts
@@ -1,0 +1,164 @@
+import type { ContractSurface } from './types'
+
+export const contractSurfaces: ContractSurface[] = [
+  {
+    id: 'contract-surface:nlboot-evidence',
+    label: 'NLBoot Evidence Contract Surface',
+    kind: 'nlboot',
+    route: '/nlboot',
+    owningRepo: 'SourceOS-Linux/sourceos-spec',
+    owningPlane: 'SourceOS Lifecycle / NLBoot',
+    schemaRef: 'sourceos.nlboot.evidence-boundary',
+    runtimeState: 'fixture',
+    evidenceLevel: 'E2',
+    authority: 'evidence-only',
+    audience: 'professional-workroom',
+    fixtureRef: 'client-vue:/features/nlboot-evidence',
+    liveContractRef: null,
+    adapterName: null,
+    capabilityProfileRef: null,
+    admissionRequirementRefs: [],
+    receiptRefs: [],
+    boundaryNotice: 'Evidence-only. The UI cannot issue boot commands, mutate EFI state, write disks, reboot, or contact host hardware.',
+    allowedActions: [
+      {
+        id: 'nlboot.inspect-evidence',
+        label: 'Inspect evidence records',
+        state: 'available',
+        requirementRefs: [],
+        boundary: 'Read-only evidence inspection.',
+      },
+    ],
+    blockedActions: [
+      {
+        id: 'nlboot.execute-boot',
+        label: 'Execute boot action',
+        state: 'blocked',
+        requirementRefs: ['agentplane admission', 'host-local executor', 'operator approval'],
+        boundary: 'Execution is outside the Vue shell and requires governed runtime admission.',
+      },
+    ],
+  },
+  {
+    id: 'contract-surface:agent-pre-dispatch',
+    label: 'Agent Pre-Dispatch Contract Surface',
+    kind: 'agent',
+    route: '/journal',
+    owningRepo: 'SourceOS-Linux/agent-term',
+    owningPlane: 'Agent Registry / Policy Fabric / AgentTerm',
+    schemaRef: 'agent-term.pre-dispatch-decision.v0.1',
+    runtimeState: 'fixture',
+    evidenceLevel: 'E2',
+    authority: 'admission-required',
+    audience: 'internal-workroom',
+    fixtureRef: 'SourceOS-Linux/agent-term#45',
+    liveContractRef: null,
+    adapterName: 'agent-term-pre-dispatch',
+    capabilityProfileRef: 'agent-registry grants required for non-human participants',
+    admissionRequirementRefs: ['Agent Registry ref', 'grant refs', 'session ref', 'Policy Fabric decision refs'],
+    receiptRefs: [],
+    boundaryNotice: 'AgentTerm pre-dispatch decisions are decision-only and must not perform runtime dispatch.',
+    allowedActions: [
+      {
+        id: 'agent.inspect-boundary',
+        label: 'Inspect pre-dispatch requirements',
+        state: 'available',
+        requirementRefs: [],
+        boundary: 'Read-only contract inspection.',
+      },
+    ],
+    blockedActions: [
+      {
+        id: 'agent.dispatch',
+        label: 'Dispatch agent action',
+        state: 'blocked',
+        requirementRefs: ['live Agent Registry lookup', 'live Policy Fabric decision', 'AgentPlane admission'],
+        boundary: 'Dispatch must occur in the owning runtime plane, not inside the UI registry.',
+      },
+    ],
+  },
+  {
+    id: 'contract-surface:browser-runtime-boundary',
+    label: 'Browser Runtime Boundary Surface',
+    kind: 'browser',
+    route: '/reader',
+    owningRepo: 'SourceOS-Linux/BearBrowser',
+    owningPlane: 'BearBrowser Runtime / Credential Broker',
+    schemaRef: 'bearbrowser.runtime-boundary.v1',
+    runtimeState: 'fixture',
+    evidenceLevel: 'E2',
+    authority: 'runtime-control-required',
+    audience: 'professional-workroom',
+    fixtureRef: 'SourceOS-Linux/BearBrowser#37',
+    liveContractRef: null,
+    adapterName: 'bearbrowser-runtime-boundary',
+    capabilityProfileRef: 'credential export denied; Agent Registry required for agent actors',
+    admissionRequirementRefs: ['Policy decision ref', 'Agent Registry ref for agent actor', 'redaction boundary'],
+    receiptRefs: [],
+    boundaryNotice: 'Browser runtime boundary records are decision-only and cannot grant credential access, submit forms, or bridge workspace downloads.',
+    allowedActions: [
+      {
+        id: 'browser.inspect-boundary',
+        label: 'Inspect browser boundary',
+        state: 'available',
+        requirementRefs: [],
+        boundary: 'Read-only runtime-boundary inspection.',
+      },
+    ],
+    blockedActions: [
+      {
+        id: 'browser.credential-export',
+        label: 'Export credential',
+        state: 'blocked',
+        requirementRefs: ['credential broker policy denies export'],
+        boundary: 'Credential export remains denied by contract.',
+      },
+    ],
+  },
+  {
+    id: 'contract-surface:model-carry-boundary',
+    label: 'Model Carry Authorization Boundary',
+    kind: 'model-carry',
+    route: '/control-plane',
+    owningRepo: 'SourceOS-Linux/sourceos-model-carry',
+    owningPlane: 'SourceOS Model Carry',
+    schemaRef: 'ModelCarryAuthorizationBoundary v0.1',
+    runtimeState: 'fixture',
+    evidenceLevel: 'E2',
+    authority: 'evidence-only',
+    audience: 'internal-workroom',
+    fixtureRef: 'SourceOS-Linux/sourceos-model-carry#12',
+    liveContractRef: null,
+    adapterName: 'model-carry-boundary',
+    capabilityProfileRef: null,
+    admissionRequirementRefs: [],
+    receiptRefs: [],
+    boundaryNotice: 'Model carry profiles are reference objects only. They do not authorize prompt egress, network, tool use, download, training, promotion, or lifecycle mutation.',
+    allowedActions: [
+      {
+        id: 'model-carry.inspect-profile',
+        label: 'Inspect carried profile',
+        state: 'available',
+        requirementRefs: [],
+        boundary: 'Read-only carry-profile inspection.',
+      },
+    ],
+    blockedActions: [
+      {
+        id: 'model-carry.download-model',
+        label: 'Download model weights',
+        state: 'blocked',
+        requirementRefs: ['explicit pull/install action', 'policy admission'],
+        boundary: 'Carry profile does not authorize download.',
+      },
+    ],
+  },
+]
+
+export function contractSurfaceById(id: string): ContractSurface | undefined {
+  return contractSurfaces.find((surface) => surface.id === id)
+}
+
+export function contractSurfacesForRoute(route: string): ContractSurface[] {
+  return contractSurfaces.filter((surface) => surface.route === route)
+}

--- a/socioprophet-web/client-vue/src/features/contract-surfaces/types.ts
+++ b/socioprophet-web/client-vue/src/features/contract-surfaces/types.ts
@@ -1,0 +1,66 @@
+import type { EvidenceLevel, RuntimeState } from '../../runtime-adapters/types'
+
+export type ContractSurfaceKind =
+  | 'nlboot'
+  | 'agent'
+  | 'run'
+  | 'workstation'
+  | 'browser'
+  | 'model-carry'
+  | 'feed'
+  | 'workspace'
+
+export type ContractSurfaceAudience = 'internal-workroom' | 'professional-workroom' | 'client-visible'
+
+export type ContractSurfaceAuthority =
+  | 'evidence-only'
+  | 'request-only'
+  | 'admission-required'
+  | 'runtime-control-required'
+  | 'authority-mutation-required'
+  | 'live-execution-authorized'
+
+export type ContractActionState = 'available' | 'blocked' | 'disabled' | 'mock-only' | 'fixture-only'
+
+export interface ContractActionAffordance {
+  id: string
+  label: string
+  state: ContractActionState
+  requirementRefs: string[]
+  boundary: string
+}
+
+export interface ContractSurface {
+  id: string
+  label: string
+  kind: ContractSurfaceKind
+  route: string
+  owningRepo: string
+  owningPlane: string
+  schemaRef: string
+  runtimeState: RuntimeState
+  evidenceLevel: EvidenceLevel
+  authority: ContractSurfaceAuthority
+  audience: ContractSurfaceAudience
+  fixtureRef: string | null
+  liveContractRef: string | null
+  adapterName: string | null
+  capabilityProfileRef: string | null
+  admissionRequirementRefs: string[]
+  receiptRefs: string[]
+  boundaryNotice: string
+  allowedActions: ContractActionAffordance[]
+  blockedActions: ContractActionAffordance[]
+}
+
+export function canAppearInProfessionalWorkroom(surface: ContractSurface): boolean {
+  return surface.audience === 'professional-workroom' || surface.audience === 'client-visible'
+}
+
+export function isExecutionAuthorized(surface: ContractSurface): boolean {
+  return surface.authority === 'live-execution-authorized' && surface.runtimeState === 'live'
+}
+
+export function requiresAdmission(surface: ContractSurface): boolean {
+  return surface.authority === 'admission-required' || surface.authority === 'runtime-control-required'
+}


### PR DESCRIPTION
## Summary

Adds the first `ContractSurface` registry tranche for the Vue product shell. This makes NLBoot, agent, browser, and model-carry boundary contracts legible through one shared UI object model before adding `/workroom` or `/professional-workroom` routes.

## Adds

- `src/features/contract-surfaces/types.ts`
  - `ContractSurface`, audience, authority, action affordance, and helper predicates.
- `src/features/contract-surfaces/registry.ts`
  - initial surfaces for NLBoot evidence, AgentTerm pre-dispatch, BearBrowser runtime boundary, and SourceOS model-carry boundary.
- `src/features/contract-surfaces/contractSurfaces.test.ts`
  - validates no initial surface is live-execution-authorized;
  - checks NLBoot remains evidence-only;
  - separates professional-workroom and internal-only surfaces;
  - checks admission/runtime-control posture;
  - indexes surfaces by route.
- `docs/CONTRACT_SURFACE_WORKROOM_PLAN.md`
  - documents Workroom vs Professional Workroom posture and non-goals.

## Boundary

This PR does not wire live backend calls, create new backend contract schemas, dispatch agents, submit NLBoot actions, access credentials, execute browser automation, download models, or mutate workstation state.

It only adds the UI-side contract-surface registry needed to prevent imported client/workroom screens from implying live execution authority.