### PR TITLE
docs(client-vue): record map static review evidence

### DIFF
--- a/socioprophet-web/client-vue/docs/MAP_VISUAL_ACCESSIBILITY_REVIEW.md
+++ b/socioprophet-web/client-vue/docs/MAP_VISUAL_ACCESSIBILITY_REVIEW.md
@@ -1,0 +1,91 @@
+# `/map` Static Visual and Accessibility Review
+
+Status: static/code-based review complete; browser screenshot QA pending  
+Scope: `socioprophet-web/client-vue/src/pages/MapPage.vue`  
+Date: 2026-05-29
+
+## Review boundary
+
+This review is based on source inspection and existing smoke tests. It is not a browser screenshot review and it is not a keyboard traversal recording.
+
+Do not treat this document as L5/product-ready approval.
+
+## Reviewed sources
+
+- `src/pages/MapPage.vue`
+- `src/__tests__/MapPage.smoke.test.ts`
+- `src/api/gaiaMap.ts` indirectly through existing smoke coverage
+- `src/runtime-adapters/routeRuntimeFeatures.ts` indirectly through route runtime badges
+
+## Static review result
+
+`/map` remains the strongest current product candidate, but it is not approved for public release yet.
+
+Static/code review passes these checks:
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Page identity | Pass | Page has explicit title: `OpenStreetMap × GAIA world model`. |
+| Route purpose | Pass | Subtitle states read-only map workbench and advisory/non-production posture. |
+| Mode disclosure | Pass | Header exposes live API/demo fallback and live/demo catalog labels. |
+| Boundary disclosure | Pass | Header includes advisory routing and non-production tile tags. Warning cards disclose product-demo/fallback mode. |
+| Loading state | Pass | `loading` renders `Loading GAIA map state…`. |
+| Error state | Pass | Initial fatal error renders `.state-card.error` when no snapshot exists. |
+| Fallback state | Pass | Fallback warning is visible when API is unavailable. |
+| Non-blank behavior | Pass | Existing smoke tests assert H3 success/failure does not blank the map grid. |
+| Map canvas label | Pass | Canvas element has `aria-label="GAIA map canvas"`. |
+| Keyboard-operable controls | Partial pass | Main controls are native buttons/inputs. Full keyboard traversal still needs browser review. |
+| Evidence/governance panels | Pass | Evidence, governance, runtime, feature, layer catalog, and tile manifest panels are rendered. |
+| Tile safety | Pass | Placeholder tile guard states placeholder metadata only and non-production tile behavior. |
+| Attribution/provenance | Pass | OSM attribution, source refs, digest refs, and receipt/provenance fields are rendered. |
+| Test coverage | Pass for static smoke | Smoke tests cover mount, canvas, fallback, live mode, H3 path, panels, status labels, catalog, and manifest. |
+
+## Browser review still required
+
+The following are pending because they require a running browser or screenshots:
+
+- desktop screenshot at normal viewport;
+- narrow/mobile screenshot;
+- keyboard tab order through top controls, left panel, map stage, and right panel;
+- visible focus review for buttons, inputs, and layer cards;
+- screen-reader order check for the two side panels and central map canvas;
+- actual visual density review after map tiles render;
+- overflow review for the right-panel detail grids and long provenance/digest strings;
+- confirmation that warning/error cards remain visible above the fold where needed.
+
+## Visual risks
+
+| Risk | Severity | Notes |
+| --- | --- | --- |
+| Dense two-panel layout may overwhelm first-time reviewers | Medium | Left controls + map + right inspector is appropriate for an operator workbench, but not for public landing/product intro. |
+| Runtime/evidence/governance panels may be too deep for first release | Medium | Consider collapsible sections or progressive disclosure before public release. |
+| MapLibre controls require browser focus review | Medium | Source uses native MapLibre control; accessibility depends partly on rendered control internals. |
+| Long hashes/source refs can overflow | Medium | Code uses detail grids and evidence lists; needs browser overflow review. |
+| Live/fallback labels may not be prominent enough for public users | Low/Medium | Existing labels are present; product copy may need stronger fallback-mode wording. |
+
+## Accessibility risks
+
+| Risk | Severity | Notes |
+| --- | --- | --- |
+| `map-canvas` is labelled, but map interaction semantics remain limited | Medium | Canvas/map widgets are inherently difficult; add adjacent textual feature summary for screen-reader users if public release is planned. |
+| Scroll-jump buttons use panel labels but not expanded descriptions | Low | Native buttons are acceptable; text is short but clear. |
+| Color-coded tags need text labels | Low | Current tags include text; not color-only. |
+| Tables/detail grids are visual pairs, not semantic tables | Medium | Review whether key-value pairs should use `dl` for screen-reader clarity. |
+
+## Release decision for `/map`
+
+Current decision: keep `/map` as the only public/product candidate route, but do not approve it for public release until browser review evidence is added.
+
+Recommended release posture:
+
+- internal/demo: include;
+- product candidate: yes;
+- public release: pending browser visual/accessibility review and fallback-mode copy update.
+
+## Required follow-up PRs
+
+1. Run browser visual review for `/map` and attach screenshots or textual summaries.
+2. Add or confirm focus-visible behavior for panel buttons and layer cards.
+3. Review narrow/mobile layout and decide whether `/map` should be desktop-only for the first demo.
+4. Add a short public-facing fallback-mode disclaimer if `/map` is exposed outside internal review.
+5. Consider converting key-value detail grids to `dl` semantics where appropriate.

--- a/socioprophet-web/client-vue/docs/RELEASE_ROUTE_MATRIX.md
+++ b/socioprophet-web/client-vue/docs/RELEASE_ROUTE_MATRIX.md
@@ -23,7 +23,7 @@ A route is not shippable because it renders. Release inclusion requires maturity
 
 | Route | Current level | State mode | Release posture | Why | Required before release |
 | --- | --- | --- | --- | --- | --- |
-| `/map` | L4 | live/fallback | Include candidate | Best current candidate: live/fallback map API posture, existing tests, clear GAIA/OSM workbench role. | Browser visual/accessibility review; route owner record; release note for fallback limits. |
+| `/map` | L4 | live/fallback | Include candidate | Static review passed for identity, mode disclosure, boundary language, loading/error/fallback state, labelled canvas, evidence/governance panels, placeholder-tile guard, attribution/provenance, and smoke coverage. See `MAP_VISUAL_ACCESSIBILITY_REVIEW.md`. | Browser screenshot QA, keyboard traversal evidence, narrow/mobile viewport evidence, route owner record, and release note for fallback limits. |
 | `/professional-intelligence` | L2 | fixture | Review only | Useful operating dashboard, but fixture-backed and dense. Actions are gated/disabled. | Live source contract, visual density pass, route-state review, source freshness model. |
 | `/control-plane` | L2 | fixture/evidence | Review only | Useful SourceOS lifecycle evidence view, but no real assignment/enrollment authority. | SourceOS/NLBoot owner contract refs, progressive disclosure, no-action release wording. |
 | `/nlboot` | L2 | fixture/evidence | Review only | Useful evidence inventory, but boot/hardware authority is intentionally absent. | Align object names to NLBoot contracts, digest overflow review, evidence fixture provenance. |
@@ -52,7 +52,25 @@ The first public/product release candidate should include only:
 
 1. `/map`
 
-Even `/map` remains conditional on visual/accessibility review and explicit fallback-mode wording.
+Even `/map` remains conditional on browser visual/accessibility review and explicit fallback-mode wording.
+
+## `/map` review evidence status
+
+Static/code review is complete and recorded in:
+
+```text
+docs/MAP_VISUAL_ACCESSIBILITY_REVIEW.md
+```
+
+The static review does not substitute for browser QA. `/map` is still blocked from public release pending:
+
+- desktop screenshot review;
+- narrow/mobile screenshot review;
+- keyboard traversal evidence;
+- visible focus review;
+- screen-reader order review for panels and canvas;
+- overflow review for detail grids and digest/source-ref strings;
+- public fallback-mode wording.
 
 ## Routes to hide or demote before public review
 
@@ -84,5 +102,5 @@ Do not ship the full Vue shell as product yet.
 The shell is now far more disciplined than the imported staging source, but most routes are still review/control surfaces rather than product routes. The correct first release posture is:
 
 - internal/demo: controlled route set above;
-- product candidate: `/map` only after visual/accessibility review;
+- product candidate: `/map` only after browser visual/accessibility review;
 - public route set: defer until release review passes.


### PR DESCRIPTION
## Summary

Adds static/code-based visual and accessibility review evidence for `/map` and updates the release-route matrix.

## What changed

- Adds `socioprophet-web/client-vue/docs/MAP_VISUAL_ACCESSIBILITY_REVIEW.md`.
- Updates `socioprophet-web/client-vue/docs/RELEASE_ROUTE_MATRIX.md` to record `/map` static-review evidence.

## Static review result

`/map` remains the strongest product candidate. Static/code review passes for page identity, route purpose, live/fallback disclosure, boundary disclosure, loading/error/fallback states, labelled map canvas, keyboard-operable native controls, evidence/governance/runtime panels, placeholder tile guard, attribution/provenance, and smoke-test coverage.

## Still blocked for public release

This PR does not claim browser QA. `/map` remains blocked from public release pending:

- desktop screenshot review;
- narrow/mobile screenshot review;
- keyboard traversal evidence;
- visible focus review;
- screen-reader order review for panels and canvas;
- overflow review for detail grids and digest/source-ref strings;
- public fallback-mode wording.

## Boundary posture

Docs-only. No runtime behavior changed. This is not L5/product-ready approval.

## Validation

Docs-only. No runtime validation run.

## Next tranche

Run actual browser visual/accessibility review for `/map` with screenshots or textual browser observations.