### PR TITLE
Index Feed Intelligence integration ledger

### DIFF
--- a/socioprophet-web/client-vue/src/features/feed-intelligence/README.md
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/README.md
@@ -33,12 +33,15 @@ It does not implement:
 
 Those belong in follow-on PRs in their owning repositories after the product surface and contracts are accepted.
 
+The owning repository contract index for this feature is `INTEGRATION_LEDGER.md`. Future live integration work must start there and update it when adapters, authority boundaries, tests, or rollback behavior change.
+
 ## Files
 
 | Path | Purpose |
 | --- | --- |
 | `types.ts` | Contract types for sources, items, events, integrations, storage posture, and membrane decisions. |
 | `state.ts` | Fixture-backed state used by the current reader UI. |
+| `INTEGRATION_LEDGER.md` | Owning-repo contract ledger for BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush. |
 | `../../pages/Reader.vue` | Product shell page rendering the fixture state. |
 
 ## Acceptance posture


### PR DESCRIPTION
## Summary

Indexes the Feed Intelligence integration ledger from the feature README.

## Changes

- Updates `socioprophet-web/client-vue/src/features/feed-intelligence/README.md`.
- Adds `INTEGRATION_LEDGER.md` to the file table.
- Adds a boundary sentence requiring future live integration work to start from the ledger.

## Validation

Connector compare confirms this branch is 1 commit ahead of `master`, 0 behind, and modifies one docs file with 3 additions and no deletions.

## Non-goals

- No Vue runtime changes.
- No route changes.
- No live integration behavior.