### PR TITLE
Add disabled Feed Intelligence adapter seams

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligenceAdapters.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligenceAdapters.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adapterBoundarySummary,
+  allFeedIntelligenceAdaptersDisabled,
+  feedIntelligenceAdapters,
+} from '../features/feed-intelligence/adapters';
+
+describe('Feed Intelligence disabled adapter seams', () => {
+  it('keeps every live adapter disabled by default', () => {
+    expect(feedIntelligenceAdapters).toHaveLength(5);
+    expect(allFeedIntelligenceAdaptersDisabled()).toBe(true);
+
+    for (const adapter of feedIntelligenceAdapters) {
+      expect(adapter.status).toBe('disabled');
+      expect(adapter.owningArtifact).toContain(':');
+      expect(adapter.disabledReason).toContain('No live');
+    }
+  });
+
+  it('declares prohibited side effects before any live adapter can be enabled', () => {
+    const sideEffects = new Set(feedIntelligenceAdapters.flatMap((adapter) => adapter.forbiddenSideEffects));
+
+    expect(sideEffects).toContain('publication');
+    expect(sideEffects).toContain('memory writeback');
+    expect(sideEffects).toContain('graph traversal');
+    expect(sideEffects).toContain('browser capture');
+  });
+
+  it('reports fixture-backed reader posture explicitly', () => {
+    expect(adapterBoundarySummary()).toBe(
+      'All Feed Intelligence live adapters are disabled; the reader remains fixture-backed.',
+    );
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/adapters.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/adapters.ts
@@ -1,0 +1,63 @@
+export type FeedIntelligenceAdapterId = 'bearbrowser' | 'slashTopics' | 'newHope' | 'memoryMesh' | 'meshRush';
+
+export type FeedIntelligenceAdapterStatus = 'disabled';
+
+export type FeedIntelligenceAdapterBoundary = {
+  id: FeedIntelligenceAdapterId;
+  name: string;
+  status: FeedIntelligenceAdapterStatus;
+  owningArtifact: string;
+  disabledReason: string;
+  forbiddenSideEffects: string[];
+};
+
+export const feedIntelligenceAdapters: FeedIntelligenceAdapterBoundary[] = [
+  {
+    id: 'bearbrowser',
+    name: 'BearBrowser reader bridge',
+    status: 'disabled',
+    owningArtifact: 'SourceOS-Linux/BearBrowser:docs/reader-bridge.md',
+    disabledReason: 'No native browser bridge adapter is wired in client-vue.',
+    forbiddenSideEffects: ['browser capture', 'feed subscription', 'publication'],
+  },
+  {
+    id: 'slashTopics',
+    name: 'SlashTopics scope resolver',
+    status: 'disabled',
+    owningArtifact: 'SocioProphet/slash-topics:examples/feed-intelligence/scope.example.md',
+    disabledReason: 'No live scope resolver is wired in client-vue.',
+    forbiddenSideEffects: ['feed fetch', 'scope mutation', 'publication'],
+  },
+  {
+    id: 'newHope',
+    name: 'New Hope membrane adapter',
+    status: 'disabled',
+    owningArtifact: 'SocioProphet/new-hope:examples/feed-intelligence/membrane-event.example.md',
+    disabledReason: 'No live membrane runtime is wired in client-vue.',
+    forbiddenSideEffects: ['policy decision mutation', 'publication', 'memory writeback'],
+  },
+  {
+    id: 'memoryMesh',
+    name: 'MemoryMesh posture adapter',
+    status: 'disabled',
+    owningArtifact: 'SocioProphet/memory-mesh:examples/feed-intelligence/memory-profile.example.md',
+    disabledReason: 'No live recall or writeback adapter is wired in client-vue.',
+    forbiddenSideEffects: ['memory recall', 'memory writeback', 'raw payload storage'],
+  },
+  {
+    id: 'meshRush',
+    name: 'MeshRush graph-view adapter',
+    status: 'disabled',
+    owningArtifact: 'SocioProphet/meshrush:fixtures/graph-views/feed-intelligence-reader-graph-view.sample.v1.json',
+    disabledReason: 'No live graph traversal adapter is wired in client-vue.',
+    forbiddenSideEffects: ['graph traversal', 'graph persistence', 'publication'],
+  },
+];
+
+export function allFeedIntelligenceAdaptersDisabled(): boolean {
+  return feedIntelligenceAdapters.every((adapter) => adapter.status === 'disabled');
+}
+
+export function adapterBoundarySummary(): string {
+  return 'All Feed Intelligence live adapters are disabled; the reader remains fixture-backed.';
+}


### PR DESCRIPTION
## Summary

Adds fail-closed adapter seams for the canonical Feed Intelligence reader.

## Changes

- Adds `socioprophet-web/client-vue/src/features/feed-intelligence/adapters.ts`.
- Adds `socioprophet-web/client-vue/src/__tests__/FeedIntelligenceAdapters.test.ts`.
- Declares BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush adapters as disabled by default.
- Records owning artifacts and forbidden side effects for each adapter.

## Validation

Connector compare confirms this branch is 2 commits ahead of `master`, 0 behind, and adds two files.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

## Non-goals

- No live adapter behavior.
- No feed fetching.
- No browser capture.
- No publication.
- No memory writeback.
- No graph traversal.