### PR TITLE
Add BearBrowser handoff fixture mapper

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bearBrowserHandoffBoundaryNotice,
+  bearBrowserReaderHandoffFixture,
+  mapBearBrowserHandoffToFeedItem,
+} from '../features/feed-intelligence/bearbrowserHandoff';
+
+describe('BearBrowser handoff fixture mapping', () => {
+  it('maps a local handoff fixture into a quarantined local-only FeedItem', () => {
+    const item = mapBearBrowserHandoffToFeedItem(bearBrowserReaderHandoffFixture);
+
+    expect(item.sourceId).toBe('source-bearbrowser-capture');
+    expect(item.topicScope).toBe('/capture/browser');
+    expect(item.membraneDecision).toBe('quarantine');
+    expect(item.storagePolicy).toBe('localOnly');
+    expect(item.provenanceHash).toBe(bearBrowserReaderHandoffFixture.contentHash);
+    expect(item.eventRefs).toEqual(bearBrowserReaderHandoffFixture.evidenceRefs);
+  });
+
+  it('preserves capture is not publication claim boundaries', () => {
+    const item = mapBearBrowserHandoffToFeedItem(bearBrowserReaderHandoffFixture);
+
+    expect(item.claims).toContain('browser-handoff-is-local-fixture');
+    expect(item.claims).toContain('capture-is-not-publication');
+    expect(item.summary).toContain('does not activate browser capture');
+  });
+
+  it('states disabled live side effects explicitly', () => {
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('fixture-only');
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('no native browser bridge');
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('memory writeback');
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('graph traversal');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
@@ -1,0 +1,57 @@
+import type { FeedItem, StoragePolicy } from './types';
+
+export type BearBrowserProfileClass = 'human' | 'agent' | 'terminal';
+
+export type BearBrowserReaderHandoffFixture = {
+  sourceUrl: string;
+  canonicalUrl?: string;
+  title?: string;
+  excerpt?: string;
+  contentHash: string;
+  capturedAt: string;
+  browserProfileClass: BearBrowserProfileClass;
+  storagePolicyRequest: StoragePolicy;
+  evidenceRefs: string[];
+};
+
+export const bearBrowserReaderHandoffFixture: BearBrowserReaderHandoffFixture = {
+  sourceUrl: 'https://example.local/sourceos/bearbrowser-capture-demo',
+  canonicalUrl: 'local://bearbrowser/captures/feed-intelligence-demo-001',
+  title: 'BearBrowser local handoff fixture',
+  excerpt:
+    'Local-only BearBrowser handoff fixture for the Feed Intelligence reader. This fixture proves mapping shape only and does not activate browser capture, feed fetching, publication, memory writeback, or graph traversal.',
+  contentHash: 'sha256:bearbrowser-feed-intelligence-demo-placeholder',
+  capturedAt: '2026-05-31T13:42:00Z',
+  browserProfileClass: 'human',
+  storagePolicyRequest: 'localOnly',
+  evidenceRefs: [
+    'browser.page.captured:fixture-001',
+    'browser.provenance.attached:fixture-001',
+    'browser.reader.handoff.requested:fixture-001',
+  ],
+};
+
+export function mapBearBrowserHandoffToFeedItem(
+  handoff: BearBrowserReaderHandoffFixture,
+): FeedItem {
+  return {
+    id: 'item-bearbrowser-handoff-fixture-001',
+    sourceId: 'source-bearbrowser-capture',
+    title: handoff.title ?? 'Untitled BearBrowser handoff',
+    summary: handoff.excerpt ?? 'BearBrowser local handoff fixture with no live adapter behavior.',
+    canonicalUrl: handoff.canonicalUrl ?? handoff.sourceUrl,
+    publishedAt: handoff.capturedAt,
+    normalizedAt: handoff.capturedAt,
+    topicScope: '/capture/browser',
+    membraneDecision: 'quarantine',
+    storagePolicy: handoff.storagePolicyRequest,
+    provenanceHash: handoff.contentHash,
+    eventRefs: handoff.evidenceRefs,
+    entities: ['BearBrowser', 'SourceOS', 'Feed Intelligence'],
+    claims: ['browser-handoff-is-local-fixture', 'capture-is-not-publication'],
+  };
+}
+
+export function bearBrowserHandoffBoundaryNotice(): string {
+  return 'BearBrowser handoff is fixture-only; no native browser bridge, network fetch, publication, memory writeback, or graph traversal is active.';
+}


### PR DESCRIPTION
## Summary

Adds a local-only BearBrowser handoff fixture mapper for the canonical Feed Intelligence reader.

## Changes

- Adds `socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts`.
- Adds `socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts`.
- Maps a local BearBrowser handoff fixture into a quarantined `FeedItem`.
- Keeps storage local-only and preserves capture-is-not-publication boundaries.

## Validation

Connector compare confirms this branch is 2 commits ahead of `master`, 0 behind, and adds two files.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

## Non-goals

- No native browser bridge.
- No network fetch.
- No publication.
- No MemoryMesh writeback.
- No MeshRush traversal.