### PR TITLE
Surface BearBrowser handoff fixture in reader state

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -12,6 +12,14 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('Ticker proof-of-life event normalized into the reader stream');
   });
 
+  it('renders the local BearBrowser handoff fixture in the stream', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('BearBrowser local handoff fixture');
+    expect(wrapper.text()).toContain('browser-handoff-is-local-fixture');
+    expect(wrapper.text()).toContain('capture-is-not-publication');
+  });
+
   it('renders disabled adapter boundary before live behavior is enabled', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/state.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/state.ts
@@ -1,3 +1,7 @@
+import {
+  bearBrowserReaderHandoffFixture,
+  mapBearBrowserHandoffToFeedItem,
+} from './bearbrowserHandoff';
 import type { FeedIntelligenceState } from './types';
 
 export const feedIntelligenceState: FeedIntelligenceState = {
@@ -89,6 +93,7 @@ export const feedIntelligenceState: FeedIntelligenceState = {
       entities: ['BearBrowser', 'SourceOS', 'MemoryMesh'],
       claims: ['capture-is-not-publication', 'local-only-by-default'],
     },
+    mapBearBrowserHandoffToFeedItem(bearBrowserReaderHandoffFixture),
   ],
   events: [
     { id: 'event-001', type: 'FeedDiscovered', label: 'Feed discovered from source link or browser capture', status: 'complete', evidenceRef: 'eventlog://feed.discovered/001' },


### PR DESCRIPTION
## Summary

Surfaces the local BearBrowser handoff fixture in the canonical Feed Intelligence reader stream.

## Changes

- Updates `socioprophet-web/client-vue/src/features/feed-intelligence/state.ts` to include the mapped BearBrowser handoff fixture.
- Updates `socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts` to assert the local handoff item and boundary claims render.

## Validation

Connector compare confirms this branch is 2 commits ahead of `master`, 0 behind, and changes only reader fixture state plus the Feed Intelligence smoke test.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

## Non-goals

- No native browser bridge.
- No network fetch.
- No publication.
- No MemoryMesh writeback.
- No MeshRush traversal.