### PR TITLE
Add SlashTopics scope fixture resolver

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/SlashTopicsScopeFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/SlashTopicsScopeFixture.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { feedIntelligenceState } from '../features/feed-intelligence/state';
+import {
+  resolveSlashTopicScopeForSource,
+  slashTopicScopeBoundaryNotice,
+  slashTopicScopeFixtures,
+} from '../features/feed-intelligence/slashTopicsScope';
+
+describe('SlashTopics scope fixture resolver', () => {
+  it('resolves every reader source to a fixture slash-topic scope', () => {
+    for (const source of feedIntelligenceState.sources) {
+      const scope = resolveSlashTopicScopeForSource(source);
+      expect(scope).toBeDefined();
+      expect(scope?.topic).toBe(source.scope);
+      expect(scope?.publicSurfaceRef).toBe('socioprophet-feed-intelligence-reader');
+    }
+  });
+
+  it('keeps browser capture scoped local-only by default', () => {
+    const browserScope = slashTopicScopeFixtures.find((scope) => scope.topic === '/capture/browser');
+
+    expect(browserScope?.kind).toBe('browser-capture-source');
+    expect(browserScope?.privacyPosture).toBe('local-only-by-default');
+    expect(browserScope?.receiptRefs).toContain('browser.page.captured');
+  });
+
+  it('states disabled live side effects explicitly', () => {
+    expect(slashTopicScopeBoundaryNotice()).toContain('fixture-only');
+    expect(slashTopicScopeBoundaryNotice()).toContain('no feed fetch');
+    expect(slashTopicScopeBoundaryNotice()).toContain('scope mutation');
+    expect(slashTopicScopeBoundaryNotice()).toContain('memory writeback');
+    expect(slashTopicScopeBoundaryNotice()).toContain('graph traversal');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/slashTopicsScope.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/slashTopicsScope.ts
@@ -1,0 +1,61 @@
+import type { FeedSource } from './types';
+
+export type SlashTopicScopeFixture = {
+  scopeId: string;
+  topic: string;
+  kind: 'feed-intelligence-source' | 'browser-capture-source';
+  sourceClass: 'rss' | 'atom' | 'jsonFeed' | 'htmlFallback' | 'bearbrowser-capture';
+  publicSurfaceRef: string;
+  downstreamMembraneRef: string;
+  memoryProfileRef: string;
+  graphViewRef: string;
+  privacyPosture: string;
+  receiptRefs: string[];
+};
+
+export const slashTopicScopeFixtures: SlashTopicScopeFixture[] = [
+  {
+    scopeId: 'feed-global-news',
+    topic: '/news/global',
+    kind: 'feed-intelligence-source',
+    sourceClass: 'rss',
+    publicSurfaceRef: 'socioprophet-feed-intelligence-reader',
+    downstreamMembraneRef: 'new-hope-feed-item-membrane',
+    memoryProfileRef: 'memorymesh-feed-intelligence-profile',
+    graphViewRef: 'meshrush-feed-item-graph-view',
+    privacyPosture: 'public-source-private-annotation',
+    receiptRefs: ['feed.subscribed', 'item.fetched', 'item.normalized', 'membrane.evaluated'],
+  },
+  {
+    scopeId: 'feed-regulatory-watch',
+    topic: '/law/regulatory-watch',
+    kind: 'feed-intelligence-source',
+    sourceClass: 'atom',
+    publicSurfaceRef: 'socioprophet-feed-intelligence-reader',
+    downstreamMembraneRef: 'new-hope-feed-item-membrane',
+    memoryProfileRef: 'memorymesh-feed-intelligence-profile',
+    graphViewRef: 'meshrush-feed-item-graph-view',
+    privacyPosture: 'private-review-before-publication',
+    receiptRefs: ['item.fetched', 'item.normalized', 'membrane.evaluated'],
+  },
+  {
+    scopeId: 'feed-browser-capture',
+    topic: '/capture/browser',
+    kind: 'browser-capture-source',
+    sourceClass: 'bearbrowser-capture',
+    publicSurfaceRef: 'socioprophet-feed-intelligence-reader',
+    downstreamMembraneRef: 'new-hope-feed-item-membrane',
+    memoryProfileRef: 'memorymesh-local-only-capture-profile',
+    graphViewRef: 'meshrush-feed-item-graph-view',
+    privacyPosture: 'local-only-by-default',
+    receiptRefs: ['browser.page.captured', 'browser.provenance.attached', 'item.normalized', 'membrane.evaluated'],
+  },
+];
+
+export function resolveSlashTopicScopeForSource(source: FeedSource): SlashTopicScopeFixture | undefined {
+  return slashTopicScopeFixtures.find((scope) => scope.topic === source.scope);
+}
+
+export function slashTopicScopeBoundaryNotice(): string {
+  return 'SlashTopics scope resolution is fixture-only; no feed fetch, scope mutation, publication, memory writeback, or graph traversal is active.';
+}


### PR DESCRIPTION
## Summary

Adds a fixture-only SlashTopics scope resolver for Feed Intelligence reader sources.

## Changes

- Adds `slashTopicsScope.ts`.
- Adds `SlashTopicsScopeFixture.test.ts`.
- Resolves each reader source to a fixture scope.
- Keeps browser capture local-only by default.

## Validation

Connector compare shows two new files and no deletions.