### PR TITLE
Add New Hope membrane fixture resolver

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/NewHopeMembraneFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/NewHopeMembraneFixture.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { feedIntelligenceState } from '../features/feed-intelligence/state';
+import {
+  newHopeMembraneBoundaryNotice,
+  resolveNewHopeMembraneForItem,
+} from '../features/feed-intelligence/newHopeMembrane';
+
+describe('New Hope membrane fixture resolver', () => {
+  it('resolves every reader item to a fixture membrane decision', () => {
+    for (const item of feedIntelligenceState.items) {
+      const membrane = resolveNewHopeMembraneForItem(item);
+      expect(membrane).toBeDefined();
+      expect(membrane?.decision).toBe(item.membraneDecision);
+      expect(membrane?.slashTopicRef).toBe(item.topicScope);
+    }
+  });
+
+  it('keeps browser capture and handoff items quarantined and blocked downstream', () => {
+    const captureItems = feedIntelligenceState.items.filter((item) => item.topicScope === '/capture/browser');
+
+    expect(captureItems.length).toBeGreaterThan(0);
+
+    for (const item of captureItems) {
+      const membrane = resolveNewHopeMembraneForItem(item);
+      expect(membrane?.decision).toBe('quarantine');
+      expect(membrane?.downstreamEligibility.memoryWriteback).toBe('blocked');
+      expect(membrane?.downstreamEligibility.graphView).toBe('blocked');
+      expect(membrane?.downstreamEligibility.derivedPublication).toBe('blocked');
+    }
+  });
+
+  it('states disabled live side effects explicitly', () => {
+    expect(newHopeMembraneBoundaryNotice()).toContain('fixture-only');
+    expect(newHopeMembraneBoundaryNotice()).toContain('no live policy mutation');
+    expect(newHopeMembraneBoundaryNotice()).toContain('publication');
+    expect(newHopeMembraneBoundaryNotice()).toContain('memory writeback');
+    expect(newHopeMembraneBoundaryNotice()).toContain('graph traversal');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/newHopeMembrane.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/newHopeMembrane.ts
@@ -1,0 +1,83 @@
+import type { FeedItem, MembraneDecision } from './types';
+
+export type NewHopeMembraneFixture = {
+  eventId: string;
+  feedItemRef: string;
+  slashTopicRef: string;
+  decision: MembraneDecision;
+  reason: string;
+  evidenceRefs: string[];
+  downstreamEligibility: {
+    memoryRecall: 'eligible' | 'blocked';
+    memoryWriteback: 'reviewOnly' | 'blocked';
+    graphView: 'eligible' | 'blocked';
+    derivedPublication: 'policyRequired' | 'blocked';
+  };
+};
+
+export const newHopeMembraneFixtures: NewHopeMembraneFixture[] = [
+  {
+    eventId: 'newhope-feed-intelligence-001',
+    feedItemRef: 'item-001',
+    slashTopicRef: '/news/global',
+    decision: 'admit',
+    reason: 'source-normalized-and-scope-resolved',
+    evidenceRefs: ['eventlog://feed.subscribed/001', 'eventlog://item.fetched/001', 'eventlog://item.normalized/001'],
+    downstreamEligibility: {
+      memoryRecall: 'eligible',
+      memoryWriteback: 'reviewOnly',
+      graphView: 'eligible',
+      derivedPublication: 'policyRequired',
+    },
+  },
+  {
+    eventId: 'newhope-feed-intelligence-002',
+    feedItemRef: 'item-002',
+    slashTopicRef: '/law/regulatory-watch',
+    decision: 'hold',
+    reason: 'timestamp-and-transform-evidence-incomplete',
+    evidenceRefs: ['eventlog://item.fetched/002', 'eventlog://item.normalized/002'],
+    downstreamEligibility: {
+      memoryRecall: 'blocked',
+      memoryWriteback: 'blocked',
+      graphView: 'blocked',
+      derivedPublication: 'blocked',
+    },
+  },
+  {
+    eventId: 'newhope-feed-intelligence-003',
+    feedItemRef: 'item-003',
+    slashTopicRef: '/capture/browser',
+    decision: 'quarantine',
+    reason: 'browser-capture-local-review-required',
+    evidenceRefs: ['browser.page.captured:fixture-001', 'browser.provenance.attached:fixture-001'],
+    downstreamEligibility: {
+      memoryRecall: 'blocked',
+      memoryWriteback: 'blocked',
+      graphView: 'blocked',
+      derivedPublication: 'blocked',
+    },
+  },
+  {
+    eventId: 'newhope-feed-intelligence-004',
+    feedItemRef: 'item-bearbrowser-handoff-fixture-001',
+    slashTopicRef: '/capture/browser',
+    decision: 'quarantine',
+    reason: 'bearbrowser-handoff-fixture-local-only',
+    evidenceRefs: ['browser.reader.handoff.requested:fixture-001'],
+    downstreamEligibility: {
+      memoryRecall: 'blocked',
+      memoryWriteback: 'blocked',
+      graphView: 'blocked',
+      derivedPublication: 'blocked',
+    },
+  },
+];
+
+export function resolveNewHopeMembraneForItem(item: FeedItem): NewHopeMembraneFixture | undefined {
+  return newHopeMembraneFixtures.find((event) => event.feedItemRef === item.id);
+}
+
+export function newHopeMembraneBoundaryNotice(): string {
+  return 'New Hope membrane resolution is fixture-only; no live policy mutation, publication, memory writeback, or graph traversal is active.';
+}


### PR DESCRIPTION
## Summary

Adds a fixture-only New Hope membrane resolver for Feed Intelligence reader items.

## Changes

- Adds `newHopeMembrane.ts`.
- Adds `NewHopeMembraneFixture.test.ts`.
- Resolves every reader item to a fixture membrane decision.
- Keeps browser capture and handoff items quarantined with downstream effects blocked.

## Validation

Connector compare shows two new files and no deletions.