### PR TITLE
Add MemoryMesh posture fixture resolver

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/MemoryMeshPostureFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MemoryMeshPostureFixture.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { feedIntelligenceState } from '../features/feed-intelligence/state';
+import {
+  memoryMeshPostureBoundaryNotice,
+  resolveMemoryMeshPostureForItem,
+} from '../features/feed-intelligence/memoryMeshPosture';
+
+describe('MemoryMesh posture fixture resolver', () => {
+  it('resolves every reader item to a fixture memory posture', () => {
+    for (const item of feedIntelligenceState.items) {
+      const posture = resolveMemoryMeshPostureForItem(item);
+      expect(posture).toBeDefined();
+      expect(posture?.feedItemRef).toBe(item.id);
+      expect(posture?.topicScope).toBe(item.topicScope);
+    }
+  });
+
+  it('keeps recall display-only with raw payload storage disallowed', () => {
+    for (const item of feedIntelligenceState.items) {
+      const posture = resolveMemoryMeshPostureForItem(item);
+      expect(posture?.recallPolicy.mode).toBe('displayOnly');
+      expect(posture?.recallPolicy.sensitivePayloadStorage).toBe('disallowed');
+      expect(posture?.recallPolicy.includeRawEvents).toBe(false);
+    }
+  });
+
+  it('keeps durable writeback disabled for every item', () => {
+    for (const item of feedIntelligenceState.items) {
+      const posture = resolveMemoryMeshPostureForItem(item);
+      expect(posture?.writebackPolicy.enabled).toBe(false);
+      expect(posture?.writebackPolicy.dryRunMode).toBe('no-writeback');
+      expect(posture?.writebackPolicy.allowedMemoryClasses).toEqual([]);
+    }
+  });
+
+  it('states disabled live side effects explicitly', () => {
+    expect(memoryMeshPostureBoundaryNotice()).toContain('fixture-only');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('display-only');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('no live recall');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('durable writeback');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('raw payload storage');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('memory promotion');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/memoryMeshPosture.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/memoryMeshPosture.ts
@@ -1,0 +1,113 @@
+import type { FeedItem } from './types';
+
+export type MemoryMeshPostureFixture = {
+  memoryProfileRef: string;
+  feedItemRef: string;
+  topicScope: string;
+  recallPolicy: {
+    mode: 'displayOnly';
+    sensitivePayloadStorage: 'disallowed';
+    includeRawEvents: false;
+  };
+  writebackPolicy: {
+    enabled: false;
+    dryRunMode: 'no-writeback';
+    allowedMemoryClasses: [];
+  };
+  redaction: {
+    enabled: true;
+    redactedFields: string[];
+  };
+  evidenceRefs: string[];
+};
+
+export const memoryMeshPostureFixtures: MemoryMeshPostureFixture[] = [
+  {
+    memoryProfileRef: 'memorymesh-feed-intelligence-profile',
+    feedItemRef: 'item-001',
+    topicScope: '/news/global',
+    recallPolicy: {
+      mode: 'displayOnly',
+      sensitivePayloadStorage: 'disallowed',
+      includeRawEvents: false,
+    },
+    writebackPolicy: {
+      enabled: false,
+      dryRunMode: 'no-writeback',
+      allowedMemoryClasses: [],
+    },
+    redaction: {
+      enabled: true,
+      redactedFields: ['excerpt', 'annotationBody', 'browserProfileClass'],
+    },
+    evidenceRefs: ['eventlog://feed.subscribed/001', 'eventlog://item.normalized/001', 'eventlog://newhope.membrane/001'],
+  },
+  {
+    memoryProfileRef: 'memorymesh-feed-intelligence-profile',
+    feedItemRef: 'item-002',
+    topicScope: '/law/regulatory-watch',
+    recallPolicy: {
+      mode: 'displayOnly',
+      sensitivePayloadStorage: 'disallowed',
+      includeRawEvents: false,
+    },
+    writebackPolicy: {
+      enabled: false,
+      dryRunMode: 'no-writeback',
+      allowedMemoryClasses: [],
+    },
+    redaction: {
+      enabled: true,
+      redactedFields: ['excerpt', 'annotationBody', 'browserProfileClass'],
+    },
+    evidenceRefs: ['eventlog://item.normalized/002', 'eventlog://newhope.membrane/002'],
+  },
+  {
+    memoryProfileRef: 'memorymesh-local-only-capture-profile',
+    feedItemRef: 'item-003',
+    topicScope: '/capture/browser',
+    recallPolicy: {
+      mode: 'displayOnly',
+      sensitivePayloadStorage: 'disallowed',
+      includeRawEvents: false,
+    },
+    writebackPolicy: {
+      enabled: false,
+      dryRunMode: 'no-writeback',
+      allowedMemoryClasses: [],
+    },
+    redaction: {
+      enabled: true,
+      redactedFields: ['excerpt', 'annotationBody', 'browserProfileClass'],
+    },
+    evidenceRefs: ['browser.page.captured:fixture-001', 'browser.provenance.attached:fixture-001'],
+  },
+  {
+    memoryProfileRef: 'memorymesh-local-only-capture-profile',
+    feedItemRef: 'item-bearbrowser-handoff-fixture-001',
+    topicScope: '/capture/browser',
+    recallPolicy: {
+      mode: 'displayOnly',
+      sensitivePayloadStorage: 'disallowed',
+      includeRawEvents: false,
+    },
+    writebackPolicy: {
+      enabled: false,
+      dryRunMode: 'no-writeback',
+      allowedMemoryClasses: [],
+    },
+    redaction: {
+      enabled: true,
+      redactedFields: ['excerpt', 'annotationBody', 'browserProfileClass'],
+    },
+    evidenceRefs: ['browser.reader.handoff.requested:fixture-001'],
+  },
+];
+
+export function resolveMemoryMeshPostureForItem(item: FeedItem): MemoryMeshPostureFixture | undefined {
+  return memoryMeshPostureFixtures.find((posture) => posture.feedItemRef === item.id);
+}
+
+export function memoryMeshPostureBoundaryNotice(): string {
+  return 'MemoryMesh posture is fixture-only and display-only; no live recall, durable writeback, raw payload storage, or memory promotion is active.';
+}


### PR DESCRIPTION
## Summary

Adds a fixture-only memory posture resolver for Feed Intelligence reader items.

## Changes

- Adds `memoryMeshPosture.ts`.
- Adds `MemoryMeshPostureFixture.test.ts`.
- Resolves each reader item to display-only posture.
- Keeps storage restrictions explicit.

## Validation

Connector compare shows two new files and no deletions.