### PR TITLE
Add MeshRush graph-view fixture resolver

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/MeshRushGraphViewFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MeshRushGraphViewFixture.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { feedIntelligenceState } from '../features/feed-intelligence/state';
+import {
+  meshRushGraphViewBoundaryNotice,
+  resolveMeshRushGraphViewForItem,
+} from '../features/feed-intelligence/meshRushGraphView';
+
+describe('MeshRush graph-view fixture resolver', () => {
+  it('resolves graph views for graph-eligible and capture fixture items', () => {
+    const expectedGraphItems = feedIntelligenceState.items.filter((item) =>
+      ['item-001', 'item-003', 'item-bearbrowser-handoff-fixture-001'].includes(item.id),
+    );
+
+    for (const item of expectedGraphItems) {
+      const graphView = resolveMeshRushGraphViewForItem(item);
+      expect(graphView).toBeDefined();
+      expect(graphView?.feedItemRef).toBe(item.id);
+      expect(graphView?.displayMode).toBe('advisoryOnly');
+    }
+  });
+
+  it('keeps graph effects disabled for every fixture graph view', () => {
+    const graphViews = feedIntelligenceState.items
+      .map((item) => resolveMeshRushGraphViewForItem(item))
+      .filter(Boolean);
+
+    expect(graphViews.length).toBeGreaterThan(0);
+
+    for (const graphView of graphViews) {
+      expect(graphView?.boundary.liveTraversalEnabled).toBe(false);
+      expect(graphView?.boundary.graphPersistenceEnabled).toBe(false);
+      expect(graphView?.boundary.publicationEnabled).toBe(false);
+      expect(graphView?.stopCondition.satisfied).toBe(true);
+    }
+  });
+
+  it('states disabled live side effects explicitly', () => {
+    expect(meshRushGraphViewBoundaryNotice()).toContain('fixture-only');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('advisory-only');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('no live traversal');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('graph persistence');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('publication');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('runtime execution');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/meshRushGraphView.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/meshRushGraphView.ts
@@ -1,0 +1,81 @@
+import type { FeedItem } from './types';
+
+export type MeshRushGraphViewFixture = {
+  graphViewId: string;
+  feedItemRef: string;
+  entryNodeRefs: string[];
+  traversedNodeRefs: string[];
+  traversedEdgeRefs: string[];
+  displayMode: 'advisoryOnly';
+  stopCondition: {
+    reason: string;
+    satisfied: true;
+  };
+  boundary: {
+    liveTraversalEnabled: false;
+    graphPersistenceEnabled: false;
+    publicationEnabled: false;
+  };
+};
+
+export const meshRushGraphViewFixtures: MeshRushGraphViewFixture[] = [
+  {
+    graphViewId: 'graph-view-feed-intelligence-reader-0001',
+    feedItemRef: 'item-001',
+    entryNodeRefs: ['feed-item:item-001'],
+    traversedNodeRefs: ['feed-source:source-global-news', 'feed-item:item-001', 'slash-topic:/news/global', 'newhope-membrane:new-hope-feed-item-membrane', 'memory-profile:memorymesh-feed-intelligence-profile'],
+    traversedEdgeRefs: ['edge:feed-source-to-feed-item', 'edge:feed-item-to-slash-topic-scope', 'edge:slash-topic-to-newhope-membrane', 'edge:newhope-membrane-to-memory-profile'],
+    displayMode: 'advisoryOnly',
+    stopCondition: {
+      reason: 'derived-publication-boundary-reached',
+      satisfied: true,
+    },
+    boundary: {
+      liveTraversalEnabled: false,
+      graphPersistenceEnabled: false,
+      publicationEnabled: false,
+    },
+  },
+  {
+    graphViewId: 'graph-view-feed-intelligence-browser-capture-0001',
+    feedItemRef: 'item-003',
+    entryNodeRefs: ['feed-item:item-003'],
+    traversedNodeRefs: ['feed-source:source-bearbrowser-capture', 'feed-item:item-003', 'slash-topic:/capture/browser', 'newhope-membrane:new-hope-feed-item-membrane', 'memory-profile:memorymesh-local-only-capture-profile'],
+    traversedEdgeRefs: ['edge:feed-source-to-feed-item', 'edge:feed-item-to-slash-topic-scope', 'edge:slash-topic-to-newhope-membrane', 'edge:newhope-membrane-to-memory-profile'],
+    displayMode: 'advisoryOnly',
+    stopCondition: {
+      reason: 'local-capture-boundary-reached',
+      satisfied: true,
+    },
+    boundary: {
+      liveTraversalEnabled: false,
+      graphPersistenceEnabled: false,
+      publicationEnabled: false,
+    },
+  },
+  {
+    graphViewId: 'graph-view-feed-intelligence-browser-handoff-0001',
+    feedItemRef: 'item-bearbrowser-handoff-fixture-001',
+    entryNodeRefs: ['feed-item:item-bearbrowser-handoff-fixture-001'],
+    traversedNodeRefs: ['feed-source:source-bearbrowser-capture', 'feed-item:item-bearbrowser-handoff-fixture-001', 'slash-topic:/capture/browser', 'newhope-membrane:new-hope-feed-item-membrane', 'memory-profile:memorymesh-local-only-capture-profile'],
+    traversedEdgeRefs: ['edge:feed-source-to-feed-item', 'edge:feed-item-to-slash-topic-scope', 'edge:slash-topic-to-newhope-membrane', 'edge:newhope-membrane-to-memory-profile'],
+    displayMode: 'advisoryOnly',
+    stopCondition: {
+      reason: 'local-handoff-boundary-reached',
+      satisfied: true,
+    },
+    boundary: {
+      liveTraversalEnabled: false,
+      graphPersistenceEnabled: false,
+      publicationEnabled: false,
+    },
+  },
+];
+
+export function resolveMeshRushGraphViewForItem(item: FeedItem): MeshRushGraphViewFixture | undefined {
+  return meshRushGraphViewFixtures.find((view) => view.feedItemRef === item.id);
+}
+
+export function meshRushGraphViewBoundaryNotice(): string {
+  return 'MeshRush graph view is fixture-only and advisory-only; no live traversal, graph persistence, publication, memory writeback, or runtime execution is active.';
+}


### PR DESCRIPTION
## Summary

Adds a fixture-only MeshRush graph-view resolver for Feed Intelligence reader items.

## Changes

- Adds `meshRushGraphView.ts`.
- Adds `MeshRushGraphViewFixture.test.ts`.
- Resolves graph-view fixtures for eligible reader items.
- Keeps graph views advisory-only.

## Validation

Connector compare shows two new files and no deletions.