### PR TITLE
Add BearBrowser local-event handoff resolver

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   bearBrowserHandoffBoundaryNotice,
   bearBrowserReaderHandoffFixture,
+  isBearBrowserReaderHandoffFixture,
   mapBearBrowserHandoffToFeedItem,
+  resolveBearBrowserLocalEventHandoff,
 } from '../features/feed-intelligence/bearbrowserHandoff';
 
 describe('BearBrowser handoff fixture mapping', () => {
@@ -25,8 +27,47 @@ describe('BearBrowser handoff fixture mapping', () => {
     expect(item.summary).toContain('does not activate browser capture');
   });
 
+  it('keeps the local-event handoff adapter disabled by default', () => {
+    const resolution = resolveBearBrowserLocalEventHandoff({ enabled: false });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.item).toBeUndefined();
+    expect(resolution.reason).toContain('disabled');
+  });
+
+  it('requires an explicit local payload when enabled', () => {
+    const resolution = resolveBearBrowserLocalEventHandoff({ enabled: true });
+
+    expect(resolution.status).toBe('missing');
+    expect(resolution.item).toBeUndefined();
+  });
+
+  it('rejects invalid local payloads without mapping an item', () => {
+    const resolution = resolveBearBrowserLocalEventHandoff({
+      enabled: true,
+      payload: { sourceUrl: 'local://bad', storagePolicyRequest: 'hostedPublic' },
+    });
+
+    expect(resolution.status).toBe('invalid');
+    expect(resolution.item).toBeUndefined();
+  });
+
+  it('accepts only local-only BearBrowser handoff payloads', () => {
+    expect(isBearBrowserReaderHandoffFixture(bearBrowserReaderHandoffFixture)).toBe(true);
+
+    const resolution = resolveBearBrowserLocalEventHandoff({
+      enabled: true,
+      payload: bearBrowserReaderHandoffFixture,
+    });
+
+    expect(resolution.status).toBe('accepted');
+    expect(resolution.item?.storagePolicy).toBe('localOnly');
+    expect(resolution.item?.membraneDecision).toBe('quarantine');
+    expect(resolution.item?.claims).toContain('capture-is-not-publication');
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(bearBrowserHandoffBoundaryNotice()).toContain('fixture-only');
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('local-event only');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('no native browser bridge');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('memory writeback');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('graph traversal');

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
@@ -14,6 +14,23 @@ export type BearBrowserReaderHandoffFixture = {
   evidenceRefs: string[];
 };
 
+export type BearBrowserLocalEventAdapterState = {
+  enabled: boolean;
+  payload?: unknown;
+};
+
+export type BearBrowserLocalEventResolution =
+  | {
+      status: 'disabled' | 'missing' | 'invalid';
+      item?: undefined;
+      reason: string;
+    }
+  | {
+      status: 'accepted';
+      item: FeedItem;
+      reason: string;
+    };
+
 export const bearBrowserReaderHandoffFixture: BearBrowserReaderHandoffFixture = {
   sourceUrl: 'https://example.local/sourceos/bearbrowser-capture-demo',
   canonicalUrl: 'local://bearbrowser/captures/feed-intelligence-demo-001',
@@ -52,6 +69,59 @@ export function mapBearBrowserHandoffToFeedItem(
   };
 }
 
+export function resolveBearBrowserLocalEventHandoff(
+  state: BearBrowserLocalEventAdapterState,
+): BearBrowserLocalEventResolution {
+  if (!state.enabled) {
+    return {
+      status: 'disabled',
+      reason: 'BearBrowser local-event handoff adapter is disabled.',
+    };
+  }
+
+  if (state.payload === undefined || state.payload === null) {
+    return {
+      status: 'missing',
+      reason: 'No explicit local BearBrowser handoff payload was provided.',
+    };
+  }
+
+  if (!isBearBrowserReaderHandoffFixture(state.payload)) {
+    return {
+      status: 'invalid',
+      reason: 'Local BearBrowser handoff payload failed shape validation.',
+    };
+  }
+
+  return {
+    status: 'accepted',
+    item: mapBearBrowserHandoffToFeedItem(state.payload),
+    reason: 'Local BearBrowser handoff payload accepted as local-only reader item.',
+  };
+}
+
+export function isBearBrowserReaderHandoffFixture(
+  value: unknown,
+): value is BearBrowserReaderHandoffFixture {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as Partial<BearBrowserReaderHandoffFixture>;
+
+  return (
+    typeof candidate.sourceUrl === 'string' &&
+    typeof candidate.contentHash === 'string' &&
+    typeof candidate.capturedAt === 'string' &&
+    isBearBrowserProfileClass(candidate.browserProfileClass) &&
+    candidate.storagePolicyRequest === 'localOnly' &&
+    Array.isArray(candidate.evidenceRefs) &&
+    candidate.evidenceRefs.every((ref) => typeof ref === 'string')
+  );
+}
+
+function isBearBrowserProfileClass(value: unknown): value is BearBrowserProfileClass {
+  return value === 'human' || value === 'agent' || value === 'terminal';
+}
+
 export function bearBrowserHandoffBoundaryNotice(): string {
-  return 'BearBrowser handoff is fixture-only; no native browser bridge, network fetch, publication, memory writeback, or graph traversal is active.';
+  return 'BearBrowser handoff is local-event only; no native browser bridge, network fetch, publication, memory writeback, or graph traversal is active.';
 }


### PR DESCRIPTION
## Summary

Implements the first gated BearBrowser read-only local-event handoff seam for Feed Intelligence.

## Changes

- Extends `bearbrowserHandoff.ts` with a disabled-by-default local-event resolver.
- Accepts only explicit local payload input.
- Validates payload shape before mapping to a local-only quarantined reader item.
- Extends `BearBrowserHandoffFixture.test.ts` for disabled, missing, invalid, and accepted payload states.

## Live-adapter gate

1. Adapter enabled: BearBrowser local-event handoff resolver only.
2. Owning artifact: `SourceOS-Linux/BearBrowser:docs/reader-bridge.md` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: local payload shape validation and in-memory item mapping.
4. Impossible side effects: no native browser bridge, network fetch, publication, federation, memory writeback, graph traversal, or persistence.
5. Disable path: pass `{ enabled: false }`; the resolver returns disabled and no item.
6. Tests: disabled, missing payload, invalid payload, accepted local-only payload, boundary notice.
7. Rollback: revert this two-file PR; existing fixture-backed reader state remains usable.

## Validation

Connector compare shows two files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #368.