### PR TITLE
Display BearBrowser local-event resolver status

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -32,6 +32,15 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('MeshRush graph-view adapter');
   });
 
+  it('renders BearBrowser local-event resolver status as disabled by default', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('BearBrowser local-event resolver');
+    expect(wrapper.text()).toContain('disabled');
+    expect(wrapper.text()).toContain('BearBrowser local-event handoff adapter is disabled');
+    expect(wrapper.text()).toContain('no native browser bridge');
+  });
+
   it('renders fixture-chain resolver outputs for the selected item', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/pages/Reader.vue
+++ b/socioprophet-web/client-vue/src/pages/Reader.vue
@@ -40,6 +40,15 @@
       </div>
     </section>
 
+    <section class="feed-card adapter-boundary" aria-label="BearBrowser local-event resolver status">
+      <div class="panel-heading">
+        <span>BearBrowser local-event resolver</span>
+        <strong>{{ bearBrowserLocalEventResolution.status }}</strong>
+      </div>
+      <p>{{ bearBrowserLocalEventResolution.reason }}</p>
+      <small>{{ bearBrowserHandoffBoundaryNotice() }}</small>
+    </section>
+
     <section class="ticker-card" aria-label="Ticker proof of life">
       <span class="ticker-label">Ticker</span>
       <button
@@ -180,6 +189,10 @@ import {
   adapterBoundarySummary,
   feedIntelligenceAdapters,
 } from '../features/feed-intelligence/adapters';
+import {
+  bearBrowserHandoffBoundaryNotice,
+  resolveBearBrowserLocalEventHandoff,
+} from '../features/feed-intelligence/bearbrowserHandoff';
 import { resolveMeshRushGraphViewForItem } from '../features/feed-intelligence/meshRushGraphView';
 import { resolveMemoryMeshPostureForItem } from '../features/feed-intelligence/memoryMeshPosture';
 import { resolveNewHopeMembraneForItem } from '../features/feed-intelligence/newHopeMembrane';
@@ -206,6 +219,7 @@ const selectedSlashTopicScope = computed(() =>
 const selectedNewHopeMembrane = computed(() => resolveNewHopeMembraneForItem(selectedItem.value));
 const selectedMemoryMeshPosture = computed(() => resolveMemoryMeshPostureForItem(selectedItem.value));
 const selectedMeshRushGraphView = computed(() => resolveMeshRushGraphViewForItem(selectedItem.value));
+const bearBrowserLocalEventResolution = computed(() => resolveBearBrowserLocalEventHandoff({ enabled: false }));
 
 function formatPolicy(policy: StoragePolicy): string {
   return policy.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());


### PR DESCRIPTION
## Summary

Displays the BearBrowser local-event resolver status in the Feed Intelligence reader as read-only state.

## Changes

- Updates `Reader.vue` with a read-only BearBrowser local-event resolver status panel.
- Shows the disabled default state and boundary notice.
- Updates `FeedIntelligence.smoke.test.ts` to assert the status panel.

## Live-adapter gate

1. Adapter enabled: none. This displays resolver state only.
2. Owning artifact: `SourceOS-Linux/BearBrowser:docs/reader-bridge.md` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: render local resolver status text.
4. Impossible side effects: no native bridge, UI input, network fetch, publication, federation, memory writeback, graph traversal, or persistence.
5. Disable path: resolver is called with `{ enabled: false }`.
6. Tests: smoke test asserts disabled status and no native bridge boundary text.
7. Rollback: revert this two-file PR; reader remains fixture-backed.

## Validation

Connector compare shows two files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #370.