### PR TITLE
Add SlashTopics read-only resolver status

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -41,6 +41,15 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('no native browser bridge');
   });
 
+  it('renders SlashTopics read-only resolver status as disabled by default', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('SlashTopics read-only resolver');
+    expect(wrapper.text()).toContain('SlashTopics read-only resolver is disabled');
+    expect(wrapper.text()).toContain('no feed fetch');
+    expect(wrapper.text()).toContain('scope mutation');
+  });
+
   it('renders fixture-chain resolver outputs for the selected item', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/__tests__/SlashTopicsScopeFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/SlashTopicsScopeFixture.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { feedIntelligenceState } from '../features/feed-intelligence/state';
 import {
   resolveSlashTopicScopeForSource,
+  resolveSlashTopicsReadOnlyScope,
   slashTopicScopeBoundaryNotice,
   slashTopicScopeFixtures,
 } from '../features/feed-intelligence/slashTopicsScope';
@@ -24,8 +25,49 @@ describe('SlashTopics scope fixture resolver', () => {
     expect(browserScope?.receiptRefs).toContain('browser.page.captured');
   });
 
+  it('keeps the read-only resolver disabled by default', () => {
+    const resolution = resolveSlashTopicsReadOnlyScope({ enabled: false });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.scope).toBeUndefined();
+    expect(resolution.reason).toContain('disabled');
+  });
+
+  it('handles missing source as unresolved without mutating scope state', () => {
+    const resolution = resolveSlashTopicsReadOnlyScope({ enabled: true });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.scope).toBeUndefined();
+    expect(resolution.reason).toContain('No Feed Intelligence source');
+  });
+
+  it('handles unknown source scope as unresolved', () => {
+    const resolution = resolveSlashTopicsReadOnlyScope({
+      enabled: true,
+      source: {
+        ...feedIntelligenceState.sources[0],
+        id: 'source-unknown',
+        scope: '/unknown/scope',
+      },
+    });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.scope).toBeUndefined();
+  });
+
+  it('resolves known source scope in read-only mode', () => {
+    const resolution = resolveSlashTopicsReadOnlyScope({
+      enabled: true,
+      source: feedIntelligenceState.sources[0],
+    });
+
+    expect(resolution.status).toBe('resolved');
+    expect(resolution.scope?.scopeId).toBe('feed-global-news');
+    expect(resolution.reason).toContain('read-only');
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(slashTopicScopeBoundaryNotice()).toContain('fixture-only');
+    expect(slashTopicScopeBoundaryNotice()).toContain('read-only');
     expect(slashTopicScopeBoundaryNotice()).toContain('no feed fetch');
     expect(slashTopicScopeBoundaryNotice()).toContain('scope mutation');
     expect(slashTopicScopeBoundaryNotice()).toContain('memory writeback');

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/slashTopicsScope.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/slashTopicsScope.ts
@@ -13,6 +13,23 @@ export type SlashTopicScopeFixture = {
   receiptRefs: string[];
 };
 
+export type SlashTopicsReadOnlyResolverState = {
+  enabled: boolean;
+  source?: FeedSource;
+};
+
+export type SlashTopicsReadOnlyResolution =
+  | {
+      status: 'disabled' | 'unresolved';
+      scope?: undefined;
+      reason: string;
+    }
+  | {
+      status: 'resolved';
+      scope: SlashTopicScopeFixture;
+      reason: string;
+    };
+
 export const slashTopicScopeFixtures: SlashTopicScopeFixture[] = [
   {
     scopeId: 'feed-global-news',
@@ -56,6 +73,39 @@ export function resolveSlashTopicScopeForSource(source: FeedSource): SlashTopicS
   return slashTopicScopeFixtures.find((scope) => scope.topic === source.scope);
 }
 
+export function resolveSlashTopicsReadOnlyScope(
+  state: SlashTopicsReadOnlyResolverState,
+): SlashTopicsReadOnlyResolution {
+  if (!state.enabled) {
+    return {
+      status: 'disabled',
+      reason: 'SlashTopics read-only resolver is disabled.',
+    };
+  }
+
+  if (!state.source) {
+    return {
+      status: 'unresolved',
+      reason: 'No Feed Intelligence source was provided for read-only scope resolution.',
+    };
+  }
+
+  const scope = resolveSlashTopicScopeForSource(state.source);
+
+  if (!scope) {
+    return {
+      status: 'unresolved',
+      reason: 'No fixture slash-topic scope matched the source scope.',
+    };
+  }
+
+  return {
+    status: 'resolved',
+    scope,
+    reason: 'Fixture slash-topic scope resolved in read-only mode.',
+  };
+}
+
 export function slashTopicScopeBoundaryNotice(): string {
-  return 'SlashTopics scope resolution is fixture-only; no feed fetch, scope mutation, publication, memory writeback, or graph traversal is active.';
+  return 'SlashTopics scope resolution is read-only; no feed fetch, scope mutation, publication, memory writeback, or graph traversal is active.';
 }

--- a/socioprophet-web/client-vue/src/pages/Reader.vue
+++ b/socioprophet-web/client-vue/src/pages/Reader.vue
@@ -49,6 +49,15 @@
       <small>{{ bearBrowserHandoffBoundaryNotice() }}</small>
     </section>
 
+    <section class="feed-card adapter-boundary" aria-label="SlashTopics read-only resolver status">
+      <div class="panel-heading">
+        <span>SlashTopics read-only resolver</span>
+        <strong>{{ slashTopicsReadOnlyResolution.status }}</strong>
+      </div>
+      <p>{{ slashTopicsReadOnlyResolution.reason }}</p>
+      <small>{{ slashTopicScopeBoundaryNotice() }}</small>
+    </section>
+
     <section class="ticker-card" aria-label="Ticker proof of life">
       <span class="ticker-label">Ticker</span>
       <button
@@ -196,7 +205,11 @@ import {
 import { resolveMeshRushGraphViewForItem } from '../features/feed-intelligence/meshRushGraphView';
 import { resolveMemoryMeshPostureForItem } from '../features/feed-intelligence/memoryMeshPosture';
 import { resolveNewHopeMembraneForItem } from '../features/feed-intelligence/newHopeMembrane';
-import { resolveSlashTopicScopeForSource } from '../features/feed-intelligence/slashTopicsScope';
+import {
+  resolveSlashTopicScopeForSource,
+  resolveSlashTopicsReadOnlyScope,
+  slashTopicScopeBoundaryNotice,
+} from '../features/feed-intelligence/slashTopicsScope';
 import { feedIntelligenceState as state } from '../features/feed-intelligence/state';
 import type { StoragePolicy } from '../features/feed-intelligence/types';
 
@@ -220,6 +233,7 @@ const selectedNewHopeMembrane = computed(() => resolveNewHopeMembraneForItem(sel
 const selectedMemoryMeshPosture = computed(() => resolveMemoryMeshPostureForItem(selectedItem.value));
 const selectedMeshRushGraphView = computed(() => resolveMeshRushGraphViewForItem(selectedItem.value));
 const bearBrowserLocalEventResolution = computed(() => resolveBearBrowserLocalEventHandoff({ enabled: false }));
+const slashTopicsReadOnlyResolution = computed(() => resolveSlashTopicsReadOnlyScope({ enabled: false }));
 
 function formatPolicy(policy: StoragePolicy): string {
   return policy.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());


### PR DESCRIPTION
## Summary

Adds a disabled/default SlashTopics read-only resolver state for Feed Intelligence.

## Changes

- Extends `slashTopicsScope.ts` with read-only resolver state and resolution outcomes.
- Adds tests for disabled, missing source, unknown source, and resolved source behavior.
- Displays SlashTopics read-only resolver status in `Reader.vue`.
- Updates the Feed Intelligence smoke test to assert the visible disabled resolver status.

## Live-adapter gate

1. Adapter enabled: none. This adds read-only resolver state and displays disabled/default posture.
2. Owning artifact: `SocioProphet/slash-topics:examples/feed-intelligence/scope.example.md` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: fixture lookup and status rendering only.
4. Impossible side effects: no scope mutation, feed fetch, publication, federation, memory writeback, graph traversal, or persistence.
5. Disable path: resolver is called with `{ enabled: false }`.
6. Tests: unit tests cover disabled, unresolved, and resolved states; smoke test asserts disabled status panel.
7. Rollback: revert this PR; existing fixture-backed reader and fixture scope lookup remain usable.

## Validation

Connector compare shows four files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #372.