### PR TITLE
Add New Hope read-only membrane resolver status

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -50,6 +50,15 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('scope mutation');
   });
 
+  it('renders New Hope read-only membrane resolver status as disabled by default', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('New Hope read-only membrane resolver');
+    expect(wrapper.text()).toContain('New Hope read-only membrane resolver is disabled');
+    expect(wrapper.text()).toContain('no live policy mutation');
+    expect(wrapper.text()).toContain('memory writeback');
+  });
+
   it('renders fixture-chain resolver outputs for the selected item', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/__tests__/NewHopeMembraneFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/NewHopeMembraneFixture.test.ts
@@ -3,6 +3,7 @@ import { feedIntelligenceState } from '../features/feed-intelligence/state';
 import {
   newHopeMembraneBoundaryNotice,
   resolveNewHopeMembraneForItem,
+  resolveNewHopeReadOnlyMembrane,
 } from '../features/feed-intelligence/newHopeMembrane';
 
 describe('New Hope membrane fixture resolver', () => {
@@ -29,8 +30,61 @@ describe('New Hope membrane fixture resolver', () => {
     }
   });
 
+  it('keeps the read-only membrane resolver disabled by default', () => {
+    const resolution = resolveNewHopeReadOnlyMembrane({ enabled: false });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.membrane).toBeUndefined();
+    expect(resolution.reason).toContain('disabled');
+  });
+
+  it('handles missing item as unresolved without mutating policy state', () => {
+    const resolution = resolveNewHopeReadOnlyMembrane({ enabled: true });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.membrane).toBeUndefined();
+    expect(resolution.reason).toContain('No Feed Intelligence item');
+  });
+
+  it('handles unknown item as unresolved', () => {
+    const resolution = resolveNewHopeReadOnlyMembrane({
+      enabled: true,
+      item: {
+        ...feedIntelligenceState.items[0],
+        id: 'item-unknown',
+      },
+    });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.membrane).toBeUndefined();
+  });
+
+  it('resolves known item membrane in read-only mode', () => {
+    const resolution = resolveNewHopeReadOnlyMembrane({
+      enabled: true,
+      item: feedIntelligenceState.items[0],
+    });
+
+    expect(resolution.status).toBe('resolved');
+    expect(resolution.membrane?.eventId).toBe('newhope-feed-intelligence-001');
+    expect(resolution.reason).toContain('read-only');
+  });
+
+  it('does not promote guarded or blocked capture states', () => {
+    const captureItems = feedIntelligenceState.items.filter((item) => item.topicScope === '/capture/browser');
+
+    for (const item of captureItems) {
+      const resolution = resolveNewHopeReadOnlyMembrane({ enabled: true, item });
+      expect(resolution.status).toBe('resolved');
+      expect(resolution.membrane?.decision).toBe('quarantine');
+      expect(resolution.membrane?.downstreamEligibility.memoryWriteback).toBe('blocked');
+      expect(resolution.membrane?.downstreamEligibility.graphView).toBe('blocked');
+      expect(resolution.membrane?.downstreamEligibility.derivedPublication).toBe('blocked');
+    }
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(newHopeMembraneBoundaryNotice()).toContain('fixture-only');
+    expect(newHopeMembraneBoundaryNotice()).toContain('read-only');
     expect(newHopeMembraneBoundaryNotice()).toContain('no live policy mutation');
     expect(newHopeMembraneBoundaryNotice()).toContain('publication');
     expect(newHopeMembraneBoundaryNotice()).toContain('memory writeback');

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/newHopeMembrane.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/newHopeMembrane.ts
@@ -15,6 +15,23 @@ export type NewHopeMembraneFixture = {
   };
 };
 
+export type NewHopeReadOnlyResolverState = {
+  enabled: boolean;
+  item?: FeedItem;
+};
+
+export type NewHopeReadOnlyResolution =
+  | {
+      status: 'disabled' | 'unresolved';
+      membrane?: undefined;
+      reason: string;
+    }
+  | {
+      status: 'resolved';
+      membrane: NewHopeMembraneFixture;
+      reason: string;
+    };
+
 export const newHopeMembraneFixtures: NewHopeMembraneFixture[] = [
   {
     eventId: 'newhope-feed-intelligence-001',
@@ -78,6 +95,39 @@ export function resolveNewHopeMembraneForItem(item: FeedItem): NewHopeMembraneFi
   return newHopeMembraneFixtures.find((event) => event.feedItemRef === item.id);
 }
 
+export function resolveNewHopeReadOnlyMembrane(
+  state: NewHopeReadOnlyResolverState,
+): NewHopeReadOnlyResolution {
+  if (!state.enabled) {
+    return {
+      status: 'disabled',
+      reason: 'New Hope read-only membrane resolver is disabled.',
+    };
+  }
+
+  if (!state.item) {
+    return {
+      status: 'unresolved',
+      reason: 'No Feed Intelligence item was provided for read-only membrane resolution.',
+    };
+  }
+
+  const membrane = resolveNewHopeMembraneForItem(state.item);
+
+  if (!membrane) {
+    return {
+      status: 'unresolved',
+      reason: 'No fixture New Hope membrane event matched the selected item.',
+    };
+  }
+
+  return {
+    status: 'resolved',
+    membrane,
+    reason: 'Fixture New Hope membrane resolved in read-only mode.',
+  };
+}
+
 export function newHopeMembraneBoundaryNotice(): string {
-  return 'New Hope membrane resolution is fixture-only; no live policy mutation, publication, memory writeback, or graph traversal is active.';
+  return 'New Hope membrane resolution is read-only; no live policy mutation, publication, memory writeback, or graph traversal is active.';
 }

--- a/socioprophet-web/client-vue/src/pages/Reader.vue
+++ b/socioprophet-web/client-vue/src/pages/Reader.vue
@@ -58,6 +58,15 @@
       <small>{{ slashTopicScopeBoundaryNotice() }}</small>
     </section>
 
+    <section class="feed-card adapter-boundary" aria-label="New Hope read-only membrane resolver status">
+      <div class="panel-heading">
+        <span>New Hope read-only membrane resolver</span>
+        <strong>{{ newHopeReadOnlyResolution.status }}</strong>
+      </div>
+      <p>{{ newHopeReadOnlyResolution.reason }}</p>
+      <small>{{ newHopeMembraneBoundaryNotice() }}</small>
+    </section>
+
     <section class="ticker-card" aria-label="Ticker proof of life">
       <span class="ticker-label">Ticker</span>
       <button
@@ -204,7 +213,11 @@ import {
 } from '../features/feed-intelligence/bearbrowserHandoff';
 import { resolveMeshRushGraphViewForItem } from '../features/feed-intelligence/meshRushGraphView';
 import { resolveMemoryMeshPostureForItem } from '../features/feed-intelligence/memoryMeshPosture';
-import { resolveNewHopeMembraneForItem } from '../features/feed-intelligence/newHopeMembrane';
+import {
+  newHopeMembraneBoundaryNotice,
+  resolveNewHopeMembraneForItem,
+  resolveNewHopeReadOnlyMembrane,
+} from '../features/feed-intelligence/newHopeMembrane';
 import {
   resolveSlashTopicScopeForSource,
   resolveSlashTopicsReadOnlyScope,
@@ -234,6 +247,7 @@ const selectedMemoryMeshPosture = computed(() => resolveMemoryMeshPostureForItem
 const selectedMeshRushGraphView = computed(() => resolveMeshRushGraphViewForItem(selectedItem.value));
 const bearBrowserLocalEventResolution = computed(() => resolveBearBrowserLocalEventHandoff({ enabled: false }));
 const slashTopicsReadOnlyResolution = computed(() => resolveSlashTopicsReadOnlyScope({ enabled: false }));
+const newHopeReadOnlyResolution = computed(() => resolveNewHopeReadOnlyMembrane({ enabled: false }));
 
 function formatPolicy(policy: StoragePolicy): string {
   return policy.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());


### PR DESCRIPTION
## Summary

Adds a disabled/default New Hope read-only membrane resolver state for Feed Intelligence.

## Changes

- Extends `newHopeMembrane.ts` with read-only resolver state and resolution outcomes.
- Adds tests for disabled, missing item, unknown item, resolved item, and blocked capture behavior.
- Displays New Hope read-only membrane resolver status in `Reader.vue`.
- Updates the Feed Intelligence smoke test to assert the visible disabled resolver status.

## Live-adapter gate

1. Adapter enabled: none. This adds read-only resolver state and displays disabled/default posture.
2. Owning artifact: `SocioProphet/new-hope:examples/feed-intelligence/membrane-event.example.md` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: fixture lookup and status rendering only.
4. Impossible side effects: no live policy mutation, publication, federation, memory writeback, graph traversal, or persistence.
5. Disable path: resolver is called with `{ enabled: false }`.
6. Tests: unit tests cover disabled, unresolved, resolved, and blocked capture states; smoke test asserts disabled status panel.
7. Rollback: revert this PR; existing fixture-backed reader and fixture membrane lookup remain usable.

## Validation

Connector compare shows four files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #374.