### PR TITLE
Add MemoryMesh read-only posture resolver status

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -59,6 +59,16 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('memory writeback');
   });
 
+  it('renders MemoryMesh read-only posture resolver status as disabled by default', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('MemoryMesh read-only posture resolver');
+    expect(wrapper.text()).toContain('MemoryMesh read-only posture resolver is disabled');
+    expect(wrapper.text()).toContain('no live recall');
+    expect(wrapper.text()).toContain('durable writeback');
+    expect(wrapper.text()).toContain('raw payload storage');
+  });
+
   it('renders fixture-chain resolver outputs for the selected item', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/__tests__/MemoryMeshPostureFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MemoryMeshPostureFixture.test.ts
@@ -3,6 +3,7 @@ import { feedIntelligenceState } from '../features/feed-intelligence/state';
 import {
   memoryMeshPostureBoundaryNotice,
   resolveMemoryMeshPostureForItem,
+  resolveMemoryMeshReadOnlyPosture,
 } from '../features/feed-intelligence/memoryMeshPosture';
 
 describe('MemoryMesh posture fixture resolver', () => {
@@ -33,8 +34,58 @@ describe('MemoryMesh posture fixture resolver', () => {
     }
   });
 
+  it('keeps the read-only posture resolver disabled by default', () => {
+    const resolution = resolveMemoryMeshReadOnlyPosture({ enabled: false });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.posture).toBeUndefined();
+    expect(resolution.reason).toContain('disabled');
+  });
+
+  it('handles missing item as unresolved without enabling memory behavior', () => {
+    const resolution = resolveMemoryMeshReadOnlyPosture({ enabled: true });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.posture).toBeUndefined();
+    expect(resolution.reason).toContain('No Feed Intelligence item');
+  });
+
+  it('handles unknown item as unresolved', () => {
+    const resolution = resolveMemoryMeshReadOnlyPosture({
+      enabled: true,
+      item: {
+        ...feedIntelligenceState.items[0],
+        id: 'item-unknown',
+      },
+    });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.posture).toBeUndefined();
+  });
+
+  it('resolves known item posture in read-only display mode', () => {
+    const resolution = resolveMemoryMeshReadOnlyPosture({
+      enabled: true,
+      item: feedIntelligenceState.items[0],
+    });
+
+    expect(resolution.status).toBe('resolved');
+    expect(resolution.posture?.memoryProfileRef).toBe('memorymesh-feed-intelligence-profile');
+    expect(resolution.reason).toContain('read-only display mode');
+  });
+
+  it('keeps read-only resolved posture writeback disabled', () => {
+    for (const item of feedIntelligenceState.items) {
+      const resolution = resolveMemoryMeshReadOnlyPosture({ enabled: true, item });
+      expect(resolution.status).toBe('resolved');
+      expect(resolution.posture?.writebackPolicy.enabled).toBe(false);
+      expect(resolution.posture?.writebackPolicy.dryRunMode).toBe('no-writeback');
+      expect(resolution.posture?.recallPolicy.sensitivePayloadStorage).toBe('disallowed');
+    }
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(memoryMeshPostureBoundaryNotice()).toContain('fixture-only');
+    expect(memoryMeshPostureBoundaryNotice()).toContain('read-only');
     expect(memoryMeshPostureBoundaryNotice()).toContain('display-only');
     expect(memoryMeshPostureBoundaryNotice()).toContain('no live recall');
     expect(memoryMeshPostureBoundaryNotice()).toContain('durable writeback');

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/memoryMeshPosture.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/memoryMeshPosture.ts
@@ -21,6 +21,23 @@ export type MemoryMeshPostureFixture = {
   evidenceRefs: string[];
 };
 
+export type MemoryMeshReadOnlyResolverState = {
+  enabled: boolean;
+  item?: FeedItem;
+};
+
+export type MemoryMeshReadOnlyResolution =
+  | {
+      status: 'disabled' | 'unresolved';
+      posture?: undefined;
+      reason: string;
+    }
+  | {
+      status: 'resolved';
+      posture: MemoryMeshPostureFixture;
+      reason: string;
+    };
+
 export const memoryMeshPostureFixtures: MemoryMeshPostureFixture[] = [
   {
     memoryProfileRef: 'memorymesh-feed-intelligence-profile',
@@ -108,6 +125,39 @@ export function resolveMemoryMeshPostureForItem(item: FeedItem): MemoryMeshPostu
   return memoryMeshPostureFixtures.find((posture) => posture.feedItemRef === item.id);
 }
 
+export function resolveMemoryMeshReadOnlyPosture(
+  state: MemoryMeshReadOnlyResolverState,
+): MemoryMeshReadOnlyResolution {
+  if (!state.enabled) {
+    return {
+      status: 'disabled',
+      reason: 'MemoryMesh read-only posture resolver is disabled.',
+    };
+  }
+
+  if (!state.item) {
+    return {
+      status: 'unresolved',
+      reason: 'No Feed Intelligence item was provided for read-only memory posture resolution.',
+    };
+  }
+
+  const posture = resolveMemoryMeshPostureForItem(state.item);
+
+  if (!posture) {
+    return {
+      status: 'unresolved',
+      reason: 'No fixture MemoryMesh posture matched the selected item.',
+    };
+  }
+
+  return {
+    status: 'resolved',
+    posture,
+    reason: 'Fixture MemoryMesh posture resolved in read-only display mode.',
+  };
+}
+
 export function memoryMeshPostureBoundaryNotice(): string {
-  return 'MemoryMesh posture is fixture-only and display-only; no live recall, durable writeback, raw payload storage, or memory promotion is active.';
+  return 'MemoryMesh posture is read-only and display-only; no live recall, durable writeback, raw payload storage, or memory promotion is active.';
 }

--- a/socioprophet-web/client-vue/src/pages/Reader.vue
+++ b/socioprophet-web/client-vue/src/pages/Reader.vue
@@ -67,6 +67,15 @@
       <small>{{ newHopeMembraneBoundaryNotice() }}</small>
     </section>
 
+    <section class="feed-card adapter-boundary" aria-label="MemoryMesh read-only posture resolver status">
+      <div class="panel-heading">
+        <span>MemoryMesh read-only posture resolver</span>
+        <strong>{{ memoryMeshReadOnlyResolution.status }}</strong>
+      </div>
+      <p>{{ memoryMeshReadOnlyResolution.reason }}</p>
+      <small>{{ memoryMeshPostureBoundaryNotice() }}</small>
+    </section>
+
     <section class="ticker-card" aria-label="Ticker proof of life">
       <span class="ticker-label">Ticker</span>
       <button
@@ -212,7 +221,11 @@ import {
   resolveBearBrowserLocalEventHandoff,
 } from '../features/feed-intelligence/bearbrowserHandoff';
 import { resolveMeshRushGraphViewForItem } from '../features/feed-intelligence/meshRushGraphView';
-import { resolveMemoryMeshPostureForItem } from '../features/feed-intelligence/memoryMeshPosture';
+import {
+  memoryMeshPostureBoundaryNotice,
+  resolveMemoryMeshPostureForItem,
+  resolveMemoryMeshReadOnlyPosture,
+} from '../features/feed-intelligence/memoryMeshPosture';
 import {
   newHopeMembraneBoundaryNotice,
   resolveNewHopeMembraneForItem,
@@ -248,6 +261,7 @@ const selectedMeshRushGraphView = computed(() => resolveMeshRushGraphViewForItem
 const bearBrowserLocalEventResolution = computed(() => resolveBearBrowserLocalEventHandoff({ enabled: false }));
 const slashTopicsReadOnlyResolution = computed(() => resolveSlashTopicsReadOnlyScope({ enabled: false }));
 const newHopeReadOnlyResolution = computed(() => resolveNewHopeReadOnlyMembrane({ enabled: false }));
+const memoryMeshReadOnlyResolution = computed(() => resolveMemoryMeshReadOnlyPosture({ enabled: false }));
 
 function formatPolicy(policy: StoragePolicy): string {
   return policy.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());


### PR DESCRIPTION
## Summary

Adds a disabled/default MemoryMesh read-only posture resolver state for Feed Intelligence.

## Changes

- Extends `memoryMeshPosture.ts` with read-only resolver state and resolution outcomes.
- Adds tests for disabled, missing item, unknown item, resolved item, and writeback-blocked behavior.
- Displays MemoryMesh read-only posture resolver status in `Reader.vue`.
- Updates the Feed Intelligence smoke test to assert the visible disabled resolver status.

## Live-adapter gate

1. Adapter enabled: none. This adds read-only/display-only resolver state and displays disabled/default posture.
2. Owning artifact: `SocioProphet/memory-mesh:examples/feed-intelligence/memory-profile.example.md` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: fixture lookup and status rendering only.
4. Impossible side effects: no live memory recall, durable writeback, raw payload storage, memory promotion, publication, federation, graph traversal, or persistence.
5. Disable path: resolver is called with `{ enabled: false }`.
6. Tests: unit tests cover disabled, unresolved, resolved, and writeback-blocked states; smoke test asserts disabled status panel.
7. Rollback: revert this PR; existing fixture-backed reader and fixture memory posture lookup remain usable.

## Validation

Connector compare shows four files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #376.