### PR TITLE
Add MeshRush read-only graph-view resolver status

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/FeedIntelligence.smoke.test.ts
@@ -69,6 +69,16 @@ describe('Feed Intelligence Reader', () => {
     expect(wrapper.text()).toContain('raw payload storage');
   });
 
+  it('renders MeshRush read-only graph-view resolver status as disabled by default', () => {
+    const wrapper = mount(Reader);
+
+    expect(wrapper.text()).toContain('MeshRush read-only graph-view resolver');
+    expect(wrapper.text()).toContain('MeshRush read-only graph-view resolver is disabled');
+    expect(wrapper.text()).toContain('no live traversal');
+    expect(wrapper.text()).toContain('graph persistence');
+    expect(wrapper.text()).toContain('runtime execution');
+  });
+
   it('renders fixture-chain resolver outputs for the selected item', () => {
     const wrapper = mount(Reader);
 

--- a/socioprophet-web/client-vue/src/__tests__/MeshRushGraphViewFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/MeshRushGraphViewFixture.test.ts
@@ -3,6 +3,7 @@ import { feedIntelligenceState } from '../features/feed-intelligence/state';
 import {
   meshRushGraphViewBoundaryNotice,
   resolveMeshRushGraphViewForItem,
+  resolveMeshRushReadOnlyGraphView,
 } from '../features/feed-intelligence/meshRushGraphView';
 
 describe('MeshRush graph-view fixture resolver', () => {
@@ -34,8 +35,62 @@ describe('MeshRush graph-view fixture resolver', () => {
     }
   });
 
+  it('keeps the read-only graph-view resolver disabled by default', () => {
+    const resolution = resolveMeshRushReadOnlyGraphView({ enabled: false });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.graphView).toBeUndefined();
+    expect(resolution.reason).toContain('disabled');
+  });
+
+  it('handles missing item as unresolved without enabling graph behavior', () => {
+    const resolution = resolveMeshRushReadOnlyGraphView({ enabled: true });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.graphView).toBeUndefined();
+    expect(resolution.reason).toContain('No Feed Intelligence item');
+  });
+
+  it('handles unknown item as unresolved', () => {
+    const resolution = resolveMeshRushReadOnlyGraphView({
+      enabled: true,
+      item: {
+        ...feedIntelligenceState.items[0],
+        id: 'item-unknown',
+      },
+    });
+
+    expect(resolution.status).toBe('unresolved');
+    expect(resolution.graphView).toBeUndefined();
+  });
+
+  it('resolves known graph view in read-only display mode', () => {
+    const resolution = resolveMeshRushReadOnlyGraphView({
+      enabled: true,
+      item: feedIntelligenceState.items[0],
+    });
+
+    expect(resolution.status).toBe('resolved');
+    expect(resolution.graphView?.graphViewId).toBe('graph-view-feed-intelligence-reader-0001');
+    expect(resolution.reason).toContain('read-only display mode');
+  });
+
+  it('keeps read-only resolved graph effects disabled', () => {
+    const graphItems = feedIntelligenceState.items.filter((item) => resolveMeshRushGraphViewForItem(item));
+
+    for (const item of graphItems) {
+      const resolution = resolveMeshRushReadOnlyGraphView({ enabled: true, item });
+      expect(resolution.status).toBe('resolved');
+      expect(resolution.graphView?.displayMode).toBe('advisoryOnly');
+      expect(resolution.graphView?.boundary.liveTraversalEnabled).toBe(false);
+      expect(resolution.graphView?.boundary.graphPersistenceEnabled).toBe(false);
+      expect(resolution.graphView?.boundary.publicationEnabled).toBe(false);
+      expect(resolution.graphView?.stopCondition.satisfied).toBe(true);
+    }
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(meshRushGraphViewBoundaryNotice()).toContain('fixture-only');
+    expect(meshRushGraphViewBoundaryNotice()).toContain('read-only');
     expect(meshRushGraphViewBoundaryNotice()).toContain('advisory-only');
     expect(meshRushGraphViewBoundaryNotice()).toContain('no live traversal');
     expect(meshRushGraphViewBoundaryNotice()).toContain('graph persistence');

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/meshRushGraphView.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/meshRushGraphView.ts
@@ -18,6 +18,23 @@ export type MeshRushGraphViewFixture = {
   };
 };
 
+export type MeshRushReadOnlyResolverState = {
+  enabled: boolean;
+  item?: FeedItem;
+};
+
+export type MeshRushReadOnlyResolution =
+  | {
+      status: 'disabled' | 'unresolved';
+      graphView?: undefined;
+      reason: string;
+    }
+  | {
+      status: 'resolved';
+      graphView: MeshRushGraphViewFixture;
+      reason: string;
+    };
+
 export const meshRushGraphViewFixtures: MeshRushGraphViewFixture[] = [
   {
     graphViewId: 'graph-view-feed-intelligence-reader-0001',
@@ -76,6 +93,39 @@ export function resolveMeshRushGraphViewForItem(item: FeedItem): MeshRushGraphVi
   return meshRushGraphViewFixtures.find((view) => view.feedItemRef === item.id);
 }
 
+export function resolveMeshRushReadOnlyGraphView(
+  state: MeshRushReadOnlyResolverState,
+): MeshRushReadOnlyResolution {
+  if (!state.enabled) {
+    return {
+      status: 'disabled',
+      reason: 'MeshRush read-only graph-view resolver is disabled.',
+    };
+  }
+
+  if (!state.item) {
+    return {
+      status: 'unresolved',
+      reason: 'No Feed Intelligence item was provided for read-only graph-view resolution.',
+    };
+  }
+
+  const graphView = resolveMeshRushGraphViewForItem(state.item);
+
+  if (!graphView) {
+    return {
+      status: 'unresolved',
+      reason: 'No fixture MeshRush graph view matched the selected item.',
+    };
+  }
+
+  return {
+    status: 'resolved',
+    graphView,
+    reason: 'Fixture MeshRush graph view resolved in read-only display mode.',
+  };
+}
+
 export function meshRushGraphViewBoundaryNotice(): string {
-  return 'MeshRush graph view is fixture-only and advisory-only; no live traversal, graph persistence, publication, memory writeback, or runtime execution is active.';
+  return 'MeshRush graph view is read-only and advisory-only; no live traversal, graph persistence, publication, memory writeback, or runtime execution is active.';
 }

--- a/socioprophet-web/client-vue/src/pages/Reader.vue
+++ b/socioprophet-web/client-vue/src/pages/Reader.vue
@@ -76,6 +76,15 @@
       <small>{{ memoryMeshPostureBoundaryNotice() }}</small>
     </section>
 
+    <section class="feed-card adapter-boundary" aria-label="MeshRush read-only graph-view resolver status">
+      <div class="panel-heading">
+        <span>MeshRush read-only graph-view resolver</span>
+        <strong>{{ meshRushReadOnlyResolution.status }}</strong>
+      </div>
+      <p>{{ meshRushReadOnlyResolution.reason }}</p>
+      <small>{{ meshRushGraphViewBoundaryNotice() }}</small>
+    </section>
+
     <section class="ticker-card" aria-label="Ticker proof of life">
       <span class="ticker-label">Ticker</span>
       <button
@@ -220,7 +229,11 @@ import {
   bearBrowserHandoffBoundaryNotice,
   resolveBearBrowserLocalEventHandoff,
 } from '../features/feed-intelligence/bearbrowserHandoff';
-import { resolveMeshRushGraphViewForItem } from '../features/feed-intelligence/meshRushGraphView';
+import {
+  meshRushGraphViewBoundaryNotice,
+  resolveMeshRushGraphViewForItem,
+  resolveMeshRushReadOnlyGraphView,
+} from '../features/feed-intelligence/meshRushGraphView';
 import {
   memoryMeshPostureBoundaryNotice,
   resolveMemoryMeshPostureForItem,
@@ -262,6 +275,7 @@ const bearBrowserLocalEventResolution = computed(() => resolveBearBrowserLocalEv
 const slashTopicsReadOnlyResolution = computed(() => resolveSlashTopicsReadOnlyScope({ enabled: false }));
 const newHopeReadOnlyResolution = computed(() => resolveNewHopeReadOnlyMembrane({ enabled: false }));
 const memoryMeshReadOnlyResolution = computed(() => resolveMemoryMeshReadOnlyPosture({ enabled: false }));
+const meshRushReadOnlyResolution = computed(() => resolveMeshRushReadOnlyGraphView({ enabled: false }));
 
 function formatPolicy(policy: StoragePolicy): string {
   return policy.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());


### PR DESCRIPTION
## Summary

Adds a disabled/default MeshRush read-only graph-view resolver state for Feed Intelligence.

## Changes

- Extends `meshRushGraphView.ts` with read-only resolver state and resolution outcomes.
- Adds tests for disabled, missing item, unknown item, resolved item, and graph effects disabled behavior.
- Displays MeshRush read-only graph-view resolver status in `Reader.vue`.
- Updates the Feed Intelligence smoke test to assert the visible disabled resolver status.

## Live-adapter gate

1. Adapter enabled: none. This adds read-only/advisory-only resolver state and displays disabled/default posture.
2. Owning artifact: `SocioProphet/meshrush:examples/feed-intelligence/graph-view.fixture.json` and `LIVE_ADAPTER_GATE.md`.
3. Possible side effects: fixture lookup and status rendering only.
4. Impossible side effects: no live graph traversal, graph persistence, runtime execution, publication, federation, memory writeback, or durable graph mutation.
5. Disable path: resolver is called with `{ enabled: false }`.
6. Tests: unit tests cover disabled, unresolved, resolved, and graph-effects-disabled states; smoke test asserts disabled status panel.
7. Rollback: revert this PR; existing fixture-backed reader and fixture graph-view lookup remain usable.

## Validation

Connector compare shows four files changed, branch is ahead of current master and not behind.

Expected local validation:

```bash
cd socioprophet-web/client-vue
npm run verify
```

Closes #378.