### PR TITLE
Document Feed Intelligence resolver-gate completion

### DIFF
--- a/socioprophet-web/client-vue/src/features/feed-intelligence/LIVE_ADAPTER_GATE.md
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/LIVE_ADAPTER_GATE.md
@@ -2,15 +2,15 @@
 
 Status: required promotion gate  
 Scope: `socioprophet-web/client-vue/src/features/feed-intelligence`  
-Current posture: fixture-backed reader with disabled live adapters
+Current posture: fixture-backed reader with disabled live adapters and completed default-disabled resolver status sequence
 
 ## Purpose
 
-This gate prevents fixture resolver modules from being silently promoted into live behavior. The Feed Intelligence reader currently renders fixture-backed state and fixture-chain status for BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush. That is intentional. Live behavior must be introduced adapter by adapter and only after the owning boundary, authority model, tests, disabled state, and rollback path are present.
+This gate prevents fixture resolver modules and read-only resolver seams from being silently promoted into live behavior. The Feed Intelligence reader currently renders fixture-backed state, fixture-chain status, disabled adapter boundaries, and default-disabled resolver status for BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush. That is intentional. Live behavior must be introduced adapter by adapter and only after the owning boundary, authority model, tests, disabled state, and rollback path are present.
 
 ## Gate rule
 
-No fixture adapter may become live unless the PR satisfies all checks below.
+No fixture adapter or read-only resolver seam may become live unless the PR satisfies all checks below.
 
 ## Required checks
 
@@ -23,6 +23,18 @@ No fixture adapter may become live unless the PR satisfies all checks below.
 | Validation | Unit, smoke, or fixture-chain tests cover normal, disabled, and failure cases. |
 | Side-effect review | The PR states whether the adapter can fetch, mutate, publish, persist, federate, write memory, or execute graph traversal. |
 | Rollback | The PR documents how to disable or revert the adapter without breaking the reader. |
+
+## Completed default-disabled resolver status sequence
+
+The resolver-gate sequence is complete as read-only/default-disabled UI and test coverage. This does not enable live adapter behavior.
+
+| Surface | Completed status | Still impossible by default |
+| --- | --- | --- |
+| BearBrowser | Local-event handoff resolver status exists and is disabled by default. | Native bridge activation, network fetch, publication, federation, memory writeback, graph traversal, persistence. |
+| SlashTopics | Read-only scope resolver status exists and is disabled by default. | Scope mutation, feed fetching, publication, federation, memory writeback, graph traversal, persistence. |
+| New Hope | Read-only membrane resolver status exists and is disabled by default. | Live policy mutation, publication, federation, memory writeback, graph traversal, persistence, promotion from guarded states. |
+| MemoryMesh | Read-only/display-only posture resolver status exists and is disabled by default. | Live recall, durable writeback, raw payload storage, memory promotion, graph traversal, persistence. |
+| MeshRush | Read-only/advisory-only graph-view resolver status exists and is disabled by default. | Live traversal, graph persistence, runtime execution, publication, federation, durable graph mutation. |
 
 ## Adapter-specific promotion requirements
 
@@ -76,6 +88,7 @@ A live MeshRush adapter requires:
 
 - Live adapters default to disabled.
 - Fixture state must remain usable without any live adapter.
+- Resolver status display does not imply adapter enablement.
 - Browser capture does not imply publication.
 - Scope resolution does not imply feed fetching.
 - Membrane admission does not imply memory writeback.
@@ -97,4 +110,6 @@ Any PR that enables live behavior must include a section titled `Live-adapter ga
 
 ## Current locked state
 
-The current reader passes the gate only as a fixture-backed surface. It has fixture modules for the full chain and tests for coherence, but no live adapter is enabled.
+The current reader passes the gate only as a fixture-backed, default-disabled surface. It has fixture modules, read-only resolver status seams, UI panels, unit tests, smoke tests, and aggregate chain coverage. No live adapter is enabled.
+
+Before any live adapter work begins, parent issue #354 must receive an explicit acceptance reconciliation stating which single adapter is next, which owning artifact authorizes it, and which side effects remain disallowed for that adapter tranche.

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/README.md
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/README.md
@@ -1,6 +1,6 @@
 # Feed Intelligence Reader
 
-Status: fixture-backed UI and contract replay  
+Status: fixture-backed UI, contract replay, and completed default-disabled resolver-gate sequence  
 Source: `mdheller/socioprophet-web` PR #25  
 Target: `socioprophet-web/client-vue`
 
@@ -42,20 +42,34 @@ The owning repository contract index for this feature is `INTEGRATION_LEDGER.md`
 | `types.ts` | Contract types for sources, items, events, integrations, storage posture, and membrane decisions. |
 | `state.ts` | Fixture-backed state used by the current reader UI. |
 | `adapters.ts` | Disabled live-adapter seams and forbidden side-effect declarations. |
-| `bearbrowserHandoff.ts` | Local-only BearBrowser handoff fixture mapper. |
-| `slashTopicsScope.ts` | Fixture-only SlashTopics scope resolver. |
-| `newHopeMembrane.ts` | Fixture-only New Hope membrane resolver. |
-| `memoryMeshPosture.ts` | Fixture-only MemoryMesh posture resolver. |
-| `meshRushGraphView.ts` | Fixture-only MeshRush graph-view resolver. |
+| `bearbrowserHandoff.ts` | Local-only BearBrowser handoff fixture mapper plus default-disabled read-only local-event resolver status. |
+| `slashTopicsScope.ts` | SlashTopics fixture scope resolver plus default-disabled read-only scope resolver status. |
+| `newHopeMembrane.ts` | New Hope fixture membrane resolver plus default-disabled read-only membrane resolver status. |
+| `memoryMeshPosture.ts` | MemoryMesh fixture posture resolver plus default-disabled read-only/display-only posture resolver status. |
+| `meshRushGraphView.ts` | MeshRush fixture graph-view resolver plus default-disabled read-only/advisory-only graph-view resolver status. |
 | `INTEGRATION_LEDGER.md` | Owning-repo contract ledger for BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush. |
-| `LIVE_ADAPTER_GATE.md` | Promotion gate required before fixture adapters can become live behavior. |
+| `LIVE_ADAPTER_GATE.md` | Promotion gate required before fixture or read-only resolver seams can become live behavior. |
 | `../../__tests__/FeedIntelligenceFixtureChain.test.ts` | Aggregate fixture-chain coverage across scope, membrane, memory posture, and graph-view fixtures. |
-| `../../pages/Reader.vue` | Product shell page rendering the fixture state. |
+| `../../pages/Reader.vue` | Product shell page rendering fixture state, adapter boundary, resolver status panels, and the selected-item fixture chain. |
+
+## Completed resolver-gate sequence
+
+The default-disabled resolver-gate sequence is complete for the five owning surfaces.
+
+| Surface | Current status | Live behavior status |
+| --- | --- | --- |
+| BearBrowser | Local-event handoff resolver status is visible and disabled by default. | No native browser bridge, network fetch, or publication. |
+| SlashTopics | Read-only scope resolver status is visible and disabled by default. | No scope mutation and no feed fetching. |
+| New Hope | Read-only membrane resolver status is visible and disabled by default. | No live policy mutation and no promotion from guarded states. |
+| MemoryMesh | Read-only/display-only posture resolver status is visible and disabled by default. | No live recall, durable writeback, raw payload storage, or memory promotion. |
+| MeshRush | Read-only/advisory-only graph-view resolver status is visible and disabled by default. | No traversal, persistence, runtime execution, publication, or durable graph mutation. |
 
 ## Fixture adapter posture
 
 The fixture adapter modules are local validation seams. They prove shape, coherence, and disabled-state behavior before live adapters exist. They must not perform live network calls, mutate scopes, make policy decisions, write durable memory, execute graph traversal, persist graph state, federate, or publish.
 
+The read-only resolver status seams added after the fixture tranche are also non-live. They expose disabled/default resolver state and failure-safe resolver outcomes. They do not authorize any adapter side effect.
+
 ## Acceptance posture
 
-The page is acceptable only while it visibly remains fixture-backed and avoids claiming live backend behavior. Any future live integration must add owning-repo contracts, tests, and authority boundaries before enabling real fetch, memory, graph, or publication actions.
+The page is acceptable only while it visibly remains fixture-backed and avoids claiming live backend behavior. Any future live integration must pass `LIVE_ADAPTER_GATE.md`, add owning-repo contracts, tests, authority boundaries, disabled-state behavior, and rollback handling before enabling real fetch, memory, graph, browser, or publication actions.


### PR DESCRIPTION
## Summary

Documents the completed Feed Intelligence resolver-gate sequence and current locked live-adapter posture.

## Changes

- Updates `README.md` with the completed resolver-gate sequence for BearBrowser, SlashTopics, New Hope, MemoryMesh, and MeshRush.
- Updates `LIVE_ADAPTER_GATE.md` with the post-sequence locked state.
- Makes clear that read-only resolver status does not enable live adapter behavior.

## Validation

Connector compare shows two documentation files changed and no runtime files changed.

Closes #380.