### PR TITLE
Conform image builder, boot/fleet & fog market to sourceos-spec (14 contracts)

### DIFF
--- a/.github/workflows/builder-contract-tests.yml
+++ b/.github/workflows/builder-contract-tests.yml
@@ -5,6 +5,10 @@
 # fails the PR instead of shipping ad-hoc shapes.
 name: builder-contract-tests
 
+# Least-privilege: this workflow only reads the repo to run the contract test.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]

--- a/.github/workflows/builder-contract-tests.yml
+++ b/.github/workflows/builder-contract-tests.yml
@@ -1,0 +1,40 @@
+# Enforce sourceos-spec conformance for the image builder. Runs the contract
+# test that validates every canonical object (BuildRequest, OSImage, NLBootPlan,
+# the fog Offer/WorkOrder/UsageReceipt/SettlementEvent, …) against the vendored
+# schemas and asserts malformed inputs are rejected — so a non-conformant change
+# fails the PR instead of shipping ad-hoc shapes.
+name: builder-contract-tests
+
+on:
+  push:
+    branches: [ "master" ]
+    paths:
+      - "socioprophet-web/server/src/contracts/**"
+      - "socioprophet-web/server/src/routes/api/builds-route.ts"
+      - "socioprophet-web/server/src/routes/boot-route.ts"
+      - "socioprophet-web/server/src/services/bootServer.ts"
+      - "socioprophet-web/server/test/contracts.test.mjs"
+      - ".github/workflows/builder-contract-tests.yml"
+  pull_request:
+    paths:
+      - "socioprophet-web/server/src/contracts/**"
+      - "socioprophet-web/server/src/routes/api/builds-route.ts"
+      - "socioprophet-web/server/src/routes/boot-route.ts"
+      - "socioprophet-web/server/src/services/bootServer.ts"
+      - "socioprophet-web/server/test/contracts.test.mjs"
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: socioprophet-web/server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install deps
+        run: npm ci || npm install
+      - name: Validate builder objects against vendored sourceos-spec schemas
+        run: npm run test:contracts

--- a/socioprophet-web/server/package.json
+++ b/socioprophet-web/server/package.json
@@ -42,10 +42,13 @@
   },
   "scripts": {
     "start": "node src/server.ts",
-    "dev": "nodemon src/server.ts"
+    "dev": "nodemon src/server.ts",
+    "test:contracts": "node test/contracts.test.mjs"
   },
   "author": "Will Jones",
   "dependencies": {
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "cookie-session": "^1.4.0",

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -12,21 +12,22 @@ const SPEC_VERSION = "2.0.0";
 const ajv = new Ajv2020({ allErrors: true, strict: false });
 addFormats(ajv);
 
-const loadSchema = (name: string) =>
-  JSON.parse(fs.readFileSync(path.join(__dirname, "schemas", `${name}.json`), "utf8"));
-
-const validators: Record<string, any> = {
-  BuildRequest: ajv.compile(loadSchema("BuildRequest")),
-  BuildValidationEvidenceBundle: ajv.compile(loadSchema("BuildValidationEvidenceBundle")),
-  OSImage: ajv.compile(loadSchema("OSImage")),
-  CatalogEntry: ajv.compile(loadSchema("CatalogEntry")),
-  NLBootPlan: ajv.compile(loadSchema("NLBootPlan")),
-  DeviceIdentity: ajv.compile(loadSchema("DeviceIdentity")),
-  BootProofRecord: ajv.compile(loadSchema("BootProofRecord")),
-  ContentSpec: ajv.compile(loadSchema("ContentSpec")),
-  ControlNodeProfile: ajv.compile(loadSchema("ControlNodeProfile")),
-  DesktopProfile: ajv.compile(loadSchema("DesktopProfile")),
-};
+// Register EVERY vendored schema with ajv first (so cross-schema $refs like
+// ContentRef resolve), then look up validators by each schema's $id.
+const schemasDir = path.join(__dirname, "schemas");
+const idByName: Record<string, string> = {};
+for (const file of fs.readdirSync(schemasDir).filter((f: string) => f.endsWith(".json"))) {
+  const schema = JSON.parse(fs.readFileSync(path.join(schemasDir, file), "utf8"));
+  if (schema.$id) { ajv.addSchema(schema); idByName[file.replace(/\.json$/, "")] = schema.$id; }
+}
+const validatorNames = [
+  "BuildRequest", "BuildValidationEvidenceBundle", "OSImage", "CatalogEntry",
+  "NLBootPlan", "DeviceIdentity", "BootProofRecord", "ContentSpec",
+  "ControlNodeProfile", "DesktopProfile", "Offer", "WorkOrder",
+  "UsageReceipt", "SettlementEvent",
+];
+const validators: Record<string, any> = {};
+for (const n of validatorNames) validators[n] = ajv.getSchema(idByName[n]);
 
 const RELEASE = "26.11";
 // editions → canonical OSImage hostProfile personas.
@@ -220,8 +221,49 @@ const builderControlNode = () => ({
   },
 });
 
+// ── Fog compute market — builds as billable fog compute ──────────────────────
+
+// The builder's standing FogCompute Offer (it offers build capacity).
+const fogOffer = () => ({
+  id: "urn:srcos:offer:sourceos-builder",
+  type: "Offer",
+  specVersion: SPEC_VERSION,
+  provider: { subjectId: BUILDER_NODE_REF },
+  resources: { cpuCores: 8, memoryBytes: 34359738368, storageBytes: 64424509440 },
+});
+
+// A build job submitted to the fog → WorkOrder (requestor = user, workload = the flavor).
+const workOrder = (buildId: string, uid: string, edition: string) => ({
+  id: `urn:srcos:workorder:${lc(buildId)}`,
+  type: "WorkOrder",
+  specVersion: SPEC_VERSION,
+  requestor: { subjectId: `urn:srcos:user:${uid}` },
+  workload: { image: contentSpecRef(edition) },
+});
+
+// Compute consumed by a finished build → UsageReceipt against its WorkOrder.
+const usageReceipt = (buildId: string, startedAt: string, endedAt: string, cpuSeconds: number) => ({
+  id: `urn:srcos:receipt:usage:${lc(buildId)}`,
+  type: "UsageReceipt",
+  specVersion: SPEC_VERSION,
+  workOrderId: `urn:srcos:workorder:${lc(buildId)}`,
+  provider: { subjectId: BUILDER_NODE_REF },
+  startedAt,
+  endedAt,
+  usage: { cpuSeconds: Math.max(0, Math.round(cpuSeconds)) },
+});
+
+// Maps a usage receipt to a settlement backend (paid/premium billing).
+const settlementEvent = (buildId: string) => ({
+  id: `urn:srcos:settlement:${lc(buildId)}`,
+  type: "SettlementEvent",
+  specVersion: SPEC_VERSION,
+  receiptId: `urn:srcos:receipt:usage:${lc(buildId)}`,
+});
+
 module.exports = {
   validate, buildRequest, evidenceBundle, osImage, catalogEntry,
   deviceIdentity, nlBootPlan, bootProofRecord,
-  contentSpec, desktopProfile, builderControlNode, SPEC_VERSION,
+  contentSpec, desktopProfile, builderControlNode,
+  fogOffer, workOrder, usageReceipt, settlementEvent, SPEC_VERSION,
 };

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -18,7 +18,16 @@ const loadSchema = (name: string) =>
 const validators: Record<string, any> = {
   BuildRequest: ajv.compile(loadSchema("BuildRequest")),
   BuildValidationEvidenceBundle: ajv.compile(loadSchema("BuildValidationEvidenceBundle")),
+  OSImage: ajv.compile(loadSchema("OSImage")),
+  CatalogEntry: ajv.compile(loadSchema("CatalogEntry")),
 };
+
+const RELEASE = "26.11";
+// editions → canonical OSImage hostProfile personas.
+const hostProfileFor = (edition: string) =>
+  edition === "desktop" ? "workstation" : edition === "edge" ? "edge-appliance" : "vm-base";
+// osimage urn local-ids must be lowercase [a-z0-9._-]; Firestore ids can be mixed-case.
+const lc = (s: string) => s.toLowerCase().replace(/[^a-z0-9._-]/g, "-");
 
 // Validate `obj` against a vendored schema. Returns [] when valid, else messages.
 const validate = (schema: string, obj: any): string[] => {
@@ -67,4 +76,53 @@ const evidenceBundle = (
   issuedAt: new Date().toISOString(),
 });
 
-module.exports = { validate, buildRequest, evidenceBundle, SPEC_VERSION };
+// Build a spec-conformant OSImage identity for a finished iso/qcow2 build.
+// `opts`: { arch, channel, artifactRef, revision }.
+const osImage = (buildId: string, edition: string, opts: any = {}) => {
+  const id = lc(buildId);
+  const hostProfile = hostProfileFor(edition);
+  const arch = opts.arch === "aarch64" ? "aarch64" : "x86_64";
+  return {
+    id: `urn:srcos:osimage:${id}`,
+    type: "OSImage",
+    specVersion: SPEC_VERSION,
+    shortId: `so1-${hostProfile}`,
+    family: "sourceos",
+    epoch: 1,
+    hostProfile,
+    artifact: opts.artifact || "iso",
+    architecture: arch,
+    osRelease: {
+      ID: "sourceos",
+      VERSION_ID: RELEASE,
+      IMAGE_ID: `sourceos-${edition}`,
+      IMAGE_VERSION: RELEASE,
+      RELEASE_TYPE: opts.channel || "custom",
+    },
+    ociAnnotations: {
+      "org.opencontainers.image.version": RELEASE,
+      "org.opencontainers.image.revision": opts.revision || "main",
+      "org.opencontainers.image.source": "https://github.com/SourceOS-Linux/source-os",
+      "org.opencontainers.image.created": new Date().toISOString(),
+    },
+    substrateCapabilities: ["nix", "systemd-boot", "immutable-base"],
+    provenance: {
+      statementRef: `urn:srcos:attestation:${id}`,
+      slsaPredicateRef: `urn:srcos:slsa:${id}`,
+    },
+  };
+};
+
+// Register a built OSImage in the catalog.
+const catalogEntry = (buildId: string, osImageUrn: string, published: boolean, evidenceRef?: string) => ({
+  id: `urn:srcos:catalog-entry:${lc(buildId)}`,
+  type: "CatalogEntry",
+  specVersion: SPEC_VERSION,
+  objectRef: osImageUrn,
+  objectType: "OSImage",
+  status: published ? "published" : "draft",
+  ...(evidenceRef ? { evidenceBundleRef: evidenceRef } : {}),
+  updatedAt: new Date().toISOString(),
+});
+
+module.exports = { validate, buildRequest, evidenceBundle, osImage, catalogEntry, SPEC_VERSION };

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -24,7 +24,7 @@ const validatorNames = [
   "BuildRequest", "BuildValidationEvidenceBundle", "OSImage", "CatalogEntry",
   "NLBootPlan", "DeviceIdentity", "BootProofRecord", "ContentSpec",
   "ControlNodeProfile", "DesktopProfile", "Offer", "WorkOrder",
-  "UsageReceipt", "SettlementEvent",
+  "UsageReceipt", "SettlementEvent", "EventEnvelope",
 ];
 const validators: Record<string, any> = {};
 for (const n of validatorNames) validators[n] = ajv.getSchema(idByName[n]);
@@ -261,9 +261,22 @@ const settlementEvent = (buildId: string) => ({
   receiptId: `urn:srcos:receipt:usage:${lc(buildId)}`,
 });
 
+// A canonical EventEnvelope for the builder's lifecycle on the event planes.
+let _evtSeq = 0;
+const eventEnvelope = (eventType: string, subjectId: string, objectId: string, payload: any = {}) => ({
+  eventId: `urn:srcos:event:${Date.now()}-${_evtSeq++}`,
+  eventType,
+  specVersion: SPEC_VERSION,
+  occurredAt: new Date().toISOString(),
+  actor: { subjectId },
+  objectId,
+  payload,
+});
+
 module.exports = {
   validate, buildRequest, evidenceBundle, osImage, catalogEntry,
   deviceIdentity, nlBootPlan, bootProofRecord,
   contentSpec, desktopProfile, builderControlNode,
-  fogOffer, workOrder, usageReceipt, settlementEvent, SPEC_VERSION,
+  fogOffer, workOrder, usageReceipt, settlementEvent,
+  eventEnvelope, SPEC_VERSION,
 };

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -20,6 +20,9 @@ const validators: Record<string, any> = {
   BuildValidationEvidenceBundle: ajv.compile(loadSchema("BuildValidationEvidenceBundle")),
   OSImage: ajv.compile(loadSchema("OSImage")),
   CatalogEntry: ajv.compile(loadSchema("CatalogEntry")),
+  NLBootPlan: ajv.compile(loadSchema("NLBootPlan")),
+  DeviceIdentity: ajv.compile(loadSchema("DeviceIdentity")),
+  BootProofRecord: ajv.compile(loadSchema("BootProofRecord")),
 };
 
 const RELEASE = "26.11";
@@ -125,4 +128,52 @@ const catalogEntry = (buildId: string, osImageUrn: string, published: boolean, e
   updatedAt: new Date().toISOString(),
 });
 
-module.exports = { validate, buildRequest, evidenceBundle, osImage, catalogEntry, SPEC_VERSION };
+// ── Boot / fleet contracts ───────────────────────────────────────────────────
+
+// A registered fleet device → conformant DeviceIdentity.
+const deviceIdentity = (deviceId: string, name: string, uid: string) => ({
+  id: `urn:srcos:device-identity:${lc(deviceId)}`,
+  type: "DeviceIdentity",
+  specVersion: SPEC_VERSION,
+  deviceName: name,
+  platform: "linux",
+  archClass: "x86_64",
+  trustProfile: { trustLevel: "provisional", enrolledAt: new Date().toISOString() },
+  ownerRef: `urn:srcos:user:${uid}`,
+  registeredAt: new Date().toISOString(),
+});
+
+// The server-managed boot plan a device receives → conformant NLBootPlan.
+// `stages` = [{name, artifactRef, contentHash}] derived from the netboot manifest.
+const nlBootPlan = (deviceId: string, buildId: string, stages: any[]) => ({
+  id: `urn:srcos:nlboot-plan:${lc(buildId)}-${lc(deviceId)}`,
+  type: "NLBootPlan",
+  specVersion: SPEC_VERSION,
+  targetDeviceRef: `urn:srcos:device-identity:${lc(deviceId)}`,
+  platform: "generic-uefi",
+  status: "active",
+  stages: stages.map((s) => ({
+    name: s.name,
+    artifactRef: s.artifactRef,
+    contentHash: s.contentHash,
+    verificationRequired: true,
+  })),
+  bootReleaseSetRef: `urn:srcos:catalog-entry:${lc(buildId)}`,
+  createdAt: new Date().toISOString(),
+});
+
+// Evidence that a device booted a plan → conformant BootProofRecord.
+const bootProofRecord = (deviceId: string, planRef: string, outcome: string) => ({
+  id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}`,
+  type: "BootProofRecord",
+  specVersion: SPEC_VERSION,
+  bootPlanRef: planRef,
+  deviceRef: `urn:srcos:device-identity:${lc(deviceId)}`,
+  outcome: ["success", "partial", "failure", "aborted"].includes(outcome) ? outcome : "failure",
+  bootedAt: new Date().toISOString(),
+});
+
+module.exports = {
+  validate, buildRequest, evidenceBundle, osImage, catalogEntry,
+  deviceIdentity, nlBootPlan, bootProofRecord, SPEC_VERSION,
+};

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -1,0 +1,70 @@
+export {};
+// sourceos-spec conformance layer for the image builder.
+// Validates payloads against the CANONICAL schemas vendored under ./schemas
+// (synced from SourceOS-Linux/sourceos-spec — see schemas/PROVENANCE.txt) and
+// builds spec-conformant BuildRequest / BuildValidationEvidenceBundle objects.
+const path = require("path");
+const fs = require("fs");
+const Ajv2020 = require("ajv/dist/2020");
+const addFormats = require("ajv-formats");
+
+const SPEC_VERSION = "2.0.0";
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+
+const loadSchema = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "schemas", `${name}.json`), "utf8"));
+
+const validators: Record<string, any> = {
+  BuildRequest: ajv.compile(loadSchema("BuildRequest")),
+  BuildValidationEvidenceBundle: ajv.compile(loadSchema("BuildValidationEvidenceBundle")),
+};
+
+// Validate `obj` against a vendored schema. Returns [] when valid, else messages.
+const validate = (schema: string, obj: any): string[] => {
+  const v = validators[schema];
+  if (!v) return [`no validator for ${schema}`];
+  return v(obj) ? [] : (v.errors || []).map((e: any) => `${e.instancePath || "/"} ${e.message}`);
+};
+
+// editions → canonical refs (ContentSpec / ControlNodeProfile families).
+const contentSpecRef = (edition: string) => `urn:srcos:content-spec:sourceos-${edition}`;
+const controlNodeRef = (edition: string) => `urn:srcos:control-node:sourceos-${edition}`;
+const outputsFor = (target: string) => (target === "netboot" ? ["pxe"] : ["iso"]);
+
+// Build a spec-conformant BuildRequest from a validated user spec.
+const buildRequest = (buildId: string, uid: string, spec: any, target: string) => ({
+  id: `urn:srcos:build-request:${buildId}`,
+  type: "BuildRequest",
+  specVersion: SPEC_VERSION,
+  contentSpecRef: contentSpecRef(spec.edition || "desktop"),
+  outputs: outputsFor(target),
+  architecture: spec.arch || null,
+  parameters: {
+    hostname: spec.hostname,
+    packages: spec.packages || [],
+    services: spec.services || {},
+    users: spec.users || [],
+    ...(spec.moduleSnippet ? { moduleSnippet: spec.moduleSnippet } : {}),
+  },
+  requestedBy: `urn:srcos:user:${uid}`,
+  requestedAt: new Date().toISOString(),
+});
+
+// Build a spec-conformant BuildValidationEvidenceBundle for a finished build.
+const evidenceBundle = (
+  buildId: string, edition: string, ok: boolean, artifactRef: string | null,
+) => ({
+  id: `urn:srcos:build-evidence:${buildId}`,
+  type: "BuildValidationEvidenceBundle",
+  specVersion: SPEC_VERSION,
+  buildRef: `urn:srcos:build-request:${buildId}`,
+  profileRef: controlNodeRef(edition),
+  artifactRefs: artifactRef ? [artifactRef] : [],
+  scenarioResults: [
+    { scenarioId: "image-build", status: ok ? "passed" : "failed", artifactRef: artifactRef || "urn:srcos:none" },
+  ],
+  issuedAt: new Date().toISOString(),
+});
+
+module.exports = { validate, buildRequest, evidenceBundle, SPEC_VERSION };

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -23,6 +23,9 @@ const validators: Record<string, any> = {
   NLBootPlan: ajv.compile(loadSchema("NLBootPlan")),
   DeviceIdentity: ajv.compile(loadSchema("DeviceIdentity")),
   BootProofRecord: ajv.compile(loadSchema("BootProofRecord")),
+  ContentSpec: ajv.compile(loadSchema("ContentSpec")),
+  ControlNodeProfile: ajv.compile(loadSchema("ControlNodeProfile")),
+  DesktopProfile: ajv.compile(loadSchema("DesktopProfile")),
 };
 
 const RELEASE = "26.11";
@@ -39,9 +42,11 @@ const validate = (schema: string, obj: any): string[] => {
   return v(obj) ? [] : (v.errors || []).map((e: any) => `${e.instancePath || "/"} ${e.message}`);
 };
 
-// editions → canonical refs (ContentSpec / ControlNodeProfile families).
+// editions → canonical ContentSpec ref. The build/validation control node is a
+// single operator-control-node (ControlNodeProfile.hostRole only allows that) —
+// NOT the edition. profileRef points at the builder node, not the flavor.
 const contentSpecRef = (edition: string) => `urn:srcos:content-spec:sourceos-${edition}`;
-const controlNodeRef = (edition: string) => `urn:srcos:control-node:sourceos-${edition}`;
+const BUILDER_NODE_REF = "urn:srcos:control-node:sourceos-builder";
 const outputsFor = (target: string) => (target === "netboot" ? ["pxe"] : ["iso"]);
 
 // Build a spec-conformant BuildRequest from a validated user spec.
@@ -71,7 +76,7 @@ const evidenceBundle = (
   type: "BuildValidationEvidenceBundle",
   specVersion: SPEC_VERSION,
   buildRef: `urn:srcos:build-request:${buildId}`,
-  profileRef: controlNodeRef(edition),
+  profileRef: BUILDER_NODE_REF,
   artifactRefs: artifactRef ? [artifactRef] : [],
   scenarioResults: [
     { scenarioId: "image-build", status: ok ? "passed" : "failed", artifactRef: artifactRef || "urn:srcos:none" },
@@ -173,7 +178,50 @@ const bootProofRecord = (deviceId: string, planRef: string, outcome: string) => 
   bootedAt: new Date().toISOString(),
 });
 
+// ── Edition descriptors (resolve the contentSpecRef / profileRef the builder emits) ──
+
+const EDITION_NAMES: Record<string, string> = {
+  desktop: "SourceOS Desktop (GNOME)", server: "SourceOS Server", edge: "SourceOS Edge",
+};
+
+// Each edition is a canonical ContentSpec of kind os-flavor.
+const contentSpec = (edition: string) => ({
+  id: contentSpecRef(edition),
+  type: "ContentSpec",
+  specVersion: SPEC_VERSION,
+  name: EDITION_NAMES[edition] || `SourceOS ${edition}`,
+  kind: "os-flavor",
+});
+
+// The desktop edition's desktop environment.
+const desktopProfile = (edition: string) => ({
+  id: `urn:srcos:desktop-profile:sourceos-${edition}`,
+  type: "DesktopProfile",
+  specVersion: SPEC_VERSION,
+  desktopEnvironment: "gnome",
+});
+
+// The single operator-control-node that builds + validates images (the profileRef
+// the evidence bundles point at).
+const builderControlNode = () => ({
+  id: BUILDER_NODE_REF,
+  type: "ControlNodeProfile",
+  specVersion: SPEC_VERSION,
+  hostRole: "operator-control-node",
+  hostPlatform: "x86_64-linux",
+  containerRuntime: "podman",
+  // Compute-placement priority: prefer local, then the private GCP lane, then
+  // burst to cloud — mirrors the builder's free/paid build lanes.
+  placementOrder: ["local", "trusted-private", "burst-cloud"],
+  workspace: {
+    configDir: "/etc/sourceos",
+    stateDir: "/var/lib/sourceos",
+    evidenceDir: "/var/lib/sourceos/evidence",
+  },
+});
+
 module.exports = {
   validate, buildRequest, evidenceBundle, osImage, catalogEntry,
-  deviceIdentity, nlBootPlan, bootProofRecord, SPEC_VERSION,
+  deviceIdentity, nlBootPlan, bootProofRecord,
+  contentSpec, desktopProfile, builderControlNode, SPEC_VERSION,
 };

--- a/socioprophet-web/server/src/contracts/openapi.builder.yaml
+++ b/socioprophet-web/server/src/contracts/openapi.builder.yaml
@@ -1,0 +1,113 @@
+openapi: 3.1.0
+info:
+  title: SourceOS self-serve image builder API
+  version: "2.0.0"
+  description: >
+    Authenticated image-builder + nlboot fleet + boot provisioning endpoints.
+    Request/response objects conform to canonical sourceos-spec schemas
+    (referenced by their $id). Conformance is enforced by the builder contract
+    test (npm run test:contracts) and builder-contract-tests CI.
+servers:
+  - url: /
+tags: [{ name: builds }, { name: fleet }, { name: boot }]
+
+paths:
+  /api/builds:
+    post:
+      tags: [builds]
+      summary: Submit a build (persists a BuildRequest + WorkOrder, dispatches by tier)
+      security: [{ firebaseIdToken: [] }]
+      responses:
+        "201": { description: Dispatched; returns the buildId. }
+        "400": { description: Spec not allowed by tier policy. }
+        "429": { description: Daily build limit reached. }
+    get:
+      tags: [builds]
+      summary: List the caller's builds
+      security: [{ firebaseIdToken: [] }]
+      responses: { "200": { description: Builds list. } }
+  /api/builds/{id}:
+    get:
+      tags: [builds]
+      summary: One build + live status; on completion emits OSImage, CatalogEntry, evidence, UsageReceipt
+      security: [{ firebaseIdToken: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
+      responses:
+        "200":
+          description: Build with conformant artifacts.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  buildRequest: { $ref: "https://schemas.srcos.ai/v2/BuildRequest.json" }
+                  osImage: { $ref: "https://schemas.srcos.ai/v2/OSImage.json" }
+                  catalogEntry: { $ref: "urn:srcos:schema:CatalogEntry" }
+                  evidence: { $ref: "https://schemas.srcos.ai/v2/BuildValidationEvidenceBundle.json" }
+                  usageReceipt: { $ref: "https://schemas.srcos.ai/v2/UsageReceipt.json" }
+        "404": { description: Not found. }
+  /api/builds/editions:
+    get:
+      tags: [builds]
+      summary: Edition descriptors (ContentSpec/DesktopProfile) + builder ControlNodeProfile + fog Offer
+      responses: { "200": { description: Validated edition + builder descriptors. } }
+  /api/builds/whoami:
+    get:
+      tags: [builds]
+      summary: Caller tier + policy
+      security: [{ firebaseIdToken: [] }]
+      responses: { "200": { description: tier + policy. } }
+
+  /api/fleet/devices:
+    post:
+      tags: [fleet]
+      summary: Register a device (emits a DeviceIdentity) and return its claim code
+      security: [{ firebaseIdToken: [] }]
+      responses:
+        "201": { description: deviceId + claimCode + DeviceIdentity ref. }
+        "403": { description: Fleet is premium-only. }
+    get:
+      tags: [fleet]
+      summary: List the caller's devices
+      security: [{ firebaseIdToken: [] }]
+      responses: { "200": { description: Devices. } }
+  /api/fleet/devices/{id}/assign:
+    post:
+      tags: [fleet]
+      summary: Assign a completed build to a device
+      security: [{ firebaseIdToken: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
+      responses: { "200": { description: Assigned. } }
+
+  /boot/announce:
+    post:
+      tags: [boot]
+      summary: nlboot device announcement (claim-code authorized; UNAUTHENTICATED)
+      description: >
+        Resolves the device by claim code, builds a canonical NLBootPlan from the
+        assigned build, and returns the wire-shape nlboot.BootInstructions derived
+        from it, or a TryAgainResponse.
+      responses:
+        "200": { description: BootInstructions or TryAgainResponse. }
+        "403": { description: Unknown claim code. }
+  /boot/proof:
+    post:
+      tags: [boot]
+      summary: Device reports a boot outcome (records a BootProofRecord)
+      responses:
+        "201": { description: BootProofRecord recorded. }
+        "403": { description: Unknown claim code. }
+
+components:
+  securitySchemes:
+    firebaseIdToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Firebase ID token
+  schemas:
+    BuildRequest: { $ref: "https://schemas.srcos.ai/v2/BuildRequest.json" }
+    OSImage: { $ref: "https://schemas.srcos.ai/v2/OSImage.json" }
+    NLBootPlan: { $ref: "https://schemas.srcos.ai/v2/NLBootPlan.json" }
+    DeviceIdentity: { $ref: "https://schemas.srcos.ai/v2/DeviceIdentity.json" }
+    WorkOrder: { $ref: "https://schemas.srcos.ai/v2/WorkOrder.json" }
+    UsageReceipt: { $ref: "https://schemas.srcos.ai/v2/UsageReceipt.json" }

--- a/socioprophet-web/server/src/contracts/schemas/BootProofRecord.json
+++ b/socioprophet-web/server/src/contracts/schemas/BootProofRecord.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/BootProofRecord.json",
+  "title": "BootProofRecord",
+  "description": "An immutable record proving the integrity and outcome of an NLBoot boot execution, linking the boot plan, per-stage evidence, and attestation refs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "bootPlanRef",
+    "deviceRef",
+    "outcome",
+    "bootedAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:boot-proof:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:boot-proof:<local-id>"
+    },
+    "type": {
+      "const": "BootProofRecord",
+      "description": "Discriminator constant — always \"BootProofRecord\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "bootPlanRef": {
+      "type": "string",
+      "description": "URN reference to the NLBootPlan that was executed."
+    },
+    "deviceRef": {
+      "type": "string",
+      "description": "URN reference to the physical device or asset on which the boot occurred."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "success",
+        "partial",
+        "failure",
+        "aborted"
+      ],
+      "description": "Overall outcome of the boot execution."
+    },
+    "bootedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the boot was initiated."
+    },
+    "stageProofs": {
+      "type": "array",
+      "description": "Per-stage proof items recording the artifact executed and verification verdict for each stage.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "stageName",
+          "artifactRef",
+          "contentHash",
+          "verdict"
+        ],
+        "properties": {
+          "stageName": {
+            "type": "string",
+            "description": "Name of the boot stage, matching the stage name in the referenced NLBootPlan."
+          },
+          "artifactRef": {
+            "type": "string",
+            "description": "URN reference to the artifact that was loaded for this stage."
+          },
+          "contentHash": {
+            "type": "string",
+            "description": "Actual content digest observed at execution time, e.g. \"sha256:...\"."
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "verified",
+              "skipped",
+              "failed",
+              "tampered"
+            ],
+            "description": "Verification verdict for this stage."
+          },
+          "notes": {
+            "type": ["string", "null"],
+            "description": "Optional diagnostic notes for this stage."
+          }
+        }
+      }
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "URN references to AttestationEvidence objects captured during this boot."
+    },
+    "policyDecisionRef": {
+      "type": ["string", "null"],
+      "description": "Optional URN reference to the PolicyDecision that authorized this boot."
+    },
+    "signature": {
+      "type": ["string", "null"],
+      "description": "Optional cryptographic signature over the serialized proof record."
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable notes about this boot proof."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/BuildRequest.json
+++ b/socioprophet-web/server/src/contracts/schemas/BuildRequest.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/BuildRequest.json",
+  "title": "BuildRequest",
+  "description": "A request to compose a ContentSpec plus zero or more OverlayBundles into one or more output artifacts or bundles.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "contentSpecRef", "outputs", "requestedAt"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:build-request:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:build-request:<local-id>"
+    },
+    "type": {
+      "const": "BuildRequest",
+      "description": "Discriminator constant — always \"BuildRequest\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "contentSpecRef": {
+      "type": "string",
+      "description": "Reference to the ContentSpec being composed."
+    },
+    "overlayRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional overlay bundle refs to apply during composition."
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["iso", "pxe", "raw", "qcow2", "ami", "bootc", "ostree", "bundle", "docs-export", "other"]
+      },
+      "description": "Requested output artifact surfaces."
+    },
+    "channel": {
+      "type": ["string", "null"],
+      "description": "Optional release channel target such as dev, qa, or prod."
+    },
+    "architecture": {
+      "type": ["string", "null"],
+      "description": "Optional architecture target such as x86_64 or arm64."
+    },
+    "enrollmentProfileRef": {
+      "type": ["string", "null"],
+      "description": "Optional enrollment profile ref for install/runtime consumption."
+    },
+    "parameters": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Execution-time parameters that do not change the canonical object family."
+    },
+    "requestedBy": {
+      "type": ["string", "null"],
+      "description": "Optional subject or actor ref that requested the build."
+    },
+    "requestedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the build request was created."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/BuildValidationEvidenceBundle.json
+++ b/socioprophet-web/server/src/contracts/schemas/BuildValidationEvidenceBundle.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/BuildValidationEvidenceBundle.json",
+  "title": "BuildValidationEvidenceBundle",
+  "description": "Evidence bundle tying build identity, scenario outcomes, and promotion references together for image validation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "buildRef", "profileRef", "artifactRefs", "scenarioResults", "issuedAt"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:build-evidence:" },
+    "type": { "const": "BuildValidationEvidenceBundle" },
+    "specVersion": { "type": "string" },
+    "buildRef": { "type": "string" },
+    "profileRef": { "type": "string", "pattern": "^urn:srcos:control-node:" },
+    "artifactRefs": { "type": "array", "items": { "type": "string" } },
+    "scenarioResults": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["scenarioId", "status", "artifactRef"],
+        "properties": {
+          "scenarioId": { "type": "string" },
+          "status": { "enum": ["passed", "failed", "skipped"] },
+          "artifactRef": { "type": "string" }
+        }
+      }
+    },
+    "promotionGateRef": { "type": ["string", "null"], "pattern": "^urn:srcos:image-gate:" },
+    "replayRef": { "type": ["string", "null"] },
+    "issuedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/CatalogEntry.json
+++ b/socioprophet-web/server/src/contracts/schemas/CatalogEntry.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/CatalogEntry.json",
+  "title": "CatalogEntry",
+  "description": "A searchable index record for a governed object, release, or artifact family without redefining the canonical object itself.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "objectRef", "objectType", "status", "updatedAt"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:catalog-entry:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:catalog-entry:<local-id>"
+    },
+    "type": {
+      "const": "CatalogEntry",
+      "description": "Discriminator constant — always \"CatalogEntry\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "objectRef": {
+      "type": "string",
+      "description": "Reference to the canonical object represented by this catalog entry."
+    },
+    "objectType": {
+      "type": "string",
+      "description": "Type name of the canonical object, such as ReleaseManifest or EvidenceBundle."
+    },
+    "title": {
+      "type": ["string", "null"],
+      "description": "Optional title for indexing and presentation."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "description": "Index labels, tags, or dimensions used for discovery."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "frozen", "published", "superseded", "restricted", "archived"],
+      "description": "Catalog-visible lifecycle state."
+    },
+    "evidenceBundleRef": {
+      "type": ["string", "null"],
+      "description": "Optional EvidenceBundle ref associated with the indexed object."
+    },
+    "authorityRef": {
+      "type": ["string", "null"],
+      "description": "Optional ref to the authority or namespace governing this entry."
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when this catalog entry was last updated."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/ContentRef.json
+++ b/socioprophet-web/server/src/contracts/schemas/ContentRef.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ContentRef.json",
+  "title": "ContentRef",
+  "description": "A content-addressed reference to bytes (blob/chunk/manifest) used by Fog topics and work orders.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["digest"],
+  "properties": {
+    "digest": {
+      "type": "string",
+      "description": "Digest string (recommended form: <algo>:<hex> e.g. sha256:...)."
+    },
+    "sizeBytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional size hint in bytes."
+    },
+    "mediaType": {
+      "type": ["string", "null"],
+      "description": "Optional IANA media type hint."
+    },
+    "uris": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional locator hints (e.g. file://, s3://, ipfs://, hyper://, https://)."
+    },
+    "chunks": {
+      "type": "array",
+      "items": {"$ref": "ContentRef.json"},
+      "description": "Optional chunk list when the content is a manifest-of-chunks."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/ContentSpec.json
+++ b/socioprophet-web/server/src/contracts/schemas/ContentSpec.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ContentSpec.json",
+  "title": "ContentSpec",
+  "description": "A canonical desired-content specification that describes a buildable or publishable unit before execution or release.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "name", "kind"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:content-spec:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:content-spec:<local-id>"
+    },
+    "type": {
+      "const": "ContentSpec",
+      "description": "Discriminator constant — always \"ContentSpec\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name of the content specification."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["os-flavor", "overlay-family", "document-export", "automation-bundle", "workspace-pack", "platform-bundle", "model-release", "other"],
+      "description": "Logical content category."
+    },
+    "sourceRefs": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Optional source refs such as git commits, OCI digests, or upstream artifact IDs."
+    },
+    "ownerRef": {
+      "type": ["string", "null"],
+      "description": "Optional owner or authority reference."
+    },
+    "labels": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
+      "description": "Human or machine labels for indexing and policy."
+    },
+    "policyTags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Policy and governance tags relevant to this content."
+    },
+    "targetSurfaces": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Named surfaces where this content may be built, installed, published, or consumed."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/ControlNodeProfile.json
+++ b/socioprophet-web/server/src/contracts/schemas/ControlNodeProfile.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/ControlNodeProfile.json",
+  "title": "ControlNodeProfile",
+  "description": "Typed profile for an operator-side local-first control node.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "hostRole", "hostPlatform", "containerRuntime", "placementOrder", "workspace"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^urn:srcos:control-node:" },
+    "type": { "const": "ControlNodeProfile" },
+    "specVersion": { "type": "string" },
+    "hostRole": { "enum": ["operator-control-node"] },
+    "hostPlatform": { "type": "string" },
+    "containerRuntime": { "enum": ["podman"] },
+    "nodeCommanderRuntimeRef": { "type": ["string", "null"], "pattern": "^urn:srcos:node-commander:" },
+    "placementOrder": {
+      "type": "array",
+      "items": { "enum": ["local", "trusted-private", "attested-fog", "burst-cloud"] },
+      "minItems": 1
+    },
+    "workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configDir", "stateDir", "evidenceDir"],
+      "properties": {
+        "configDir": { "type": "string" },
+        "stateDir": { "type": "string" },
+        "evidenceDir": { "type": "string" }
+      }
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/DesktopProfile.json
+++ b/socioprophet-web/server/src/contracts/schemas/DesktopProfile.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/DesktopProfile.json",
+  "title": "DesktopProfile",
+  "description": "A typed desktop-environment profile for workstation realization, including extensions, input posture, and launcher defaults.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "desktopEnvironment"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:desktop-profile:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:desktop-profile:<local-id>."
+    },
+    "type": {
+      "const": "DesktopProfile",
+      "description": "Discriminator constant — always \"DesktopProfile\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.1.0\"."
+    },
+    "desktopEnvironment": {
+      "type": "string",
+      "enum": ["gnome", "kde", "cosmic", "sway", "other"],
+      "description": "Desktop environment or shell family."
+    },
+    "extensionSet": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Pinned shell extension identifiers or package names."
+    },
+    "keybindings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "binding", "command"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "binding": { "type": "string", "minLength": 1 },
+          "command": { "type": "string", "minLength": 1 }
+        }
+      },
+      "description": "Declarative desktop keybindings."
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "primaryBackend": { "type": "string" },
+        "compatibilityBackends": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "gestures": { "type": "string" }
+      },
+      "description": "Keyboard remap and gesture posture."
+    },
+    "launcherProviderRef": {
+      "type": ["string", "null"],
+      "description": "Optional reference to the primary LauncherProvider."
+    },
+    "macOnLinuxPolish": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional bounded Mac-on-Linux polish metadata. This records active and future workstation polish signals without claiming full macOS parity.",
+      "properties": {
+        "implementationAuthority": {
+          "type": "string",
+          "description": "Repository or authority responsible for concrete realization."
+        },
+        "activeFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Currently active / implemented polish signals."
+        },
+        "validationBackedFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Signals backed by helper or CI validation surfaces."
+        },
+        "proposedFeatures": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Future or proposed signals that must not be counted as delivered."
+        },
+        "nonGoals": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Explicit non-goals for this desktop profile."
+        }
+      }
+    },
+    "appearance": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Bounded appearance defaults for the desktop environment.",
+      "properties": {
+        "colorScheme": {
+          "type": "string",
+          "enum": ["light", "dark", "follow-system"],
+          "description": "Preferred color scheme."
+        },
+        "accentColor": {
+          "type": ["string", "null"],
+          "description": "Accent color token or hex value."
+        },
+        "fontScaling": {
+          "type": ["number", "null"],
+          "description": "Font scaling factor (1.0 = default)."
+        }
+      }
+    },
+    "sidebarBookmarks": {
+      "type": "array",
+      "description": "Sidebar (e.g., Files/Nautilus) bookmark entries mirroring Mac Finder sidebar conventions.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "path"],
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/DeviceIdentity.json
+++ b/socioprophet-web/server/src/contracts/schemas/DeviceIdentity.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/DeviceIdentity.json",
+  "title": "DeviceIdentity",
+  "description": "Device identity and trust profile for a SourceOS local-first workstation or operator device. Governs admission, attestation, capability assignment, and local data plane access.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "deviceName",
+    "platform",
+    "trustProfile",
+    "registeredAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:device-identity:",
+      "description": "Stable device identity URN. Must be unique per device."
+    },
+    "type": { "const": "DeviceIdentity" },
+    "specVersion": { "type": "string" },
+    "deviceName": {
+      "type": "string",
+      "description": "Human-readable device name. Must not include raw network addresses or PII."
+    },
+    "platform": {
+      "type": "string",
+      "enum": ["linux", "macos", "windows", "other"],
+      "description": "Host platform type."
+    },
+    "archClass": {
+      "type": ["string", "null"],
+      "enum": ["x86_64", "aarch64", "apple-silicon", "riscv64", "other", null],
+      "description": "CPU architecture class."
+    },
+    "trustProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trustLevel"],
+      "description": "Device trust posture evaluated at registration or last attestation.",
+      "properties": {
+        "trustLevel": {
+          "type": "string",
+          "enum": ["untrusted", "provisional", "trusted", "anchor"],
+          "description": "untrusted = not admitted; provisional = limited policy scope; trusted = full local data plane; anchor = quorum-eligible trust root."
+        },
+        "enrolledAt": { "type": ["string", "null"], "format": "date-time" },
+        "lastAttestedAt": { "type": ["string", "null"], "format": "date-time" },
+        "enrollmentRef": {
+          "type": ["string", "null"],
+          "description": "EnrollmentProfile URN governing this device's admission."
+        },
+        "attestationRefs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "AttestationEvidence URNs supporting the current trust level."
+        },
+        "trustExpiresAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Optional expiry for time-bounded trust grants."
+        },
+        "trustRevocationRef": {
+          "type": ["string", "null"],
+          "description": "RevocationEntry URN if trust has been revoked."
+        }
+      }
+    },
+    "capabilityProfileRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:workspace-capability-profile:",
+      "description": "WorkspaceCapabilityProfile URN describing surfaces available on this device."
+    },
+    "encryptionProfileRef": {
+      "type": ["string", "null"],
+      "pattern": "^urn:srcos:local-encryption-profile:",
+      "description": "LocalEncryptionProfile URN for this device's local data encryption posture."
+    },
+    "ownerRef": {
+      "type": ["string", "null"],
+      "description": "Subject or org authority reference for device ownership."
+    },
+    "registeredAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "policyDecisionRefs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/EventEnvelope.json
+++ b/socioprophet-web/server/src/contracts/schemas/EventEnvelope.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/EventEnvelope.json",
+  "title": "EventEnvelope",
+  "description": "The universal wrapper for all AsyncAPI channel messages. Carries event identity, type, actor, target object, typed payload, and optional integrity hashes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "eventId",
+    "eventType",
+    "specVersion",
+    "occurredAt",
+    "actor",
+    "objectId",
+    "payload"
+  ],
+  "properties": {
+    "eventId": {
+      "type": "string",
+      "pattern": "^urn:srcos:event:",
+      "description": "Stable URN identifier for this event. Pattern: urn:srcos:event:<local-id>"
+    },
+    "eventType": {
+      "type": "string",
+      "description": "Identifies the domain event (e.g. \"DatasetUpserted\", \"RunRecorded\", \"PolicyEvaluated\")."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "occurredAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when the domain event occurred."
+    },
+    "actor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "subjectId"
+      ],
+      "properties": {
+        "subjectId": {
+          "type": "string"
+        },
+        "ip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "description": "The subject that triggered this event (subjectId URN and optional IP address)."
+    },
+    "objectId": {
+      "type": "string",
+      "description": "URN of the primary object affected by this event."
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "The full domain object payload (typed by `eventType`)."
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "eventHash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signature": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "description": "Optional integrity envelope: hash of the event payload and/or a cryptographic signature."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/NLBootPlan.json
+++ b/socioprophet-web/server/src/contracts/schemas/NLBootPlan.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/NLBootPlan.json",
+  "title": "NLBootPlan",
+  "description": "An NLBoot boot plan describing the ordered sequence of boot stages, artifact references, and verification policy for a target device.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "targetDeviceRef",
+    "platform",
+    "status",
+    "stages",
+    "createdAt"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:nlboot-plan:[A-Za-z0-9._~-]+$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:nlboot-plan:<local-id>"
+    },
+    "type": {
+      "const": "NLBootPlan",
+      "description": "Discriminator constant — always \"NLBootPlan\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "targetDeviceRef": {
+      "type": "string",
+      "description": "URN reference to the physical device or asset this plan targets."
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "apple-silicon-asahi",
+        "generic-uefi",
+        "generic-bios"
+      ],
+      "description": "Target platform type that determines bootloader selection and stage ordering."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "draft",
+        "active",
+        "superseded",
+        "revoked"
+      ],
+      "description": "Lifecycle state of the boot plan."
+    },
+    "stages": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Ordered list of boot stages that must be executed to complete the boot sequence.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "artifactRef",
+          "contentHash"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Human-readable stage name, e.g. \"m1n1\", \"u-boot\", \"kernel\"."
+          },
+          "artifactRef": {
+            "type": "string",
+            "description": "URN reference to the stage artifact in the artifact cache or release set."
+          },
+          "contentHash": {
+            "type": "string",
+            "description": "Content-addressed digest of the stage artifact, e.g. \"sha256:...\"."
+          },
+          "verificationRequired": {
+            "type": "boolean",
+            "description": "When true, the boot executor must verify the digest before executing this stage."
+          },
+          "notes": {
+            "type": ["string", "null"],
+            "description": "Optional human-readable notes for this stage."
+          }
+        }
+      }
+    },
+    "bootReleaseSetRef": {
+      "type": ["string", "null"],
+      "description": "Optional URN reference to the BootReleaseSet that sourced the artifacts for this plan."
+    },
+    "policyRef": {
+      "type": ["string", "null"],
+      "description": "Optional URN reference to the policy that governs execution of this boot plan."
+    },
+    "activatedAt": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 date-time when this plan was activated on the target device."
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 date-time when this boot plan was created."
+    },
+    "notes": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable notes about this boot plan."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/OSImage.json
+++ b/socioprophet-web/server/src/contracts/schemas/OSImage.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/OSImage.json",
+  "title": "OSImage",
+  "description": "Immutable host image identity and substrate contract for a SourceOS operating-system artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "shortId",
+    "family",
+    "epoch",
+    "hostProfile",
+    "artifact",
+    "architecture",
+    "osRelease",
+    "ociAnnotations",
+    "substrateCapabilities",
+    "provenance"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:osimage:[a-z0-9][a-z0-9._-]*$",
+      "description": "Stable URN identifier. Pattern: urn:srcos:osimage:<local-id>."
+    },
+    "type": {
+      "const": "OSImage",
+      "description": "Discriminator constant — always \"OSImage\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.1.0\"."
+    },
+    "shortId": {
+      "type": "string",
+      "pattern": "^so[0-9]+-[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "description": "Immutable short substrate identifier. Pattern: so<epoch>-<host-profile>."
+    },
+    "family": {
+      "const": "sourceos",
+      "description": "OS family constant for SourceOS image contracts."
+    },
+    "epoch": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Compatibility epoch for the host image contract."
+    },
+    "hostProfile": {
+      "type": "string",
+      "enum": [
+        "workstation",
+        "edge-appliance",
+        "vm-base",
+        "installer",
+        "recovery",
+        "builder"
+      ],
+      "description": "Coarse substrate persona for the image. This is not a cybernetic runtime role."
+    },
+    "artifact": {
+      "type": "string",
+      "enum": [
+        "oci",
+        "qcow2",
+        "raw",
+        "iso",
+        "ami",
+        "vmdk"
+      ],
+      "description": "Rendered artifact form for the image."
+    },
+    "architecture": {
+      "type": "string",
+      "enum": [
+        "x86_64",
+        "aarch64"
+      ],
+      "description": "Target machine architecture for the rendered image."
+    },
+    "osRelease": {
+      "type": "object",
+      "description": "Rendered os-release identity fields exported by the image.",
+      "additionalProperties": false,
+      "required": [
+        "ID",
+        "VERSION_ID",
+        "IMAGE_ID",
+        "IMAGE_VERSION"
+      ],
+      "properties": {
+        "ID": {
+          "type": "string",
+          "description": "Primary os-release ID value."
+        },
+        "ID_LIKE": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Related upstream distribution identifier."
+          },
+          "description": "Optional list of upstream-compatible distribution identifiers."
+        },
+        "VERSION_ID": {
+          "type": "string",
+          "description": "Primary OS version identifier."
+        },
+        "BUILD_ID": {
+          "type": "string",
+          "description": "Optional build identifier for the original installation image."
+        },
+        "IMAGE_ID": {
+          "type": "string",
+          "description": "Image-family identifier exported through os-release."
+        },
+        "IMAGE_VERSION": {
+          "type": "string",
+          "description": "Image version exported through os-release."
+        },
+        "RELEASE_TYPE": {
+          "type": "string",
+          "description": "Optional release-type hint such as stable or preview."
+        }
+      }
+    },
+    "ociAnnotations": {
+      "type": "object",
+      "description": "OCI metadata carried with the bootable image artifact.",
+      "additionalProperties": true,
+      "required": [
+        "org.opencontainers.image.version",
+        "org.opencontainers.image.revision",
+        "org.opencontainers.image.source"
+      ],
+      "properties": {
+        "org.opencontainers.image.version": {
+          "type": "string",
+          "description": "OCI version annotation for the built image."
+        },
+        "org.opencontainers.image.revision": {
+          "type": "string",
+          "description": "OCI revision annotation referencing the source commit."
+        },
+        "org.opencontainers.image.source": {
+          "type": "string",
+          "description": "OCI source annotation referencing the canonical source repository."
+        },
+        "org.opencontainers.image.created": {
+          "type": "string",
+          "description": "Optional OCI creation timestamp."
+        },
+        "com.socioprophet.os.channel": {
+          "type": "string",
+          "description": "SocioProphet-specific update channel label for the image."
+        },
+        "com.socioprophet.os.capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "Declared substrate capability string."
+          },
+          "description": "Optional SocioProphet-specific substrate capability list."
+        }
+      }
+    },
+    "substrateCapabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "description": "Declared substrate capability string."
+      },
+      "description": "Host-level capabilities that affect boot, attestation, extension compatibility, or updates."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Attestation and provenance references for the image artifact.",
+      "additionalProperties": false,
+      "required": [
+        "statementRef",
+        "slsaPredicateRef"
+      ],
+      "properties": {
+        "statementRef": {
+          "type": "string",
+          "pattern": "^urn:srcos:attestation:[a-z0-9][a-z0-9._:-]*$",
+          "description": "URN reference to the in-toto or equivalent attestation statement."
+        },
+        "slsaPredicateRef": {
+          "type": "string",
+          "pattern": "^urn:srcos:slsa:[a-z0-9][a-z0-9._:-]*$",
+          "description": "URN reference to the SLSA provenance predicate artifact."
+        },
+        "sbomRef": {
+          "type": "string",
+          "description": "Optional URN or URL reference to the SBOM for this image."
+        },
+        "signatureRef": {
+          "type": "string",
+          "description": "Optional URN or URL reference to the signature verification material."
+        }
+      }
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/Offer.json
+++ b/socioprophet-web/server/src/contracts/schemas/Offer.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/Offer.json",
+  "title": "Offer",
+  "description": "FogCompute resource offer published by a provider node/workstation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "provider", "resources"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:offer:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:offer:<local-id>"
+    },
+    "type": {
+      "const": "Offer",
+      "description": "Discriminator constant — always \"Offer\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectId"],
+      "properties": {
+        "subjectId": {"type": "string", "description": "Provider subject URN."},
+        "nodeId": {"type": ["string", "null"], "description": "Optional provider node identifier."}
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpuCores": {"type": "number", "minimum": 0},
+        "memoryBytes": {"type": "integer", "minimum": 0},
+        "gpu": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "count": {"type": "integer", "minimum": 0},
+            "model": {"type": ["string", "null"]}
+          }
+        },
+        "storageBytes": {"type": "integer", "minimum": 0},
+        "networkMbps": {"type": "number", "minimum": 0}
+      },
+      "description": "Advertised resource caps."
+    },
+    "availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "timeWindow": {"type": ["string", "null"], "description": "Optional ISO-8601 interval window."},
+        "maxJobSeconds": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "pricing": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unit": {"type": ["string", "null"], "description": "e.g. credits, token, usd."},
+        "cpuSecond": {"type": ["number", "null"], "minimum": 0},
+        "gpuSecond": {"type": ["number", "null"], "minimum": 0},
+        "gbHour": {"type": ["number", "null"], "minimum": 0}
+      },
+      "description": "Optional pricing schedule."
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Optional provider constraints (allow/deny workload classes, privacy mode, power caps)."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/PROVENANCE.txt
+++ b/socioprophet-web/server/src/contracts/schemas/PROVENANCE.txt
@@ -1,0 +1,1 @@
+PROVENANCE: synced from SourceOS-Linux/sourceos-spec @ {"message":"

--- a/socioprophet-web/server/src/contracts/schemas/SettlementEvent.json
+++ b/socioprophet-web/server/src/contracts/schemas/SettlementEvent.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/SettlementEvent.json",
+  "title": "SettlementEvent",
+  "description": "Optional settlement event mapping a UsageReceipt to credits/tokens/escrow outcomes. Pluggable layer.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "receiptId"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:settlement:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:settlement:<local-id>"
+    },
+    "type": {
+      "const": "SettlementEvent",
+      "description": "Discriminator constant — always \"SettlementEvent\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "receiptId": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:usage:",
+      "description": "UsageReceipt URN."
+    },
+    "amount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unit": {"type": "string"},
+        "value": {"type": "number"}
+      },
+      "description": "Settled amount (credits/tokens)."
+    },
+    "backend": {
+      "type": ["string", "null"],
+      "description": "Settlement backend identifier (e.g., internal-ledger, iexec, akash, golem)."
+    },
+    "txRef": {
+      "type": ["string", "null"],
+      "description": "Optional settlement transaction reference."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/UsageReceipt.json
+++ b/socioprophet-web/server/src/contracts/schemas/UsageReceipt.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/UsageReceipt.json",
+  "title": "UsageReceipt",
+  "description": "FogCompute usage receipt emitted by a worker for a completed work order.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "workOrderId", "provider", "startedAt", "endedAt", "usage"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:receipt:usage:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:receipt:usage:<local-id>"
+    },
+    "type": {
+      "const": "UsageReceipt",
+      "description": "Discriminator constant — always \"UsageReceipt\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "workOrderId": {
+      "type": "string",
+      "pattern": "^urn:srcos:workorder:",
+      "description": "Associated WorkOrder URN."
+    },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectId"],
+      "properties": {
+        "subjectId": {"type": "string"},
+        "nodeId": {"type": ["string", "null"]}
+      }
+    },
+    "startedAt": {"type": "string", "format": "date-time"},
+    "endedAt": {"type": "string", "format": "date-time"},
+    "exit": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": {"type": ["integer", "null"]},
+        "status": {"type": ["string", "null"]}
+      }
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cpuSeconds": {"type": "number", "minimum": 0},
+        "memoryPeakBytes": {"type": "integer", "minimum": 0},
+        "ioReadBytes": {"type": "integer", "minimum": 0},
+        "ioWriteBytes": {"type": "integer", "minimum": 0},
+        "gpuSeconds": {"type": "number", "minimum": 0}
+      },
+      "description": "Metered usage (best-effort, OS-derived)."
+    },
+    "outputs": {
+      "type": "array",
+      "items": {"$ref": "ContentRef.json"},
+      "description": "Output content references produced by the work order."
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "receiptHash": {"type": ["string", "null"]},
+        "signature": {"type": ["string", "null"]}
+      },
+      "description": "Optional receipt hash and signature."
+    }
+  }
+}

--- a/socioprophet-web/server/src/contracts/schemas/WorkOrder.json
+++ b/socioprophet-web/server/src/contracts/schemas/WorkOrder.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/WorkOrder.json",
+  "title": "WorkOrder",
+  "description": "FogCompute work order: container/image digest + inputs/outputs + verification policy.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "type", "specVersion", "requestor", "workload"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:workorder:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:workorder:<local-id>"
+    },
+    "type": {
+      "const": "WorkOrder",
+      "description": "Discriminator constant — always \"WorkOrder\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.0.0\"."
+    },
+    "requestor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectId"],
+      "properties": {
+        "subjectId": {"type": "string"}
+      },
+      "description": "Requestor identity."
+    },
+    "workload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image"],
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Container image reference (recommended: digest-pinned)."
+        },
+        "command": {
+          "type": ["array", "null"],
+          "items": {"type": "string"},
+          "description": "Optional argv-style command override."
+        },
+        "env": {
+          "type": "object",
+          "additionalProperties": {"type": "string"},
+          "description": "Optional environment variables."
+        }
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "items": {"$ref": "ContentRef.json"},
+      "description": "Input content references."
+    },
+    "outputs": {
+      "type": "array",
+      "items": {"$ref": "ContentRef.json"},
+      "description": "Optional expected output refs (or output policy manifests)."
+    },
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"enum": ["none", "tee", "replicate", "spotcheck", "reputation"]},
+        "replicas": {"type": ["integer", "null"], "minimum": 0}
+      },
+      "description": "Verification policy (TEE or replication-based)."
+    },
+    "placement": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requireGpu": {"type": "boolean"},
+        "neighborhood": {"type": ["string", "null"]}
+      },
+      "description": "Optional placement constraints."
+    }
+  }
+}

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -97,6 +97,28 @@ router.get("/", async (req: any, res: any) => {
   return res.json({ builds });
 });
 
+// Edition catalog: the canonical ContentSpec (+ DesktopProfile) each edition
+// resolves to, and the builder ControlNodeProfile the evidence bundles cite.
+// Makes contentSpecRef/profileRef resolvable + conformant.
+router.get("/editions", async (_req: any, res: any) => {
+  const editions = ["desktop", "server", "edge"].map((e) => {
+    const cs = contracts.contentSpec(e);
+    const out: any = { edition: e, contentSpec: cs, contentSpecErrors: contracts.validate("ContentSpec", cs) };
+    if (e === "desktop") {
+      const dp = contracts.desktopProfile(e);
+      out.desktopProfile = dp;
+      out.desktopProfileErrors = contracts.validate("DesktopProfile", dp);
+    }
+    return out;
+  });
+  const builder = contracts.builderControlNode();
+  return res.json({
+    editions,
+    builderControlNode: builder,
+    builderControlNodeErrors: contracts.validate("ControlNodeProfile", builder),
+  });
+});
+
 // Caller's tier + what that tier may customize (for UI gating; server still enforces).
 router.get("/whoami", async (req: any, res: any) => {
   const tier = await getTier(req.uid);

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -118,11 +118,31 @@ router.get("/:id", async (req: any, res: any) => {
     // On a terminal status, emit a spec-conformant BuildValidationEvidenceBundle
     // — "validated" now means an evidence record exists, not a bucket glance.
     if (live.status === "complete" || live.status === "error") {
-      const edition = snap.data()?.spec?.edition || "desktop";
-      const bundle = contracts.evidenceBundle(req.params.id, edition, live.status === "complete", live.artifact || null);
-      const errs = contracts.validate("BuildValidationEvidenceBundle", bundle);
-      if (!errs.length) update.evidence = bundle;
-      else update.evidenceError = errs.join("; ");
+      const data = snap.data() || {};
+      const edition = data.spec?.edition || "desktop";
+      const ok = live.status === "complete";
+      const errs: string[] = [];
+
+      // On success of an iso/qcow2 build: emit a conformant OSImage identity +
+      // register it as a CatalogEntry. artifactRefs then point at the OSImage urn.
+      let artifactRef = live.artifact || null;
+      if (ok && (data.spec?.target || "iso") !== "netboot") {
+        const img = contracts.osImage(req.params.id, edition, {
+          arch: data.spec?.arch, channel: data.tier, revision: live.revision,
+        });
+        const ie = contracts.validate("OSImage", img);
+        if (!ie.length) { update.osImage = img; artifactRef = img.id; } else errs.push("OSImage: " + ie.join("; "));
+
+        const cat = contracts.catalogEntry(req.params.id, img.id, true, `urn:srcos:build-evidence:${req.params.id.toLowerCase()}`);
+        const ce = contracts.validate("CatalogEntry", cat);
+        if (!ce.length) update.catalogEntry = cat; else errs.push("CatalogEntry: " + ce.join("; "));
+      }
+
+      const bundle = contracts.evidenceBundle(req.params.id, edition, ok, artifactRef);
+      const be = contracts.validate("BuildValidationEvidenceBundle", bundle);
+      if (!be.length) update.evidence = bundle; else errs.push("evidence: " + be.join("; "));
+
+      if (errs.length) update.evidenceError = errs.join(" | ");
     }
     await ref.update(update);
   }

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -76,6 +76,11 @@ router.post("/", async (req: any, res: any) => {
     }
     await doc.update({ buildRequest });
 
+    // Conform: the build is a fog WorkOrder (billable compute work).
+    const wo = contracts.workOrder(doc.id, uid, spec.edition || "desktop");
+    const woErrors = contracts.validate("WorkOrder", wo);
+    if (!woErrors.length) await doc.update({ workOrder: wo });
+
     try {
       const dispatch = await dispatchBuild(uid, doc.id, spec, tier);
       await doc.update({ status: "dispatched", lane: dispatch.lane });
@@ -112,10 +117,13 @@ router.get("/editions", async (_req: any, res: any) => {
     return out;
   });
   const builder = contracts.builderControlNode();
+  const offer = contracts.fogOffer();
   return res.json({
     editions,
     builderControlNode: builder,
     builderControlNodeErrors: contracts.validate("ControlNodeProfile", builder),
+    fogOffer: offer,
+    fogOfferErrors: contracts.validate("Offer", offer),
   });
 });
 
@@ -163,6 +171,20 @@ router.get("/:id", async (req: any, res: any) => {
       const bundle = contracts.evidenceBundle(req.params.id, edition, ok, artifactRef);
       const be = contracts.validate("BuildValidationEvidenceBundle", bundle);
       if (!be.length) update.evidence = bundle; else errs.push("evidence: " + be.join("; "));
+
+      // Fog usage receipt for the consumed compute (+ settlement for paid/premium).
+      const started = data.createdAt?._seconds ? new Date(data.createdAt._seconds * 1000) : new Date();
+      const endedAt = new Date();
+      const cpuSeconds = (endedAt.getTime() - started.getTime()) / 1000;
+      const receipt = contracts.usageReceipt(req.params.id, started.toISOString(), endedAt.toISOString(), cpuSeconds);
+      const re = contracts.validate("UsageReceipt", receipt);
+      if (!re.length) update.usageReceipt = receipt; else errs.push("usage: " + re.join("; "));
+
+      if (data.tier === "paid" || data.tier === "premium") {
+        const settle = contracts.settlementEvent(req.params.id);
+        const se = contracts.validate("SettlementEvent", settle);
+        if (!se.length) update.settlement = settle; else errs.push("settlement: " + se.join("; "));
+      }
 
       if (errs.length) update.evidenceError = errs.join(" | ");
     }

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -7,6 +7,7 @@ const express = require("express");
 const { admin } = require("../../middleware/auth");
 const { dispatchBuild, readBuildStatus } = require("../../services/buildOrchestrator");
 const contracts = require("../../contracts");
+const { emitEvent } = require("../../services/events");
 
 const router = express.Router();
 const db = () => admin.firestore();
@@ -84,6 +85,8 @@ router.post("/", async (req: any, res: any) => {
     try {
       const dispatch = await dispatchBuild(uid, doc.id, spec, tier);
       await doc.update({ status: "dispatched", lane: dispatch.lane });
+      await emitEvent("srcos.builder.build.dispatched", `urn:srcos:user:${uid}`,
+        buildRequest.id, { tier, lane: dispatch.lane, edition: spec.edition }, "fog");
     } catch (err: any) {
       await doc.update({ status: "error", error: String(err?.message || err) });
       return res.status(502).json({ error: "build dispatch failed", buildId: doc.id });
@@ -187,6 +190,11 @@ router.get("/:id", async (req: any, res: any) => {
       }
 
       if (errs.length) update.evidenceError = errs.join(" | ");
+
+      // Emit the terminal lifecycle event onto the planes.
+      await emitEvent(ok ? "srcos.builder.build.completed" : "srcos.builder.build.failed",
+        `urn:srcos:user:${uid}`, `urn:srcos:build-request:${req.params.id}`,
+        { status: live.status, artifactRef, tier: data.tier }, "ops-history");
     }
     await ref.update(update);
   }

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -6,6 +6,7 @@ export {};
 const express = require("express");
 const { admin } = require("../../middleware/auth");
 const { dispatchBuild, readBuildStatus } = require("../../services/buildOrchestrator");
+const contracts = require("../../contracts");
 
 const router = express.Router();
 const db = () => admin.firestore();
@@ -59,11 +60,21 @@ router.post("/", async (req: any, res: any) => {
     const [ok, result] = validateSpec(req.body?.spec, policy);
     if (!ok) return res.status(400).json({ error: result });
     const spec = result;
+    const target = spec.target === "netboot" ? "netboot" : "iso";
 
     const doc = await db().collection("users").doc(uid).collection("builds").add({
       spec, tier, status: "queued",
       createdAt: admin.firestore.FieldValue.serverTimestamp(),
     });
+
+    // Conform: persist a canonical sourceos-spec BuildRequest alongside the build.
+    const buildRequest = contracts.buildRequest(doc.id, uid, spec, target);
+    const reqErrors = contracts.validate("BuildRequest", buildRequest);
+    if (reqErrors.length) {
+      await doc.update({ status: "error", error: "BuildRequest not spec-conformant: " + reqErrors.join("; ") });
+      return res.status(500).json({ error: "internal: non-conformant BuildRequest", details: reqErrors });
+    }
+    await doc.update({ buildRequest });
 
     try {
       const dispatch = await dispatchBuild(uid, doc.id, spec, tier);
@@ -102,7 +113,18 @@ router.get("/:id", async (req: any, res: any) => {
   // Reflect live status from the build's GCS status.json.
   const live = await readBuildStatus(uid, req.params.id);
   if (live?.status && live.status !== snap.data()?.status) {
-    await ref.update({ status: live.status, ...(live.artifact ? { artifact: live.artifact } : {}) });
+    const update: any = { status: live.status };
+    if (live.artifact) update.artifact = live.artifact;
+    // On a terminal status, emit a spec-conformant BuildValidationEvidenceBundle
+    // — "validated" now means an evidence record exists, not a bucket glance.
+    if (live.status === "complete" || live.status === "error") {
+      const edition = snap.data()?.spec?.edition || "desktop";
+      const bundle = contracts.evidenceBundle(req.params.id, edition, live.status === "complete", live.artifact || null);
+      const errs = contracts.validate("BuildValidationEvidenceBundle", bundle);
+      if (!errs.length) update.evidence = bundle;
+      else update.evidenceError = errs.join("; ");
+    }
+    await ref.update(update);
   }
   const fresh = await ref.get();
   return res.json({ id: fresh.id, ...fresh.data() });

--- a/socioprophet-web/server/src/routes/api/fleet-route.ts
+++ b/socioprophet-web/server/src/routes/api/fleet-route.ts
@@ -6,6 +6,7 @@ export {};
 const express = require("express");
 const crypto = require("crypto");
 const { admin } = require("../../middleware/auth");
+const contracts = require("../../contracts");
 
 const router = express.Router();
 const db = () => admin.firestore();
@@ -30,14 +31,19 @@ router.post("/devices", async (req: any, res: any) => {
   const claim = crypto.randomBytes(18).toString("base64url");
 
   const devRef = db().collection("users").doc(uid).collection("devices").doc();
+  // Conform: a registered device is a canonical DeviceIdentity.
+  const identity = contracts.deviceIdentity(devRef.id, name, uid);
+  const idErrors = contracts.validate("DeviceIdentity", identity);
+  if (idErrors.length) return res.status(500).json({ error: "non-conformant DeviceIdentity", details: idErrors });
+
   await devRef.set({
-    name, claimCode: claim, assignedBuildId: null,
+    name, claimCode: claim, assignedBuildId: null, identity,
     createdAt: admin.firestore.FieldValue.serverTimestamp(), lastSeen: null,
   });
   // Top-level index the unauth /boot/announce resolves against.
   await db().collection("device_claims").doc(claim).set({ uid, deviceId: devRef.id });
 
-  return res.status(201).json({ deviceId: devRef.id, name, claimCode: claim });
+  return res.status(201).json({ deviceId: devRef.id, name, claimCode: claim, identityRef: identity.id });
 });
 
 router.get("/devices", async (req: any, res: any) => {

--- a/socioprophet-web/server/src/routes/boot-route.ts
+++ b/socioprophet-web/server/src/routes/boot-route.ts
@@ -3,7 +3,7 @@ export {};
 // token; they authenticate with the claim code on their boot drive. Mounted
 // WITHOUT requireAuth (see server.ts).
 const express = require("express");
-const { handleAnnounce } = require("../services/bootServer");
+const { handleAnnounce, handleBootProof } = require("../services/bootServer");
 
 const router = express.Router();
 
@@ -12,6 +12,17 @@ const router = express.Router();
 router.post("/announce", async (req: any, res: any) => {
   try {
     const { http, body } = await handleAnnounce(req.body || {});
+    return res.status(http).json(body);
+  } catch (err: any) {
+    return res.status(500).json({ error: String(err?.message || err) });
+  }
+});
+
+// Device reports a boot outcome → server records a BootProofRecord.
+//   { claim, outcome: success|partial|failure|aborted }
+router.post("/proof", async (req: any, res: any) => {
+  try {
+    const { http, body } = await handleBootProof(req.body || {});
     return res.status(http).json(body);
   } catch (err: any) {
     return res.status(500).json({ error: String(err?.message || err) });

--- a/socioprophet-web/server/src/services/bootServer.ts
+++ b/socioprophet-web/server/src/services/bootServer.ts
@@ -5,6 +5,7 @@ export {};
 // or a TryAgainResponse when nothing is assigned/ready yet.
 const admin = require("firebase-admin");
 const contracts = require("../contracts");
+const { emitEvent } = require("./events");
 const GCS_BUCKET = process.env.SOURCEOS_GCS_BUCKET || "sourceos-artifacts-socioprophet";
 const SIGNED_TTL_MS = 15 * 60 * 1000;
 
@@ -108,6 +109,8 @@ const handleBootProof = async (announce: any) => {
   const errs = contracts.validate("BootProofRecord", proof);
   if (errs.length) return { http: 500, body: { error: "non-conformant BootProofRecord", details: errs } };
   await devRef.collection("bootProofs").add(proof);
+  await emitEvent("srcos.builder.boot.proof", proof.deviceRef, proof.id,
+    { outcome: proof.outcome, bootPlanRef: planRef }, "ops-history");
   return { http: 201, body: { recorded: proof.id, outcome: proof.outcome } };
 };
 

--- a/socioprophet-web/server/src/services/bootServer.ts
+++ b/socioprophet-web/server/src/services/bootServer.ts
@@ -4,6 +4,7 @@ export {};
 // (signed kernel/initramfs URLs + checksums + kargs) per the nlboot contract,
 // or a TryAgainResponse when nothing is assigned/ready yet.
 const admin = require("firebase-admin");
+const contracts = require("../contracts");
 const GCS_BUCKET = process.env.SOURCEOS_GCS_BUCKET || "sourceos-artifacts-socioprophet";
 const SIGNED_TTL_MS = 15 * 60 * 1000;
 
@@ -24,8 +25,8 @@ const signed = async (path: string): Promise<string> => {
   return url;
 };
 
-// Build the nlboot.BootInstructions for a completed netboot build.
-const bootInstructionsFor = async (uid: string, buildId: string) => {
+// Resolve a completed netboot build into signed kernel/initramfs refs + sha + kargs.
+const netbootArtifacts = async (uid: string, buildId: string) => {
   const prefix = `user-builds/${uid}/${buildId}`;
   let manifest: any;
   try {
@@ -35,17 +36,31 @@ const bootInstructionsFor = async (uid: string, buildId: string) => {
     return null; // netboot artifacts not present (e.g. an ISO-only build)
   }
   return {
-    _type: "nlboot.BootInstructions",
-    kernel: {
-      url: await signed(`${prefix}/kernel`),
-      checksum: `sha256:${manifest.kernel?.sha256 || ""}`,
-      args: manifest.kernel?.args || "",
-    },
-    initramfs: {
-      url: await signed(`${prefix}/initrd`),
-      checksum: `sha256:${manifest.initramfs?.sha256 || ""}`,
-    },
+    kernelUrl: await signed(`${prefix}/kernel`),
+    kernelSha: manifest.kernel?.sha256 || "",
+    kargs: manifest.kernel?.args || "",
+    initrdUrl: await signed(`${prefix}/initrd`),
+    initrdSha: manifest.initramfs?.sha256 || "",
   };
+};
+
+// Build the CANONICAL NLBootPlan for a build, then derive the wire-shape
+// nlboot.BootInstructions the device's nlbootd actually parses. The plan is the
+// spec-conformant record; the instructions are the interop projection of it.
+const planAndInstructions = async (uid: string, deviceId: string, buildId: string) => {
+  const a = await netbootArtifacts(uid, buildId);
+  if (!a) return null;
+  const plan = contracts.nlBootPlan(deviceId, buildId, [
+    { name: "kernel", artifactRef: a.kernelUrl, contentHash: `sha256:${a.kernelSha}` },
+    { name: "initramfs", artifactRef: a.initrdUrl, contentHash: `sha256:${a.initrdSha}` },
+  ]);
+  const planErrors = contracts.validate("NLBootPlan", plan);
+  const instructions = {
+    _type: "nlboot.BootInstructions",
+    kernel: { url: a.kernelUrl, checksum: `sha256:${a.kernelSha}`, args: a.kargs },
+    initramfs: { url: a.initrdUrl, checksum: `sha256:${a.initrdSha}` },
+  };
+  return { plan, planErrors, instructions };
 };
 
 const tryAgain = (seconds = 30) => ({
@@ -71,9 +86,29 @@ const handleAnnounce = async (announce: any) => {
   const build = (await db().collection("users").doc(ref.uid).collection("builds").doc(dev.assignedBuildId).get()).data();
   if (!build || build.status !== "complete") return { http: 200, body: tryAgain() };
 
-  const instr = await bootInstructionsFor(ref.uid, dev.assignedBuildId);
-  if (!instr) return { http: 200, body: tryAgain() };
-  return { http: 200, body: instr };
+  const pi = await planAndInstructions(ref.uid, ref.deviceId, dev.assignedBuildId);
+  if (!pi) return { http: 200, body: tryAgain() };
+
+  // Persist the conformant NLBootPlan; serve the device its wire instructions.
+  if (!pi.planErrors.length) {
+    await devRef.set({ activeBootPlan: pi.plan }, { merge: true });
+  }
+  return { http: 200, body: pi.instructions };
 };
 
-module.exports = { handleAnnounce, bootInstructionsFor };
+// A device reports a boot outcome → store a conformant BootProofRecord.
+const handleBootProof = async (announce: any) => {
+  const claim = announce?.claim;
+  const ref = await resolveClaim(claim);
+  if (!ref) return { http: 403, body: { error: "unknown claim code" } };
+  const devRef = db().collection("users").doc(ref.uid).collection("devices").doc(ref.deviceId);
+  const dev = (await devRef.get()).data() || {};
+  const planRef = dev.activeBootPlan?.id || "urn:srcos:nlboot-plan:none";
+  const proof = contracts.bootProofRecord(ref.deviceId, planRef, announce?.outcome || "failure");
+  const errs = contracts.validate("BootProofRecord", proof);
+  if (errs.length) return { http: 500, body: { error: "non-conformant BootProofRecord", details: errs } };
+  await devRef.collection("bootProofs").add(proof);
+  return { http: 201, body: { recorded: proof.id, outcome: proof.outcome } };
+};
+
+module.exports = { handleAnnounce, handleBootProof, planAndInstructions };

--- a/socioprophet-web/server/src/services/events.ts
+++ b/socioprophet-web/server/src/services/events.ts
@@ -1,0 +1,27 @@
+export {};
+// Emit builder lifecycle events onto the event planes. Builds a conformant
+// EventEnvelope and writes it to notification_outbox — the same outbox the
+// existing Kafka relay (functions/publishPendingOutbox) drains to the planes.
+const admin = require("firebase-admin");
+const contracts = require("../contracts");
+
+// emitEvent(eventType, subjectId, objectId, payload, channel)
+// Returns the envelope (or null + logs if it would be non-conformant).
+const emitEvent = async (
+  eventType: string, subjectId: string, objectId: string,
+  payload: any = {}, channel = "ops-history",
+) => {
+  const envelope = contracts.eventEnvelope(eventType, subjectId, objectId, payload);
+  const errs = contracts.validate("EventEnvelope", envelope);
+  if (errs.length) { console.error("non-conformant EventEnvelope, dropping", eventType, errs); return null; }
+  await admin.firestore().collection("notification_outbox").add({
+    kind: eventType,
+    event: envelope,
+    status: "pending",
+    destination: { mode: "system", channel },
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+  return envelope;
+};
+
+module.exports = { emitEvent };

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -94,5 +94,11 @@ ck("SettlementEvent conformant", c.validate("SettlementEvent", settle).length ==
 ck("  receiptId links the UsageReceipt", settle.receiptId === ur.id);
 ck("bad WorkOrder REJECTED", c.validate("WorkOrder", { id: "urn:srcos:workorder:x", type: "WorkOrder" }).length > 0);
 
+// Event-plane envelopes for the builder lifecycle.
+const evt = c.eventEnvelope("srcos.builder.build.completed", "urn:srcos:user:u9", "urn:srcos:build-request:b7", { status: "complete" });
+ck("EventEnvelope conformant", c.validate("EventEnvelope", evt).length === 0);
+ck("  eventId is event urn + actor.subjectId", /^urn:srcos:event:/.test(evt.eventId) && evt.actor.subjectId === "urn:srcos:user:u9");
+ck("bad EventEnvelope REJECTED", c.validate("EventEnvelope", { eventId: "x", eventType: "y" }).length > 0);
+
 console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
 process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -66,5 +66,19 @@ ck("BootProofRecord conformant", c.validate("BootProofRecord", bp).length === 0)
 ck("  outcome success", bp.outcome === "success");
 ck("bad NLBootPlan REJECTED", c.validate("NLBootPlan", { id: "urn:srcos:nlboot-plan:x", type: "NLBootPlan" }).length > 0);
 
+// Edition descriptors — the refs the builder emits must resolve to conformant objects.
+for (const ed of ["desktop", "server", "edge"]) {
+  const cs = c.contentSpec(ed);
+  ck(`ContentSpec(${ed}) conformant`, c.validate("ContentSpec", cs).length === 0);
+  ck(`  os-flavor + content-spec urn`, cs.kind === "os-flavor" && cs.id === `urn:srcos:content-spec:sourceos-${ed}`);
+}
+const dp = c.desktopProfile("desktop");
+ck("DesktopProfile(gnome) conformant", c.validate("DesktopProfile", dp).length === 0);
+const bn = c.builderControlNode();
+ck("builder ControlNodeProfile conformant", c.validate("ControlNodeProfile", bn).length === 0);
+ck("  operator-control-node + podman", bn.hostRole === "operator-control-node" && bn.containerRuntime === "podman");
+// The evidence bundle's profileRef now resolves to the builder control node.
+ck("evidence profileRef == builder node", ev.profileRef === bn.id);
+
 console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
 process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -34,5 +34,18 @@ ck("  profileRef is control-node urn", /^urn:srcos:control-node:/.test(ev.profil
 const evF = c.evidenceBundle("abc", "server", false, null);
 ck("EvidenceBundle(fail) conformant", c.validate("BuildValidationEvidenceBundle", evF).length === 0);
 
+// OSImage per edition (host-profile mapping) + mixed-case build id → lowercase urn.
+for (const [ed, hp] of [["desktop", "workstation"], ["server", "vm-base"], ["edge", "edge-appliance"]]) {
+  const img = c.osImage("Build-XYZ", ed, { arch: "x86_64", channel: "paid", revision: "abc123" });
+  ck(`OSImage(${ed}) conformant`, c.validate("OSImage", img).length === 0);
+  ck(`  shortId so1-${hp}`, img.shortId === `so1-${hp}`);
+  ck("  id urn is lowercased", img.id === "urn:srcos:osimage:build-xyz");
+}
+const img1 = c.osImage("b1", "server", { arch: "aarch64" });
+const cat = c.catalogEntry("b1", img1.id, true, "urn:srcos:build-evidence:b1");
+ck("CatalogEntry conformant", c.validate("CatalogEntry", cat).length === 0);
+ck("  objectRef = OSImage urn", cat.objectRef === img1.id);
+ck("bad OSImage REJECTED", c.validate("OSImage", { id: "urn:srcos:osimage:x", type: "OSImage" }).length > 0);
+
 console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
 process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -47,5 +47,24 @@ ck("CatalogEntry conformant", c.validate("CatalogEntry", cat).length === 0);
 ck("  objectRef = OSImage urn", cat.objectRef === img1.id);
 ck("bad OSImage REJECTED", c.validate("OSImage", { id: "urn:srcos:osimage:x", type: "OSImage" }).length > 0);
 
+// Boot / fleet contracts.
+const di = c.deviceIdentity("Dev-1", "rack-01", "user9");
+ck("DeviceIdentity conformant", c.validate("DeviceIdentity", di).length === 0);
+ck("  trustLevel provisional", di.trustProfile.trustLevel === "provisional");
+ck("  id lowercased urn", di.id === "urn:srcos:device-identity:dev-1");
+
+const plan = c.nlBootPlan("dev1", "build7", [
+  { name: "kernel", artifactRef: "https://x/kernel", contentHash: "sha256:aa" },
+  { name: "initramfs", artifactRef: "https://x/initrd", contentHash: "sha256:bb" },
+]);
+ck("NLBootPlan conformant", c.validate("NLBootPlan", plan).length === 0);
+ck("  platform generic-uefi", plan.platform === "generic-uefi");
+ck("  2 stages", plan.stages.length === 2 && plan.stages[0].name === "kernel");
+
+const bp = c.bootProofRecord("dev1", plan.id, "success");
+ck("BootProofRecord conformant", c.validate("BootProofRecord", bp).length === 0);
+ck("  outcome success", bp.outcome === "success");
+ck("bad NLBootPlan REJECTED", c.validate("NLBootPlan", { id: "urn:srcos:nlboot-plan:x", type: "NLBootPlan" }).length > 0);
+
 console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
 process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -1,0 +1,38 @@
+// Contract test: the builder's canonical objects validate against the vendored
+// sourceos-spec schemas (BuildRequest, BuildValidationEvidenceBundle).
+// Self-contained — transpiles src/contracts/index.ts on the fly so it runs in
+// CI without a TS loader. Run: node test/contracts.test.mjs
+import { createRequire } from "module";
+import path from "path";
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const fs = require("fs");
+const Module = require("module");
+
+const src = fs.readFileSync("src/contracts/index.ts", "utf8");
+const js = ts.transpileModule(src, { compilerOptions: { module: "commonjs", target: "es2020" } }).outputText;
+const m = new Module("contracts");
+m.filename = path.resolve("src/contracts/index.js");
+m.paths = Module._nodeModulePaths(path.resolve("src/contracts"));
+m._compile(js, m.filename);
+const c = m.exports;
+
+let fail = 0;
+const ck = (n, ok) => { console.log((ok ? "ok  " : "FAIL ") + n); if (!ok) fail++; };
+
+const br = c.buildRequest("abc123", "u1", { edition: "server", arch: "x86_64", hostname: "h1", packages: ["htop"], services: { openssh: true }, users: [] }, "iso");
+ck("BuildRequest(iso) conformant", c.validate("BuildRequest", br).length === 0);
+ck("  outputs=[iso]", JSON.stringify(br.outputs) === '["iso"]');
+ck("  id is build-request urn", /^urn:srcos:build-request:/.test(br.id));
+const brN = c.buildRequest("d1", "u", { edition: "edge", arch: "x86_64", hostname: "n" }, "netboot");
+ck("BuildRequest(netboot) outputs=[pxe]", JSON.stringify(brN.outputs) === '["pxe"]');
+ck("bad BuildRequest REJECTED", c.validate("BuildRequest", { id: "nope", type: "BuildRequest" }).length > 0);
+
+const ev = c.evidenceBundle("abc123", "server", true, "gs://b/u/abc123/x.iso");
+ck("EvidenceBundle(pass) conformant", c.validate("BuildValidationEvidenceBundle", ev).length === 0);
+ck("  profileRef is control-node urn", /^urn:srcos:control-node:/.test(ev.profileRef));
+const evF = c.evidenceBundle("abc", "server", false, null);
+ck("EvidenceBundle(fail) conformant", c.validate("BuildValidationEvidenceBundle", evF).length === 0);
+
+console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
+process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/contracts.test.mjs
+++ b/socioprophet-web/server/test/contracts.test.mjs
@@ -80,5 +80,19 @@ ck("  operator-control-node + podman", bn.hostRole === "operator-control-node" &
 // The evidence bundle's profileRef now resolves to the builder control node.
 ck("evidence profileRef == builder node", ev.profileRef === bn.id);
 
+// Fog compute market — build as billable fog compute.
+const offer = c.fogOffer();
+ck("Offer conformant", c.validate("Offer", offer).length === 0);
+const wo = c.workOrder("Build-7", "user9", "server");
+ck("WorkOrder conformant", c.validate("WorkOrder", wo).length === 0);
+ck("  workload.image = content-spec", wo.workload.image === "urn:srcos:content-spec:sourceos-server");
+const ur = c.usageReceipt("Build-7", "2026-06-22T00:00:00Z", "2026-06-22T00:05:00Z", 300);
+ck("UsageReceipt conformant", c.validate("UsageReceipt", ur).length === 0);
+ck("  workOrderId links the WorkOrder", ur.workOrderId === wo.id);
+const settle = c.settlementEvent("Build-7");
+ck("SettlementEvent conformant", c.validate("SettlementEvent", settle).length === 0);
+ck("  receiptId links the UsageReceipt", settle.receiptId === ur.id);
+ck("bad WorkOrder REJECTED", c.validate("WorkOrder", { id: "urn:srcos:workorder:x", type: "WorkOrder" }).length > 0);
+
 console.log(fail ? `\n${fail} FAILED` : "\nALL CONFORMANCE CHECKS PASSED");
 process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Spec-conformance for the image builder + boot/fleet, anchored to the canonical `sourceos-spec` contracts (the builder shipped working but against ad-hoc shapes). Done in passes; every object is **ajv-validated** and covered by `npm run test:contracts` (which also proves malformed inputs are rejected).

## Contracts now conformant (10)
**Builder:** `BuildRequest` · `BuildValidationEvidenceBundle` · `OSImage` · `CatalogEntry`
**Boot/fleet:** `DeviceIdentity` · `NLBootPlan` · `BootProofRecord`
**Editions:** `ContentSpec` (os-flavor ×3) · `DesktopProfile` · `ControlNodeProfile` (builder node)

## Behavior
- `POST /api/builds` persists a schema-validated `BuildRequest`; on completion `GET :id` emits `OSImage` + `CatalogEntry` + `BuildValidationEvidenceBundle` — **"validated" = an evidence record exists.**
- `/boot/announce` builds + persists a canonical `NLBootPlan` and derives the wire `nlboot.BootInstructions` from it; `/boot/proof` records a `BootProofRecord`; fleet registration emits a `DeviceIdentity`.
- `GET /api/builds/editions` exposes the `ContentSpec`/`DesktopProfile` + builder `ControlNodeProfile` so the URNs the builder emits resolve.

## Semantic fixes made along the way
- `ArtifactManifest` is PDF-centric → use `OSImage` for OS images.
- `ControlNodeProfile.hostRole` only allows `operator-control-node` → editions are not control nodes; `profileRef` now points at a real builder node, not the flavor.

## Honest remaining (not in this PR)
Fog plane as a **compute market** (`Offer`/`WorkOrder`/`UsageReceipt`/`SettlementEvent`); `WorkstationProfile`/`ImmutableNodeProfile`; `OverlayBundle`; `ReleaseManifest`/`ReleaseReceipt`/`ReleaseSet`; `AppleSiliconAdapterEvidence` (M2); `ImagePromotionGate`; routes into an `openapi.*.patch` + AsyncAPI events; wiring `sourceos-spec` contract tests into CI.