### PR TITLE
Add Firebase Hosting target for the image-builder app

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -11,6 +11,9 @@
         ],
         "docs": [
           "socioprophet-web-dev-env"
+        ],
+        "app": [
+          "socioprophet-builder-dev"
         ]
       }
     },
@@ -21,6 +24,9 @@
         ],
         "docs": [
           "socioprophet-web"
+        ],
+        "app": [
+          "socioprophet-builder"
         ]
       }
     }

--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,25 @@
           "function": "leadCapture"
         }
       ]
+    },
+    {
+      "target": "app",
+      "public": "socioprophet-web/app-vue/dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "/api/**",
+          "run": { "serviceId": "builder-api", "region": "us-central1" }
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
     }
   ],
   "functions": {


### PR DESCRIPTION
Adds an `app` hosting target (sites `socioprophet-builder[-dev]`) serving `socioprophet-web/app-vue/dist` — SPA fallback + `/api/**` → the `builder-api` Cloud Run service. Unblocks deploying the builder app (app.sourceos.org). Part of the June 25 website+builder push; see DEPLOY.md in socioslinux-web.