### PR TITLE
feat(client-vue): wire Value Drivers surface to the live economic engine

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/vdtApi.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/vdtApi.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchVdtWithFallback, fixtureView } from '../api/vdtApi';
+import { computeVdt } from '../data/vdtFixture';
+
+const LIVE_RESPONSE = {
+  service: 'dashboard-bff',
+  industry: 'GICS45_SoftwarePlatforms',
+  scenario: 'baseline',
+  enterprise_value_baseline: 1_000_000_000,
+  drivers: ['RevenueGrowth', 'CostEfficiency', 'Experience', 'KnowledgeProductivity', 'TrustComplianceResilience', 'Innovation'],
+  domains: ['CustomerInterface', 'ProductServiceDev', 'SupplyDelivery', 'OperationsSupport', 'RiskSecurity', 'GovernanceKnowledge'],
+  weights: [{ driver: 'RevenueGrowth', domain: 'CustomerInterface', weight: 0.096774 }],
+  per_kpi_contribution: [
+    { kpi: 'arr_growth_pct', driver: 'RevenueGrowth', domain: 'CustomerInterface', delta_pct: 10.0, polarity: 'higher_better', value_contribution: 9677419.35 },
+  ],
+  per_driver_uplift: { RevenueGrowth: 9677419.35 },
+  per_domain_uplift: { CustomerInterface: 9677419.35 },
+  computed_total_value_uplift: 10201612.9,
+  computed_value_uplift_fraction: 0.0102,
+  projected_enterprise_value: 1010201612.9,
+  epistemic_status: { level: 'synthetic', review_status: 'machine_checked' },
+  provenance: { source_repo: 'SocioProphet/economic-prophet', input_hash: 'hash://synthetic/input-vdt-software-001' },
+  headline: 'GICS45_SoftwarePlatforms: ... machine-checked measurement ...',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('vdtApi', () => {
+  it('fixtureView reproduces the canonical engine math (computeVdt)', () => {
+    const c = computeVdt();
+    const v = fixtureView();
+    expect(v.totalUplift).toBe(c.totalUplift);
+    expect(v.projectedEnterpriseValue).toBe(c.projectedEnterpriseValue);
+    expect(v.perKpi.length).toBe(c.perKpi.length);
+    expect(v.weights.length).toBe(36);
+  });
+
+  it('maps a live /v1/vdt response (snake_case → camelCase) and reports live mode', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => LIVE_RESPONSE,
+    } as Response));
+
+    const res = await fetchVdtWithFallback();
+    expect(res.mode).toBe('live');
+    expect(res.view.industry).toBe('GICS45_SoftwarePlatforms');
+    expect(res.view.perKpi[0]).toMatchObject({ kpi: 'arr_growth_pct', deltaPct: 10.0, contribution: 9677419.35 });
+    expect(res.view.totalUplift).toBe(10201612.9);
+  });
+
+  it('falls back to the fixture (and reports the error) when the backend is unavailable', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('connection refused')));
+
+    const res = await fetchVdtWithFallback();
+    expect(res.mode).toBe('fixture');
+    expect(res.error).toContain('connection refused');
+    expect(res.view.weights.length).toBe(36);
+  });
+});

--- a/socioprophet-web/client-vue/src/api/vdtApi.ts
+++ b/socioprophet-web/client-vue/src/api/vdtApi.ts
@@ -1,0 +1,157 @@
+// Value Driver Tree API client.
+//
+// Fronts the prophet-platform dashboard-bff route GET /v1/vdt (apps/dashboard-bff/main.py),
+// which serves the canonical economic-prophet engine's OUTPUT — the driver×domain attribution
+// tensor plus the engine-computed per-KPI / per-driver uplifts, provenance + input_hash intact.
+// The value math (EP/UVMC/VDT identities) is NOT in the frontend; it lives in economic-prophet.
+//
+// Mirrors intelligenceSuperiorityApi.ts / personGraphApi.ts: an env-configured base, a getJson
+// wrapper, and a *WithFallback variant that returns the local fixture (data/vdtFixture.ts — the
+// SAME engine math, computed client-side) when the backend is absent, so the surface still renders
+// in fixture mode rather than blanking.
+
+import {
+  industry as fxIndustry,
+  enterpriseValueBaseline,
+  drivers as fxDrivers,
+  domains as fxDomains,
+  weights as fxWeights,
+  computeVdt,
+  type Polarity,
+} from '../data/vdtFixture';
+
+const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || '/api';
+
+export interface VdtWeightCell {
+  driver: string;
+  domain: string;
+  weight: number;
+}
+
+export interface VdtKpiView {
+  kpi: string;
+  driver: string;
+  domain: string;
+  deltaPct: number;
+  polarity: Polarity;
+  contribution: number;
+}
+
+/** Normalized (camelCase) view the surface renders — from live BFF or the fixture. */
+export interface VdtView {
+  industry: string;
+  evBaseline: number;
+  drivers: string[];
+  domains: string[];
+  weights: VdtWeightCell[];
+  perKpi: VdtKpiView[];
+  perDriver: Record<string, number>;
+  perDomain: Record<string, number>;
+  totalUplift: number;
+  upliftFraction: number;
+  projectedEnterpriseValue: number;
+  provenance: Record<string, unknown>;
+  epistemicStatus: Record<string, unknown>;
+}
+
+// Server response (snake_case) — matches dashboard-bff contracts.VdtResponse.
+interface VdtResponse {
+  service: string;
+  industry: string;
+  scenario: string;
+  enterprise_value_baseline: number;
+  drivers: string[];
+  domains: string[];
+  weights: { driver: string; domain: string; weight: number }[];
+  per_kpi_contribution: {
+    kpi: string; driver: string; domain: string;
+    delta_pct: number; polarity: Polarity; value_contribution: number;
+  }[];
+  per_driver_uplift: Record<string, number>;
+  per_domain_uplift: Record<string, number>;
+  computed_total_value_uplift: number;
+  computed_value_uplift_fraction: number;
+  projected_enterprise_value: number;
+  epistemic_status: Record<string, unknown>;
+  provenance: Record<string, unknown>;
+  headline: string;
+}
+
+export type VdtMode = 'live' | 'fixture';
+
+export interface VdtLoadResult {
+  view: VdtView;
+  mode: VdtMode;
+  error?: string;
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText} for ${path}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function fromResponse(d: VdtResponse): VdtView {
+  return {
+    industry: d.industry,
+    evBaseline: d.enterprise_value_baseline,
+    drivers: d.drivers,
+    domains: d.domains,
+    weights: d.weights,
+    perKpi: d.per_kpi_contribution.map((k) => ({
+      kpi: k.kpi,
+      driver: k.driver,
+      domain: k.domain,
+      deltaPct: k.delta_pct,
+      polarity: k.polarity,
+      contribution: k.value_contribution,
+    })),
+    perDriver: d.per_driver_uplift,
+    perDomain: d.per_domain_uplift,
+    totalUplift: d.computed_total_value_uplift,
+    upliftFraction: d.computed_value_uplift_fraction,
+    projectedEnterpriseValue: d.projected_enterprise_value,
+    provenance: d.provenance ?? {},
+    epistemicStatus: d.epistemic_status ?? {},
+  };
+}
+
+/** Deterministic fixture view — the SAME canonical engine math computed locally, so the surface
+ *  renders identically to the live path when dashboard-bff is not running. */
+export function fixtureView(): VdtView {
+  const c = computeVdt();
+  return {
+    industry: fxIndustry,
+    evBaseline: enterpriseValueBaseline,
+    drivers: [...fxDrivers],
+    domains: [...fxDomains],
+    weights: fxWeights,
+    perKpi: c.perKpi.map((k) => ({
+      kpi: k.kpi, driver: k.driver, domain: k.domain,
+      deltaPct: k.deltaPct, polarity: k.polarity, contribution: k.contribution,
+    })),
+    perDriver: c.perDriver,
+    perDomain: c.perDomain,
+    totalUplift: c.totalUplift,
+    upliftFraction: c.upliftFraction,
+    projectedEnterpriseValue: c.projectedEnterpriseValue,
+    provenance: {
+      source: 'client fixture (data/vdtFixture.ts)',
+      note: 'canonical economic-prophet VDT math, computed locally',
+    },
+    epistemicStatus: { level: 'synthetic', review_status: 'machine_checked' },
+  };
+}
+
+export async function fetchVdtWithFallback(): Promise<VdtLoadResult> {
+  try {
+    const d = await getJson<VdtResponse>('/v1/vdt');
+    return { view: fromResponse(d), mode: 'live' };
+  } catch (err) {
+    return { view: fixtureView(), mode: 'fixture', error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
+++ b/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
@@ -19,7 +19,14 @@
     <div class="vdt-body">
       <!-- Driver × capability-domain value-attribution tensor -->
       <div class="vdt-panel">
-        <div class="vdt-panel-h">Value attribution — driver × capability domain <span class="vdt-hint">weights sum to 100% of EV · outlined cells carry a KPI lever</span></div>
+        <div class="vdt-panel-h vdt-panel-h-row">
+          <span>Value attribution — driver × capability domain <span class="vdt-hint">share of EV · outlined = KPI lever</span></span>
+          <span class="vdt-scale" aria-hidden="true">
+            <span class="vdt-scale-lo">{{ (minWeight * 100).toFixed(1) }}%</span>
+            <span class="vdt-scale-bar"></span>
+            <span class="vdt-scale-hi">{{ (maxWeight * 100).toFixed(1) }}%</span>
+          </span>
+        </div>
         <div class="vdt-matrix" :style="{ gridTemplateColumns: `minmax(150px, 1.3fr) repeat(${domains.length}, 1fr)` }">
           <div class="vdt-corner"></div>
           <div v-for="d in domains" :key="d" class="vdt-colh" :title="d">{{ short(d) }}</div>
@@ -30,9 +37,9 @@
               :key="drv + d"
               class="vdt-cell"
               :class="{ lever: hasLever(drv, d) }"
-              :style="{ background: cellColor(weightOf(drv, d)) }"
+              :style="cellStyle(weightOf(drv, d))"
               :title="`${drv} × ${d} — ${(weightOf(drv, d) * 100).toFixed(1)}% of EV${hasLever(drv, d) ? ' · KPI: ' + leverOf(drv, d)!.kpi : ''}`"
-            >{{ (weightOf(drv, d) * 100).toFixed(1) }}</div>
+            ><span v-if="hasLever(drv, d)" class="vdt-cell-dot" aria-hidden="true"></span>{{ (weightOf(drv, d) * 100).toFixed(1) }}</div>
           </template>
         </div>
       </div>
@@ -113,10 +120,32 @@ const leverMap = computed(
 const hasLever = (drv: string, d: string) => leverMap.value.has(`${drv}|${d}`);
 const leverOf = (drv: string, d: string) => leverMap.value.get(`${drv}|${d}`);
 
-const maxWeight = computed(() => Math.max(0, ...view.value.weights.map((w) => w.weight)));
-function cellColor(w: number): string {
-  const a = maxWeight.value > 0 ? (w / maxWeight.value) * 0.5 : 0; // 0..0.5 alpha
-  return `rgba(88, 166, 255, ${a.toFixed(3)})`;
+const minWeight = computed(() => Math.min(...view.value.weights.map((w) => w.weight)));
+const maxWeight = computed(() => Math.max(...view.value.weights.map((w) => w.weight)));
+
+// Sequential blue ramp (light → dark) for the attribution heatmap. Replaces the old
+// low-alpha wash, which left small-share cells almost invisible on the dark surface.
+const RAMP: Array<[number, number, number]> = [
+  [230, 241, 251], [133, 183, 235], [55, 138, 221], [24, 95, 165], [4, 44, 83],
+];
+function normWeight(w: number): number {
+  const lo = minWeight.value;
+  const hi = maxWeight.value;
+  return hi > lo ? (w - lo) / (hi - lo) : 0;
+}
+function rampColor(t: number): string {
+  const c = Math.max(0, Math.min(1, t)) * (RAMP.length - 1);
+  const i = Math.floor(c);
+  const f = c - i;
+  const a = RAMP[i];
+  const b = RAMP[Math.min(i + 1, RAMP.length - 1)];
+  const mix = (k: number) => Math.round(a[k] + (b[k] - a[k]) * f);
+  return `rgb(${mix(0)}, ${mix(1)}, ${mix(2)})`;
+}
+// Cell fill by share of EV; text flips to dark ink on the lighter (low-share) cells.
+function cellStyle(w: number): Record<string, string> {
+  const t = normWeight(w);
+  return { background: rampColor(t), color: t < 0.55 ? '#042c53' : '#eaf2fc' };
 }
 
 const driversWithUplift = computed(() => view.value.drivers.filter((d) => (view.value.perDriver[d] ?? 0) !== 0));
@@ -144,13 +173,17 @@ const barPct = (v: number) => Math.max(2, (v / maxDriverUplift.value) * 100);
 .vdt-panel { border: 1px solid var(--line-2); border-radius: 12px; padding: 0.85rem; background: var(--surface); }
 .vdt-panel-h { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.09em; color: rgba(255, 255, 255, 0.5); margin-bottom: 0.7rem; }
 .vdt-hint { text-transform: none; letter-spacing: 0; color: var(--text-3); font-size: 0.66rem; }
+.vdt-panel-h-row { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; }
+.vdt-scale { display: inline-flex; align-items: center; gap: 6px; text-transform: none; letter-spacing: 0; font-size: 0.62rem; color: var(--text-3); }
+.vdt-scale-bar { width: 110px; height: 9px; border-radius: 3px; background: linear-gradient(90deg, rgb(230, 241, 251), rgb(55, 138, 221), rgb(4, 44, 83)); }
 
 .vdt-matrix { display: grid; gap: 3px; }
 .vdt-corner { }
 .vdt-colh { font-size: 0.6rem; color: rgba(255, 255, 255, 0.5); text-align: center; padding: 0.2rem 0; white-space: nowrap; }
 .vdt-rowh { font-size: 0.72rem; color: rgba(255, 255, 255, 0.8); display: flex; align-items: center; padding-right: 0.4rem; }
-.vdt-cell { display: grid; place-items: center; height: 30px; border-radius: 5px; font-size: 0.66rem; color: rgba(255, 255, 255, 0.85); font-variant-numeric: tabular-nums; }
-.vdt-cell.lever { outline: 2px solid var(--up); outline-offset: -2px; font-weight: 700; color: #fff; }
+.vdt-cell { position: relative; display: grid; place-items: center; height: 34px; border-radius: 6px; font-size: 0.7rem; font-weight: 500; font-variant-numeric: tabular-nums; }
+.vdt-cell.lever { outline: 2px solid #eda100; outline-offset: -2px; font-weight: 700; }
+.vdt-cell-dot { position: absolute; top: 3px; right: 4px; width: 5px; height: 5px; border-radius: 50%; background: #eda100; }
 
 .vdt-bars { display: flex; flex-direction: column; gap: 0.45rem; }
 .vdt-bar-row { display: grid; grid-template-columns: 8.5rem 1fr auto; align-items: center; gap: 0.6rem; }

--- a/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
+++ b/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
@@ -6,7 +6,7 @@
           <p class="vdt-eyebrow">Economy &amp; Industry</p>
           <h1>Value Drivers</h1>
         </div>
-        <span class="vdt-pill">fixture</span>
+        <span class="vdt-pill" :class="mode" :title="mode === 'live' ? 'Served live from economic-prophet via dashboard-bff /v1/vdt' : 'dashboard-bff unavailable — rendering the local fixture (same engine math)'">{{ mode }}</span>
         <span class="vdt-ind">{{ industry }}</span>
       </div>
       <div class="vdt-metrics">
@@ -68,13 +68,26 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
-import {
-  industry, enterpriseValueBaseline as evBaseline, drivers, domains,
-  weights, kpis, weightOf, computeVdt,
-} from '../data/vdtFixture';
+import { computed, onMounted, ref } from 'vue';
+import { fetchVdtWithFallback, fixtureView, type VdtView } from '../api/vdtApi';
 
-const c = computeVdt();
+// Initialise from the fixture (canonical engine math computed locally) so the surface renders
+// synchronously; on mount, try the live dashboard-bff /v1/vdt and swap in the engine's output.
+const view = ref<VdtView>(fixtureView());
+const mode = ref<'live' | 'fixture'>('fixture');
+
+onMounted(async () => {
+  const res = await fetchVdtWithFallback();
+  view.value = res.view;
+  mode.value = res.mode;
+});
+
+const industry = computed(() => view.value.industry);
+const evBaseline = computed(() => view.value.evBaseline);
+const drivers = computed(() => view.value.drivers);
+const domains = computed(() => view.value.domains);
+const weights = computed(() => view.value.weights);
+const c = computed(() => view.value);
 
 const money = (n: number): string =>
   new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', notation: 'compact', maximumFractionDigits: 2 }).format(n);
@@ -89,18 +102,25 @@ function short(d: string): string {
     .replace('GovernanceKnowledge', 'Govern');
 }
 
-const leverMap = new Map(kpis.map((k) => [`${k.driver}|${k.domain}`, k] as const));
-const hasLever = (drv: string, d: string) => leverMap.has(`${drv}|${d}`);
-const leverOf = (drv: string, d: string) => leverMap.get(`${drv}|${d}`);
+const weightIndex = computed(
+  () => new Map(view.value.weights.map((w) => [`${w.driver}|${w.domain}`, w.weight] as const)),
+);
+const weightOf = (drv: string, d: string): number => weightIndex.value.get(`${drv}|${d}`) ?? 0;
 
-const maxWeight = Math.max(...weights.map((w) => w.weight));
+const leverMap = computed(
+  () => new Map(view.value.perKpi.map((k) => [`${k.driver}|${k.domain}`, k] as const)),
+);
+const hasLever = (drv: string, d: string) => leverMap.value.has(`${drv}|${d}`);
+const leverOf = (drv: string, d: string) => leverMap.value.get(`${drv}|${d}`);
+
+const maxWeight = computed(() => Math.max(0, ...view.value.weights.map((w) => w.weight)));
 function cellColor(w: number): string {
-  const a = maxWeight > 0 ? (w / maxWeight) * 0.5 : 0; // 0..0.5 alpha
+  const a = maxWeight.value > 0 ? (w / maxWeight.value) * 0.5 : 0; // 0..0.5 alpha
   return `rgba(88, 166, 255, ${a.toFixed(3)})`;
 }
 
-const driversWithUplift = computed(() => drivers.filter((d) => (c.perDriver[d] ?? 0) !== 0));
-const maxDriverUplift = computed(() => Math.max(1, ...Object.values(c.perDriver)));
+const driversWithUplift = computed(() => view.value.drivers.filter((d) => (view.value.perDriver[d] ?? 0) !== 0));
+const maxDriverUplift = computed(() => Math.max(1, ...Object.values(view.value.perDriver)));
 const barPct = (v: number) => Math.max(2, (v / maxDriverUplift.value) * 100);
 </script>
 
@@ -110,6 +130,7 @@ const barPct = (v: number) => Math.max(2, (v / maxDriverUplift.value) * 100);
 .vdt-title { display: flex; align-items: baseline; gap: 0.7rem; flex-wrap: wrap; } .vdt-title h1 { margin: 0; font-size: 1.3rem; }
 .vdt-eyebrow { margin: 0 0 0.1rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); }
 .vdt-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: #e3b341; background: rgba(227, 179, 65, 0.14); border-radius: 5px; padding: 0.1rem 0.35rem; }
+.vdt-pill.live { color: var(--up); background: rgba(63, 185, 80, 0.16); }
 .vdt-ind { font-size: 0.78rem; color: rgba(255, 255, 255, 0.55); }
 .vdt-metrics { display: flex; gap: 0.6rem; flex-wrap: wrap; }
 .vdt-metric { display: flex; flex-direction: column; border: 1px solid var(--line-2); border-radius: 10px; padding: 0.4rem 0.8rem; min-width: 8rem; }


### PR DESCRIPTION
## What
Wires the **Value Drivers** cockpit surface (shipped in #413) to the **live economic-prophet engine** instead of the hand-mirrored `vdtFixture.ts`.

## Why
The surface computed value uplift from a TS fixture that duplicated the engine's tensor+KPI math — drift risk and not actually live. This makes it consume the canonical engine's output over HTTP, with the fixture retained only as an offline fallback.

## How
- **`src/api/vdtApi.ts`** — fronts dashboard-bff `GET /v1/vdt` (prophet-platform #711). Maps the server response (snake_case) to a normalized `VdtView`, and exposes `fetchVdtWithFallback()` returning `{ view, mode: 'live' | 'fixture' }`. Mirrors `intelligenceSuperiorityApi.ts`.
- **`ValueDriverTree.vue`** — initialises from `fixtureView()` (synchronous render, same engine math), then on mount swaps in the live engine output when the BFF is reachable; falls back to the fixture otherwise. A **live/fixture pill** shows which source is rendering.
- The value math (EP/UVMC/VDT identities) stays in `economic-prophet` — never reimplemented in the frontend.

## Tests
- `src/__tests__/vdtApi.test.ts` — live snake→camel mapping, fixture fallback on backend error, `fixtureView()` reproduces `computeVdt()`.
- existing `vdtSurface.test.ts` mount test still green (renders from the fixture initial state).

**5/5 vitest green · `vue-tsc --noEmit` clean project-wide.**

## Depends on
prophet-platform #711 (the `/v1/vdt` endpoint). Until deployed, the surface renders in fixture mode — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
