### PR TITLE
feat(client-vue): industry selector on the Value Drivers surface

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/vdtApi.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/vdtApi.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchVdtWithFallback, fixtureView } from '../api/vdtApi';
+import { fetchVdtWithFallback, fetchVdtCatalogWithFallback, fixtureView } from '../api/vdtApi';
 import { computeVdt } from '../data/vdtFixture';
 
 const LIVE_RESPONSE = {
@@ -58,5 +58,32 @@ describe('vdtApi', () => {
     expect(res.mode).toBe('fixture');
     expect(res.error).toContain('connection refused');
     expect(res.view.weights.length).toBe(36);
+  });
+
+  it('requests the selected industry via the query param', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => LIVE_RESPONSE } as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchVdtWithFallback('banks');
+    expect(fetchMock.mock.calls[0]![0]).toContain('/v1/vdt?industry=banks');
+  });
+
+  it('loads the industry catalog live, and degrades to Software-only offline', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ service: 'dashboard-bff', industries: [
+        { id: 'software', label: 'Software & Platforms', industry: 'GICS45_SoftwarePlatforms' },
+        { id: 'banks', label: 'Banks & Financials', industry: 'GICS40_BanksDiversifiedFinancials' },
+        { id: 'energy', label: 'Energy', industry: 'GICS10_Energy' },
+      ] }),
+    } as Response));
+    const live = await fetchVdtCatalogWithFallback();
+    expect(live.mode).toBe('live');
+    expect(live.industries.map((i) => i.id)).toEqual(['software', 'banks', 'energy']);
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    const off = await fetchVdtCatalogWithFallback();
+    expect(off.mode).toBe('fixture');
+    expect(off.industries).toHaveLength(1);
+    expect(off.industries[0]!.id).toBe('software');
   });
 });

--- a/socioprophet-web/client-vue/src/api/vdtApi.ts
+++ b/socioprophet-web/client-vue/src/api/vdtApi.ts
@@ -147,11 +147,38 @@ export function fixtureView(): VdtView {
   };
 }
 
-export async function fetchVdtWithFallback(): Promise<VdtLoadResult> {
+export async function fetchVdtWithFallback(industry = 'software'): Promise<VdtLoadResult> {
   try {
-    const d = await getJson<VdtResponse>('/v1/vdt');
+    const d = await getJson<VdtResponse>(`/v1/vdt?industry=${encodeURIComponent(industry)}`);
     return { view: fromResponse(d), mode: 'live' };
   } catch (err) {
+    // Fixture only carries the Software tensor; a live backend is needed for other industries.
     return { view: fixtureView(), mode: 'fixture', error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface VdtIndustry {
+  id: string;
+  label: string;
+  industry: string;
+}
+
+interface VdtCatalogResponse {
+  service: string;
+  industries: VdtIndustry[];
+}
+
+// The industry selector's options. Live from /v1/vdt/catalog; offline it degrades to the one
+// industry the client fixture can actually compute (Software).
+const FIXTURE_CATALOG: VdtIndustry[] = [
+  { id: 'software', label: 'Software & Platforms', industry: fxIndustry },
+];
+
+export async function fetchVdtCatalogWithFallback(): Promise<{ industries: VdtIndustry[]; mode: VdtMode }> {
+  try {
+    const d = await getJson<VdtCatalogResponse>('/v1/vdt/catalog');
+    return { industries: d.industries, mode: 'live' };
+  } catch {
+    return { industries: FIXTURE_CATALOG, mode: 'fixture' };
   }
 }

--- a/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
+++ b/socioprophet-web/client-vue/src/pages/ValueDriverTree.vue
@@ -7,7 +7,10 @@
           <h1>Value Drivers</h1>
         </div>
         <span class="vdt-pill" :class="mode" :title="mode === 'live' ? 'Served live from economic-prophet via dashboard-bff /v1/vdt' : 'dashboard-bff unavailable — rendering the local fixture (same engine math)'">{{ mode }}</span>
-        <span class="vdt-ind">{{ industry }}</span>
+        <select v-if="industries.length > 1" v-model="industryId" class="vdt-industry" aria-label="Industry">
+          <option v-for="i in industries" :key="i.id" :value="i.id">{{ i.label }}</option>
+        </select>
+        <span v-else class="vdt-ind">{{ industry }}</span>
       </div>
       <div class="vdt-metrics">
         <div class="vdt-metric"><span class="vdt-m-label">Enterprise value</span><span class="vdt-m-val">{{ money(evBaseline) }}</span></div>
@@ -75,19 +78,31 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-import { fetchVdtWithFallback, fixtureView, type VdtView } from '../api/vdtApi';
+import { computed, onMounted, ref, watch } from 'vue';
+import { fetchVdtWithFallback, fetchVdtCatalogWithFallback, fixtureView, type VdtView, type VdtIndustry } from '../api/vdtApi';
 
 // Initialise from the fixture (canonical engine math computed locally) so the surface renders
-// synchronously; on mount, try the live dashboard-bff /v1/vdt and swap in the engine's output.
+// synchronously; on mount, load the industry catalog + the live dashboard-bff /v1/vdt and swap in
+// the engine's output. Fixture mode carries only Software (the client can't compute other tensors).
 const view = ref<VdtView>(fixtureView());
 const mode = ref<'live' | 'fixture'>('fixture');
+const industries = ref<VdtIndustry[]>([{ id: 'software', label: 'Software & Platforms', industry: view.value.industry }]);
+const industryId = ref<string>('software');
 
-onMounted(async () => {
-  const res = await fetchVdtWithFallback();
+async function loadVdt(): Promise<void> {
+  const res = await fetchVdtWithFallback(industryId.value);
   view.value = res.view;
   mode.value = res.mode;
+}
+
+onMounted(async () => {
+  const cat = await fetchVdtCatalogWithFallback();
+  industries.value = cat.industries;
+  if (!industries.value.some((i) => i.id === industryId.value)) industryId.value = industries.value[0]?.id ?? 'software';
+  await loadVdt();
 });
+
+watch(industryId, loadVdt);
 
 const industry = computed(() => view.value.industry);
 const evBaseline = computed(() => view.value.evBaseline);
@@ -161,6 +176,7 @@ const barPct = (v: number) => Math.max(2, (v / maxDriverUplift.value) * 100);
 .vdt-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: #e3b341; background: rgba(227, 179, 65, 0.14); border-radius: 5px; padding: 0.1rem 0.35rem; }
 .vdt-pill.live { color: var(--up); background: rgba(63, 185, 80, 0.16); }
 .vdt-ind { font-size: 0.78rem; color: rgba(255, 255, 255, 0.55); }
+.vdt-industry { font-size: 0.78rem; color: var(--text, rgba(255,255,255,0.9)); background: var(--surface, transparent); border: 1px solid var(--line-2, rgba(255,255,255,0.15)); border-radius: 7px; padding: 0.2rem 0.45rem; }
 .vdt-metrics { display: flex; gap: 0.6rem; flex-wrap: wrap; }
 .vdt-metric { display: flex; flex-direction: column; border: 1px solid var(--line-2); border-radius: 10px; padding: 0.4rem 0.8rem; min-width: 8rem; }
 .vdt-metric.up { border-color: rgba(63, 185, 80, 0.35); }


### PR DESCRIPTION
## What
Adds an **industry dropdown** (Software / Banks / Energy) to the Value Drivers surface.

## How
- Driven by the live **`/v1/vdt/catalog`** (prophet-platform #712); switching refetches **`/v1/vdt?industry=<id>`** and re-renders the tensor, uplift bars, and KPI cards.
- Offline it degrades to **Software-only** — the client fixture carries just that tensor, so other industries need the live backend (the `fixture`/`live` pill already signals which).
- `vdtApi` gains `fetchVdtCatalogWithFallback()` + an `industry` arg on `fetchVdtWithFallback()`.

## Chain
economic-prophet **#26** (Banks/Energy tensors) → prophet-platform **#712** (industry-aware BFF + catalog) → this. Until the BFF ships, the surface shows Software in fixture mode — no regression.

## Tests
Catalog live + offline degrade, industry query param. vdtApi suite green, `vue-tsc` clean, full suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)