### PR TITLE
feat(client-vue): GYG causal valuation, nav IA cleanup, user settings + mesh connect

### DIFF
--- a/socioprophet-web/client-vue/src/App.vue
+++ b/socioprophet-web/client-vue/src/App.vue
@@ -95,33 +95,29 @@
            it never disturbs the grid. -->
       <div v-if="navOpen" class="sp-nav-backdrop" @click="navOpen = false" />
       <nav v-if="navOpen" ref="navPanelEl" class="sp-nav-panel" aria-label="Capability navigation" @keydown="onNavPanelKey">
-        <div class="sp-nav-section-title">Capabilities</div>
-        <RouterLink
-          v-for="cap in capabilityRail"
-          :key="cap.to"
-          :to="cap.to"
-          class="sp-nav-link"
-          @click="navOpen = false"
-        >{{ cap.label }}</RouterLink>
-        <div class="sp-nav-section-title">Working surfaces</div>
-        <RouterLink
-          v-for="op in operatorShortcuts"
-          :key="op.to"
-          :to="op.to"
-          class="sp-nav-link"
-          @click="navOpen = false"
-        >{{ op.label }}</RouterLink>
-        <template v-if="settings.operatorMode">
-          <div class="sp-nav-section-title sp-nav-op">Operator · SourceOS</div>
-          <template v-for="grp in agentCockpit" :key="grp.label">
-            <div class="sp-nav-section-title">{{ grp.label }}</div>
-            <RouterLink
-              v-for="leaf in grp.items"
-              :key="leaf.to"
-              :to="leaf.to"
-              class="sp-nav-link"
-              @click="navOpen = false"
-            >{{ leaf.label }}</RouterLink>
+        <button class="sp-nav-search" type="button" @click="paletteOpen = true; navOpen = false">
+          <span>⌕ Jump to a surface…</span><kbd>⌘K</kbd>
+        </button>
+
+        <template v-if="pinnedSurfaces.length">
+          <div class="sp-nav-section-title">Pinned</div>
+          <div v-for="p in pinnedSurfaces" :key="p.to" class="sp-nav-link sp-nav-leaf">
+            <RouterLink :to="p.to" class="sp-nav-lbl" @click="navOpen = false">{{ p.label }}</RouterLink>
+            <button class="sp-pin on" type="button" title="Unpin" @click.stop="settings.togglePin(p.to)">★</button>
+          </div>
+        </template>
+
+        <template v-for="sec in drawerSections" :key="sec.id">
+          <button class="sp-nav-sec" type="button" :aria-expanded="secOpen(sec)" @click="settings.toggleSection(sec.id, secOpen(sec))">
+            <span class="sp-nav-caret">{{ secOpen(sec) ? '▾' : '▸' }}</span>
+            <span class="sp-nav-sec-lbl" :class="{ op: sec.operator }">{{ sec.label }}</span>
+            <span class="sp-nav-count">{{ sec.items.length }}</span>
+          </button>
+          <template v-if="secOpen(sec)">
+            <div v-for="leaf in sec.items" :key="leaf.to" class="sp-nav-link sp-nav-leaf">
+              <RouterLink :to="leaf.to" class="sp-nav-lbl" @click="navOpen = false">{{ leaf.label }}</RouterLink>
+              <button class="sp-pin" :class="{ on: settings.isPinned(leaf.to) }" type="button" :title="settings.isPinned(leaf.to) ? 'Unpin' : 'Pin'" @click.stop="settings.togglePin(leaf.to)">{{ settings.isPinned(leaf.to) ? '★' : '☆' }}</button>
+            </div>
           </template>
         </template>
       </nav>
@@ -243,7 +239,7 @@ import GraphDock from './components/GraphDock.vue';
 import { useOperatorTerminal } from './composables/useOperatorTerminal';
 import { useNoeticaChat } from './composables/useNoeticaChat';
 import { domainSurfaces, surfaceForRoute, surfacesForDomain } from './config/domainRoutes';
-import { AGENT_COCKPIT, CAPABILITY_RAIL, DOMAIN_MENU, OPERATOR_SHORTCUTS } from './config/cockpitNav';
+import { CAPABILITY_RAIL, DOMAIN_MENU, DRAWER_SECTIONS, ALL_SURFACES, type SurfaceEntry } from './config/cockpitNav';
 import {
   entriesForDomain,
   registryEntryForPath,
@@ -269,8 +265,11 @@ const logout = async () => {
 // and only when Operator mode is on). Keeps the primary bar clean for everyday users.
 const domainMenu = [...DOMAIN_MENU];
 const capabilityRail = CAPABILITY_RAIL;
-const operatorShortcuts = OPERATOR_SHORTCUTS;
-const agentCockpit = AGENT_COCKPIT;
+// Accordion drawer: everyday sections open, everything else collapsed-but-present.
+const drawerSections = DRAWER_SECTIONS;
+function secOpen(sec: (typeof DRAWER_SECTIONS)[number]) { return settings.isSectionOpen(sec.id, sec.defaultOpen, sec.operator); }
+const pinnedSurfaces = computed<SurfaceEntry[]>(() =>
+  settings.pinned.map((to) => ALL_SURFACES.find((s) => s.to === to)).filter(Boolean) as SurfaceEntry[]);
 const navOpen = ref(false);
 const userMenuOpen = ref(false);
 const userInitials = computed(() => {
@@ -671,4 +670,19 @@ const activeRuntimeFeatures = computed<RuntimeAdapterFeature[]>(() => {
 }
 .sp-nav-link:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
 .sp-nav-link.router-link-active { color: #78c88c; }
+/* Accordion drawer */
+.sp-nav-search { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; width: calc(100% - 1.2rem); margin: 0.6rem; padding: 0.5rem 0.7rem; background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 8px; color: rgba(255, 255, 255, 0.6); cursor: pointer; font-size: 0.82rem; }
+.sp-nav-search kbd { font-size: 0.66rem; border: 1px solid rgba(255, 255, 255, 0.18); border-radius: 4px; padding: 0 0.3rem; }
+.sp-nav-sec { display: flex; align-items: center; gap: 0.5rem; width: 100%; background: transparent; border: 0; cursor: pointer; padding: 0.5rem 1rem; color: rgba(255, 255, 255, 0.85); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; }
+.sp-nav-sec:hover { background: rgba(255, 255, 255, 0.05); }
+.sp-nav-caret { width: 0.8rem; color: rgba(255, 255, 255, 0.5); font-size: 0.7rem; }
+.sp-nav-sec-lbl { flex: 1; text-align: left; }
+.sp-nav-sec-lbl.op { color: #34d399; }
+.sp-nav-count { font-size: 0.68rem; color: rgba(255, 255, 255, 0.4); }
+.sp-nav-leaf { display: flex; align-items: center; gap: 0.5rem; }
+.sp-nav-leaf .sp-nav-lbl { flex: 1; color: rgba(255, 255, 255, 0.82); text-decoration: none; }
+.sp-nav-leaf .sp-nav-lbl.router-link-active { color: #78c88c; }
+.sp-nav-leaf:hover { background: rgba(255, 255, 255, 0.08); }
+.sp-pin { background: transparent; border: 0; cursor: pointer; color: rgba(255, 255, 255, 0.28); font-size: 0.9rem; padding: 0 0.2rem; line-height: 1; }
+.sp-pin.on, .sp-pin:hover { color: #f5b301; }
 </style>

--- a/socioprophet-web/client-vue/src/App.vue
+++ b/socioprophet-web/client-vue/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sp-shell" :class="{ 'dock-open': cockpit.dockOpen }">
     <header class="sp-topbar">
-      <RouterLink class="sp-brand" to="/news">SocioProphet</RouterLink>
+      <RouterLink class="sp-brand" to="/capability/dashboard">SocioProphet</RouterLink>
       <nav ref="domainNavEl" class="sp-domain-nav" aria-label="Primary domains" @focusout="onDomainFocusOut">
         <div v-for="(menu, mi) in domainMenu" :key="menu.label" class="sp-menu" :class="{ open: openMenu === mi }">
           <RouterLink
@@ -43,10 +43,27 @@
           </div>
         </div>
       </nav>
-      <div class="sp-profile" v-if="auth.user">
-        <span class="sp-tier-pill">{{ auth.tier }}</span>
-        <span class="sp-user-email">{{ auth.user.email }}</span>
-        <button type="button" class="sp-signout" @click="logout">Sign out</button>
+      <div class="sp-user" v-if="auth.user">
+        <button type="button" class="sp-avatar" :aria-expanded="userMenuOpen" aria-label="User menu" @click="userMenuOpen = !userMenuOpen">
+          {{ userInitials }}
+        </button>
+        <div v-if="userMenuOpen" class="sp-user-backdrop" @click="userMenuOpen = false" />
+        <div v-if="userMenuOpen" class="sp-user-menu" role="menu">
+          <div class="sp-user-head">
+            <span class="sp-user-email">{{ auth.user.email }}</span>
+            <span class="sp-tier-pill">{{ auth.tier }}</span>
+          </div>
+          <RouterLink to="/settings" class="sp-user-item" role="menuitem" @click="userMenuOpen = false">Profile</RouterLink>
+          <RouterLink to="/settings" class="sp-user-item" role="menuitem" @click="userMenuOpen = false">Settings</RouterLink>
+          <RouterLink to="/operator/holograph-me" class="sp-user-item" role="menuitem" @click="userMenuOpen = false">HolographMe</RouterLink>
+          <button type="button" class="sp-user-item sp-user-toggle" role="menuitemcheckbox" :aria-checked="settings.theme === 'light'" @click="settings.toggleTheme()">
+            <span>Appearance</span><span class="sp-toggle-state">{{ settings.theme === 'light' ? 'Light' : 'Dark' }}</span>
+          </button>
+          <button type="button" class="sp-user-item sp-user-toggle" role="menuitemcheckbox" :aria-checked="settings.operatorMode" @click="settings.toggleOperatorMode()">
+            <span>Operator mode</span><span class="sp-toggle-state" :class="{ on: settings.operatorMode }">{{ settings.operatorMode ? 'On' : 'Off' }}</span>
+          </button>
+          <button type="button" class="sp-user-item sp-user-signout" role="menuitem" @click="logout">Sign out</button>
+        </div>
       </div>
       <RouterLink v-else class="sp-signin" to="/login">Sign in</RouterLink>
     </header>
@@ -94,15 +111,18 @@
           class="sp-nav-link"
           @click="navOpen = false"
         >{{ op.label }}</RouterLink>
-        <template v-for="grp in agentCockpit" :key="grp.label">
-          <div class="sp-nav-section-title">{{ grp.label }}</div>
-          <RouterLink
-            v-for="leaf in grp.items"
-            :key="leaf.to"
-            :to="leaf.to"
-            class="sp-nav-link"
-            @click="navOpen = false"
-          >{{ leaf.label }}</RouterLink>
+        <template v-if="settings.operatorMode">
+          <div class="sp-nav-section-title sp-nav-op">Operator · SourceOS</div>
+          <template v-for="grp in agentCockpit" :key="grp.label">
+            <div class="sp-nav-section-title">{{ grp.label }}</div>
+            <RouterLink
+              v-for="leaf in grp.items"
+              :key="leaf.to"
+              :to="leaf.to"
+              class="sp-nav-link"
+              @click="navOpen = false"
+            >{{ leaf.label }}</RouterLink>
+          </template>
         </template>
       </nav>
 
@@ -214,6 +234,7 @@ import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router';
 import { useAuth } from './stores/auth';
 import { useResearch } from './stores/research';
 import { useCockpit } from './stores/cockpit';
+import { useSettings } from './stores/settings';
 import RuntimeAdapterStatusBadge from './components/RuntimeAdapterStatusBadge.vue';
 import QuakeTerminal from './components/QuakeTerminal.vue';
 import CommandPalette from './components/CommandPalette.vue';
@@ -222,7 +243,7 @@ import GraphDock from './components/GraphDock.vue';
 import { useOperatorTerminal } from './composables/useOperatorTerminal';
 import { useNoeticaChat } from './composables/useNoeticaChat';
 import { domainSurfaces, surfaceForRoute, surfacesForDomain } from './config/domainRoutes';
-import { AGENT_COCKPIT, CAPABILITY_RAIL, DOMAIN_MENU, OPERATOR_MENU, OPERATOR_SHORTCUTS } from './config/cockpitNav';
+import { AGENT_COCKPIT, CAPABILITY_RAIL, DOMAIN_MENU, OPERATOR_SHORTCUTS } from './config/cockpitNav';
 import {
   entriesForDomain,
   registryEntryForPath,
@@ -236,17 +257,28 @@ const router = useRouter();
 const auth = useAuth();
 const research = useResearch();
 const cockpit = useCockpit();
+const settings = useSettings();
 
 const logout = async () => {
   await auth.signOut();
   router.push('/login');
 };
 
-const domainMenu = [...DOMAIN_MENU, OPERATOR_MENU];
+// Top row = user domains only. The Operator / SourceOS surfaces do NOT sit in this
+// row (they're a dashboard-class thing, already reachable from the hamburger drawer,
+// and only when Operator mode is on). Keeps the primary bar clean for everyday users.
+const domainMenu = [...DOMAIN_MENU];
 const capabilityRail = CAPABILITY_RAIL;
 const operatorShortcuts = OPERATOR_SHORTCUTS;
 const agentCockpit = AGENT_COCKPIT;
 const navOpen = ref(false);
+const userMenuOpen = ref(false);
+const userInitials = computed(() => {
+  const name: string = auth.user?.displayName ?? '';
+  if (name) return name.split(/\s+/).map((s: string) => s[0]).slice(0, 2).join('').toUpperCase();
+  const email: string = auth.user?.email ?? '';
+  return (email.slice(0, 2) || '?').toUpperCase();
+});
 
 // ── Keyboard navigation for the nav menus ────────────────────────────────────
 const domainNavEl = ref<HTMLElement | null>(null);
@@ -302,7 +334,7 @@ function onNavPanelKey(e: KeyboardEvent) {
 }
 
 // Any navigation closes the open menus.
-watch(() => route.path, () => { openMenu.value = null; navOpen.value = false; });
+watch(() => route.path, () => { openMenu.value = null; navOpen.value = false; userMenuOpen.value = false; });
 
 // Quake drop-down terminal — shell-wide, toggled by the footer button or Ctrl+`.
 const paletteOpen = ref(false);
@@ -460,6 +492,39 @@ const activeRuntimeFeatures = computed<RuntimeAdapterFeature[]>(() => {
 .sp-signout:hover,
 .sp-signin:hover { background: rgba(255, 255, 255, 0.08); }
 .sp-signin { margin-left: auto; }
+
+/* Top-right user dropdown */
+.sp-user { margin-left: auto; position: relative; }
+.sp-avatar {
+  width: 30px; height: 30px; border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.72rem; font-weight: 600; cursor: pointer;
+}
+.sp-avatar:hover { background: rgba(255, 255, 255, 0.16); }
+.sp-user-backdrop { position: fixed; inset: 0; z-index: 40; }
+.sp-user-menu {
+  position: absolute; top: calc(100% + 8px); right: 0; z-index: 41;
+  min-width: 240px; padding: 6px 0;
+  background: #14161c; border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.sp-user-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 8px 14px 10px; border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.sp-user-item {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  width: 100%; text-align: left; padding: 8px 14px;
+  background: transparent; border: 0; cursor: pointer;
+  color: rgba(255, 255, 255, 0.85); font-size: 0.82rem; text-decoration: none;
+}
+.sp-user-item:hover { background: rgba(255, 255, 255, 0.08); }
+.sp-toggle-state { font-size: 0.72rem; color: rgba(255, 255, 255, 0.5); }
+.sp-toggle-state.on { color: #34d399; }
+.sp-user-signout { border-top: 1px solid rgba(255, 255, 255, 0.1); margin-top: 4px; }
+.sp-nav-op { color: #34d399; }
 
 .sp-capture-actions {
   display: flex;

--- a/socioprophet-web/client-vue/src/__tests__/OperatorDashboard.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/OperatorDashboard.smoke.test.ts
@@ -29,7 +29,7 @@ describe('Operator Dashboard', () => {
     const wrapper = await mountDashboard();
     const text = wrapper.text();
 
-    expect(text).toContain('Operator Dashboard');
+    expect(text).toContain('User Dashboard');
     for (const tile of ['Markets', 'News & Events', 'Economy', 'People', 'Law & Regulation', 'Weather', 'Social Signals', 'Active Alerts']) {
       expect(text).toContain(tile);
     }

--- a/socioprophet-web/client-vue/src/__tests__/navScope.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/navScope.test.ts
@@ -12,8 +12,10 @@ describe('navScopeForPath', () => {
   });
 
   it('resolves a CAPABILITY rail cell as a non-primary lens', () => {
-    const portfolios = navScopeForPath('/capability/portfolios');
-    expect(portfolios).toMatchObject({ domain: 'Capabilities', label: 'Portfolios & Watch Lists', isPrimary: false });
+    // Economic Prophet stays rail-only, so it resolves via the CAPABILITY axis.
+    // (Portfolios & Algo Trading were intentionally promoted into the Capital & Markets menu.)
+    const cap = navScopeForPath('/capability/economic-prophet');
+    expect(cap).toMatchObject({ domain: 'Capabilities', label: 'Economic Prophet', isPrimary: false });
 
     const entity = navScopeForPath('/capability/entity-analytics');
     expect(entity?.label).toBe('Entity Analytics');

--- a/socioprophet-web/client-vue/src/api/causalValuationApi.ts
+++ b/socioprophet-web/client-vue/src/api/causalValuationApi.ts
@@ -1,0 +1,111 @@
+// Causal valuation + location-twin API client (GYG use case).
+//
+// Fronts the prophet-platform dashboard-bff routes:
+//   GET  /v1/valuation/causal            — hellgraph supply-chain causal graph joined with the
+//                                           economic-prophet value-driver-tree valuation.
+//   POST /v1/valuation/causal/recompute  — what-if: re-runs the CANONICAL economic-prophet engine
+//                                           on assumption / horizon / discount overrides.
+//   GET  /v1/locations                   — restaurant sample with MODELED per-site foot-traffic/sales.
+//
+// The value math lives in economic-prophet; this client only fetches and normalises. Mirrors
+// vdtApi.ts: an env-configured base + a getJson wrapper + graceful fallback so the surface labels
+// live vs unavailable rather than blanking.
+
+// Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE or VITE_MESH_BASE
+// (mesh.socioprophet.ai) to run the SPA against a hosted Prophet Mesh instance.
+const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || (import.meta as any).env?.VITE_MESH_BASE || '/api';
+
+export type LoadMode = 'live' | 'unavailable';
+
+export interface GraphNode { id: string; labels: string[]; properties: Record<string, any> }
+export interface GraphEdge { label: string; from: string; to: string; properties: Record<string, any> }
+
+export interface CausalValuation {
+  company: string;
+  subject: string;
+  recomputed: boolean;
+  valuation: { currency: string; ev_baseline: number; projected_ev: number; value_uplift: number; uplift_fraction: number };
+  timeseries: {
+    horizon_years: number;
+    discount_rate: number;
+    periods: Array<{ year: number; projected_enterprise_value: number; total_value_uplift: number; value_uplift_fraction: number; incremental_value_uplift: number }>;
+    terminal_projected_enterprise_value: number;
+    terminal_total_value_uplift: number;
+    present_value_of_uplift: number;
+  };
+  assumptions_editable: Array<{ kpi: string; driver: string; domain: string; delta_pct: number; polarity: string }>;
+  causal_graph: { nodes: GraphNode[]; edges: GraphEdge[] };
+  vdt: {
+    scenario: string; industry: string;
+    per_driver_uplift: Record<string, number>;
+    per_kpi_contribution: Array<{ kpi: string; driver: string; domain: string; delta_pct: number; polarity: string; value_contribution: number }>;
+    epistemic_status: Record<string, any>;
+    assumptions: string[]; limitations: string[]; evidence_refs: string[];
+  };
+  provenance: Record<string, any>;
+  headline: string;
+}
+
+export interface GygLocation {
+  id: string; suburb: string; state: string; lat: number; lng: number;
+  format: string; ownership: string; metro_tier: number; catchment_profile: string;
+  est_annual_sales_aud: number; modeled_weekly_footfall: number; basis: string;
+}
+
+export interface LocationsPayload {
+  subject: string;
+  locations: GygLocation[];
+  sample_size: number;
+  network_totals: { total_au_restaurants: number; drive_thru: number; strip: number; other: number; as_of: string };
+  org_twin: {
+    sample_modeled_annual_sales_aud: number;
+    sample_modeled_weekly_footfall: number;
+    by_state: Record<string, number>;
+    by_format: Record<string, number>;
+    network_extrapolation_note: string;
+  };
+}
+
+export interface CausalOverrides {
+  ev_baseline?: number;
+  horizon_years?: number;
+  discount_rate?: number;
+  kpi_overrides?: Record<string, number>;
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, { headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<T>;
+}
+
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${path}`);
+  return res.json() as Promise<T>;
+}
+
+export async function fetchCausalValuation(company = 'gyg'): Promise<{ data: CausalValuation | null; mode: LoadMode; error?: string }> {
+  try {
+    return { data: await getJson<CausalValuation>(`/v1/valuation/causal?company=${encodeURIComponent(company)}`), mode: 'live' };
+  } catch (err) {
+    return { data: null, mode: 'unavailable', error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function recomputeCausalValuation(overrides: CausalOverrides, company = 'gyg'): Promise<CausalValuation> {
+  return postJson<CausalValuation>(`/v1/valuation/causal/recompute?company=${encodeURIComponent(company)}`, overrides);
+}
+
+export async function fetchLocations(company = 'gyg', q = '', state = ''): Promise<{ data: LocationsPayload | null; mode: LoadMode; error?: string }> {
+  const params = new URLSearchParams({ company, q, state });
+  try {
+    return { data: await getJson<LocationsPayload>(`/v1/locations?${params.toString()}`), mode: 'live' };
+  } catch (err) {
+    return { data: null, mode: 'unavailable', error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/socioprophet-web/client-vue/src/api/causalValuationApi.ts
+++ b/socioprophet-web/client-vue/src/api/causalValuationApi.ts
@@ -101,6 +101,32 @@ export async function recomputeCausalValuation(overrides: CausalOverrides, compa
   return postJson<CausalValuation>(`/v1/valuation/causal/recompute?company=${encodeURIComponent(company)}`, overrides);
 }
 
+// ── Value Driver Studio — causal valuation for ANY company (listed via ticker, or private) ──
+export interface StudioParams {
+  ticker?: string; template?: string; ev_baseline?: number; name?: string;
+  horizon_years?: number; discount_rate?: number;
+}
+
+export async function fetchStudioTemplates(): Promise<Array<{ id: string; industry: string }>> {
+  try { return (await getJson<{ templates: Array<{ id: string; industry: string }> }>('/v1/valuation/studio/templates')).templates; }
+  catch { return []; }
+}
+
+export async function fetchStudioValuation(p: StudioParams): Promise<CausalValuation> {
+  const q = new URLSearchParams();
+  if (p.ticker) q.set('ticker', p.ticker);
+  if (p.template) q.set('template', p.template);
+  if (p.ev_baseline) q.set('ev_baseline', String(p.ev_baseline));
+  if (p.name) q.set('name', p.name);
+  if (p.horizon_years) q.set('horizon_years', String(p.horizon_years));
+  if (p.discount_rate != null) q.set('discount_rate', String(p.discount_rate));
+  return getJson<CausalValuation>(`/v1/valuation/studio?${q.toString()}`);
+}
+
+export async function recomputeStudioValuation(overrides: StudioParams & { kpi_overrides?: Record<string, number> }): Promise<CausalValuation> {
+  return postJson<CausalValuation>('/v1/valuation/studio/recompute', overrides);
+}
+
 export async function fetchLocations(company = 'gyg', q = '', state = ''): Promise<{ data: LocationsPayload | null; mode: LoadMode; error?: string }> {
   const params = new URLSearchParams({ company, q, state });
   try {

--- a/socioprophet-web/client-vue/src/api/causalValuationApi.ts
+++ b/socioprophet-web/client-vue/src/api/causalValuationApi.ts
@@ -11,9 +11,9 @@
 // vdtApi.ts: an env-configured base + a getJson wrapper + graceful fallback so the surface labels
 // live vs unavailable rather than blanking.
 
-// Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE or VITE_MESH_BASE
-// (mesh.socioprophet.ai) to run the SPA against a hosted Prophet Mesh instance.
-const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || (import.meta as any).env?.VITE_MESH_BASE || '/api';
+// Dashboard-bff (data). Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE
+// to a hosted bff. (The Prophet Mesh is the model gateway, a separate endpoint — see config/mesh.ts.)
+const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || '/api';
 
 export type LoadMode = 'live' | 'unavailable';
 

--- a/socioprophet-web/client-vue/src/api/vdtApi.ts
+++ b/socioprophet-web/client-vue/src/api/vdtApi.ts
@@ -20,7 +20,9 @@ import {
   type Polarity,
 } from '../data/vdtFixture';
 
-const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || '/api';
+// Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE or VITE_MESH_BASE
+// (mesh.socioprophet.ai) to run the SPA against a hosted Prophet Mesh instance.
+const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || (import.meta as any).env?.VITE_MESH_BASE || '/api';
 
 export interface VdtWeightCell {
   driver: string;

--- a/socioprophet-web/client-vue/src/api/vdtApi.ts
+++ b/socioprophet-web/client-vue/src/api/vdtApi.ts
@@ -20,9 +20,9 @@ import {
   type Polarity,
 } from '../data/vdtFixture';
 
-// Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE or VITE_MESH_BASE
-// (mesh.socioprophet.ai) to run the SPA against a hosted Prophet Mesh instance.
-const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || (import.meta as any).env?.VITE_MESH_BASE || '/api';
+// Dashboard-bff (data). Dev uses the Vite proxy ('/api'); set VITE_DASHBOARD_BFF_BASE
+// to a hosted bff. (The Prophet Mesh is the model gateway, a separate endpoint — see config/mesh.ts.)
+const API_BASE = (import.meta as any).env?.VITE_DASHBOARD_BFF_BASE || '/api';
 
 export interface VdtWeightCell {
   driver: string;

--- a/socioprophet-web/client-vue/src/components/CommandPalette.vue
+++ b/socioprophet-web/client-vue/src/components/CommandPalette.vue
@@ -41,7 +41,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
-import { routeRegistry } from '../config/routeRegistry';
+import { ALL_SURFACES } from '../config/cockpitNav';
 import { newsItems, newsSources } from '../data/newsFeedFixture';
 import { entities } from '../data/peopleFixture';
 import { indices, watchlist } from '../data/marketsFixture';
@@ -61,17 +61,10 @@ const inputEl = ref<HTMLInputElement | null>(null);
 const listEl = ref<HTMLElement | null>(null);
 
 interface Dest { id: string; to: string; label: string; sub: string }
-// Real screens, from the route registry (deduped by path).
-const destinations: Dest[] = (() => {
-  const seen = new Set<string>();
-  const out: Dest[] = [];
-  for (const e of routeRegistry) {
-    if (seen.has(e.path)) continue;
-    seen.add(e.path);
-    out.push({ id: e.path, to: e.path, label: e.label, sub: e.domain });
-  }
-  return out;
-})();
+// Every reachable surface across the domain menus + drawer sections (deduped),
+// so ⌘K can jump to anything — including operator/SourceOS surfaces not in the
+// curated route registry.
+const destinations: Dest[] = ALL_SURFACES.map((s) => ({ id: s.to, to: s.to, label: s.label, sub: s.group }));
 
 type Kind = 'nav' | 'article' | 'entity' | 'market' | 'docket' | 'region' | 'econ' | 'chat';
 interface Result { id: string; kind: Kind; icon: string; label: string; sub?: string; hint: string; route?: RouteLocationRaw; idx: number }

--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -6,7 +6,7 @@
 import { ref, watch } from 'vue';
 import { AM_BASE } from '../services/agentMachineApi';
 import { useSettings } from '../stores/settings';
-import { meshChat } from '../config/mesh';
+import { meshChatStream } from '../config/mesh';
 
 const STORE_KEY = 'noetica-chat-v1';
 function loadPersisted(): ChatTurn[] {
@@ -60,8 +60,8 @@ export function createNoeticaChat() {
     // conductor (model=prophet-mesh) instead of the local agent-machine. Non-streaming.
     if (useSettings().meshChat) {
       try {
-        const r = await meshChat(history);
-        assistant.content = r.content;
+        const r = await meshChatStream(history, (delta) => { assistant.content += delta; });
+        if (!assistant.content) assistant.content = r.content;
         assistant.model = r.seat ? `${r.model} · seat ${r.seat}` : r.model;
         assistant.badge = 'Prophet Cloud Mesh';
       } catch (e) {

--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -5,6 +5,8 @@
 // `done` finalizes, `error` degrades honestly. One shared session below.
 import { ref, watch } from 'vue';
 import { AM_BASE } from '../services/agentMachineApi';
+import { useSettings } from '../stores/settings';
+import { meshChat } from '../config/mesh';
 
 const STORE_KEY = 'noetica-chat-v1';
 function loadPersisted(): ChatTurn[] {
@@ -53,6 +55,24 @@ export function createNoeticaChat() {
     const history = turns.value
       .filter((t) => !(t.role === 'assistant' && t.streaming))
       .map((t) => ({ role: t.role, content: t.content }));
+
+    // Prophet Cloud Mesh: when enabled in Settings, route the turn to the live GKE
+    // conductor (model=prophet-mesh) instead of the local agent-machine. Non-streaming.
+    if (useSettings().meshChat) {
+      try {
+        const r = await meshChat(history);
+        assistant.content = r.content;
+        assistant.model = r.seat ? `${r.model} · seat ${r.seat}` : r.model;
+        assistant.badge = 'Prophet Cloud Mesh';
+      } catch (e) {
+        assistant.content = `⚠ ${e instanceof Error ? e.message : 'mesh chat failed'}`;
+        assistant.error = true;
+      } finally {
+        assistant.streaming = false;
+        busy.value = false;
+      }
+      return;
+    }
 
     try {
       const res = await fetch(`${AM_BASE}/api/chat`, {

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -251,3 +251,62 @@ export const AGENT_COCKPIT: NavGroup[] = [
     ],
   },
 ];
+
+// --- Accordion drawer sections -----------------------------------------------
+// Progressive disclosure: everyday sections open by default, everything else
+// collapsed but PRESENT (nothing removed). `operator: true` sections default to the
+// user's Operator-mode preference (on → expanded/pinned) but stay reachable regardless.
+export interface DrawerSection {
+  id: string;
+  label: string;
+  defaultOpen: boolean;
+  operator?: boolean;
+  items: NavLeaf[];
+}
+
+const _slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
+export const DRAWER_SECTIONS: DrawerSection[] = [
+  {
+    id: 'capabilities',
+    label: 'Capabilities',
+    defaultOpen: true,
+    items: CAPABILITY_RAIL.map((c) => ({ label: c.label, to: c.to })),
+  },
+  {
+    id: 'working',
+    label: 'Working surfaces',
+    defaultOpen: true,
+    items: [...OPERATOR_SHORTCUTS, { label: 'Feed', to: '/feed' }],
+  },
+  {
+    id: 'knowledge',
+    label: 'Knowledge & Data',
+    defaultOpen: false,
+    items: [
+      { label: 'Knowledge Graph', to: '/knowledge/graph' },
+      { label: 'Search', to: '/data/search' },
+      { label: 'Living Ontology', to: '/ontology' },
+      { label: 'Noetica Chat', to: '/noetica' },
+    ],
+  },
+  ...AGENT_COCKPIT.map((g) => ({ id: _slug(g.label), label: g.label, defaultOpen: false, operator: true, items: g.items })),
+];
+
+// Flat, de-duplicated surface index for the ⌘K command palette — every reachable
+// leaf across the domain menus and the drawer sections, tagged with its group.
+export interface SurfaceEntry { label: string; to: string; group: string }
+
+export const ALL_SURFACES: SurfaceEntry[] = (() => {
+  const seen = new Set<string>();
+  const out: SurfaceEntry[] = [];
+  const push = (label: string, to: string, group: string) => {
+    if (seen.has(to)) return;
+    seen.add(to);
+    out.push({ label, to, group });
+  };
+  for (const d of DOMAIN_MENU) for (const leaf of d.items) push(leaf.label, leaf.to, d.label);
+  for (const s of DRAWER_SECTIONS) for (const leaf of s.items) push(leaf.label, leaf.to, s.label);
+  push('Settings', '/settings', 'Account');
+  return out;
+})();

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -65,6 +65,7 @@ export const DOMAIN_MENU: NavGroup[] = [
       { label: 'Labor Economics', to: '/economy/labor-economics' },
       { label: 'Industry & Commerce', to: '/economy/industry-commerce' },
       { label: 'Value Drivers', to: '/economy/value-drivers' },
+      { label: 'Causal Valuation', to: '/economy/causal-valuation' },
       { label: 'Farming & Agriculture', to: '/economy/farming-agriculture' },
       { label: 'Mining & Extraction', to: '/economy/mining-extraction' },
       { label: 'Processing & Refinement', to: '/economy/processing-refinement' },
@@ -85,6 +86,8 @@ export const DOMAIN_MENU: NavGroup[] = [
       { label: 'Crypto / Digital', to: '/markets/crypto-digital' },
       { label: 'Real-Assets', to: '/markets/real-assets' },
       { label: 'Alternative Investments', to: '/markets/alternative-investments' },
+      { label: 'Portfolios & Watch Lists', to: '/capability/portfolios' },
+      { label: 'Algorithmic Trading', to: '/capability/algorithmic-trading' },
     ],
   },
   {
@@ -106,6 +109,20 @@ export const DOMAIN_MENU: NavGroup[] = [
       { label: 'Charts & Graphs', to: '/analytics/charts-graphs' },
       { label: 'Maps & Interactives', to: '/map' },
       { label: 'Custom Analytics', to: '/analytics' },
+    ],
+  },
+  {
+    label: 'Knowledge',
+    to: '/knowledge/graph',
+    items: [
+      { label: 'Knowledge Graph', to: '/knowledge/graph' },
+      { label: 'Search', to: '/data/search' },
+      { label: 'Living Ontology', to: '/ontology' },
+      { label: 'Noetica Chat', to: '/noetica' },
+      { label: 'Research Capture', to: '/research' },
+      { label: 'Reader', to: '/reader' },
+      { label: 'Journal', to: '/journal' },
+      { label: 'Feed', to: '/feed' },
     ],
   },
 ];
@@ -164,59 +181,45 @@ export const CAPABILITY_RAIL: NavGroup[] = [
   { label: 'Experiments & Simulations', to: '/capability/experiments-simulations', items: [] },
 ];
 
-// Real working surfaces that already exist — surfaced as direct rail links
-// below the capability axis so nothing that works is buried.
+// Everyday working surfaces surfaced as direct rail links (always visible). The
+// former dev/SourceOS shortcuts (Code Search, NLBoot Evidence, Operator Workbench)
+// moved into the operator-mode-gated AGENT_COCKPIT · SourceOS group; the reading/
+// capture surfaces now also live in the Knowledge domain menu.
 export const OPERATOR_SHORTCUTS: NavLeaf[] = [
   { label: 'Research Capture', to: '/research' },
-  { label: 'Feed', to: '/feed' },
   { label: 'Reader', to: '/reader' },
   { label: 'Journal', to: '/journal' },
-  { label: 'Code Search', to: '/code' },
-  { label: 'NLBoot Evidence', to: '/nlboot' },
-  { label: 'Operator Workbench', to: '/workbench' },
 ];
 
 // Agent Machine cockpit — live on-device surfaces backed by the Noetica
 // agent-machine /api/* endpoints (sovereign, no auth). These are the ported
 // command-center surfaces: workstation ops, models, knowledge, forge.
+// Operator / SourceOS cockpit — revealed only when the user enables Operator mode
+// in Settings (off by default, so a normal user never meets SourceOS). Regrouped
+// for clarity; Model Labs deduped to /ai/labs; NLBoot Evidence / Operator Workbench
+// / Code Search collected under SourceOS. Noetica Chat and HolographMe moved OUT to
+// user-facing places (Knowledge menu and the user dropdown).
 export const AGENT_COCKPIT: NavGroup[] = [
   {
-    label: 'Operating System',
+    label: 'Infrastructure',
     to: '/agentic-os',
     items: [
       { label: 'Agentic OS', to: '/agentic-os' },
-    ],
-  },
-  {
-    label: 'Marketplace',
-    to: '/marketplace',
-    items: [
-      { label: 'Triparty Netting', to: '/marketplace' },
-      { label: 'Supply-chain Orchestrator', to: '/marketplace/orchestrate' },
-    ],
-  },
-  {
-    label: 'Noetica',
-    to: '/noetica',
-    items: [
-      { label: 'Chat (social surface)', to: '/noetica' },
-    ],
-  },
-  {
-    label: 'Operator & Infra',
-    to: '/control-plane/org',
-    items: [
       { label: 'Control Plane', to: '/control-plane/org' },
       { label: 'Universe Viewer', to: '/universe' },
       { label: 'Situations (n-ary)', to: '/situations' },
-      { label: 'Living Ontology', to: '/ontology' },
-      { label: 'Data Catalog', to: '/operator/data-catalog' },
-      { label: 'Pipelines (Beam / Ray)', to: '/operator/pipelines' },
-      { label: 'Model Labs', to: '/operator/labs' },
+    ],
+  },
+  {
+    label: 'Models & Pipelines',
+    to: '/ai/labs',
+    items: [
+      { label: 'Model Labs', to: '/ai/labs' },
       { label: 'Studio', to: '/operator/studio' },
-      { label: 'RAG Inspect', to: '/operator/rag-inspect' },
-      { label: 'HolographMe', to: '/operator/holograph-me' },
+      { label: 'Pipelines (Beam / Ray)', to: '/operator/pipelines' },
       { label: 'Lattice Forge', to: '/operator/lattice-forge' },
+      { label: 'RAG Inspect', to: '/operator/rag-inspect' },
+      { label: 'Data Catalog', to: '/operator/data-catalog' },
     ],
   },
   {
@@ -227,22 +230,24 @@ export const AGENT_COCKPIT: NavGroup[] = [
       { label: 'Deploy', to: '/workstation/deploy' },
       { label: 'Services · DevSpaces', to: '/workstation/services' },
       { label: 'Terminal', to: '/workstation/terminal' },
-    ],
-  },
-  {
-    label: 'Knowledge & Data',
-    to: '/knowledge/graph',
-    items: [
-      { label: 'Knowledge Graph', to: '/knowledge/graph' },
-      { label: 'Search', to: '/data/search' },
-    ],
-  },
-  {
-    label: 'Models & Forge',
-    to: '/ai/labs',
-    items: [
-      { label: 'Model Labs', to: '/ai/labs' },
       { label: 'Add Local Repo', to: '/forge/import' },
+    ],
+  },
+  {
+    label: 'SourceOS',
+    to: '/nlboot',
+    items: [
+      { label: 'NLBoot Evidence', to: '/nlboot' },
+      { label: 'Operator Workbench', to: '/workbench' },
+      { label: 'Code Search', to: '/code' },
+    ],
+  },
+  {
+    label: 'Marketplace',
+    to: '/marketplace',
+    items: [
+      { label: 'Triparty Netting', to: '/marketplace' },
+      { label: 'Supply-chain Orchestrator', to: '/marketplace/orchestrate' },
     ],
   },
 ];

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -11,7 +11,9 @@ const LS_BASE = 'sp.conn.mesh';
 const LS_TOKEN = 'sp.conn.mesh-token';
 
 export const DEFAULT_MESH_BASE = 'https://mesh.socioprophet.ai';
-export const MESH_MODEL = 'prophet-mesh';
+// Default to the muscular seat (Qwen3-32B on A100). The conductor routes 'xl' → that seat;
+// it falls back to the always-on T4 'default' seat if xl is scaled down.
+export const MESH_MODEL = 'xl';
 
 // The mesh sends no CORS headers, so the browser can't call it cross-origin directly.
 // Fetches go through a SAME-ORIGIN proxy path ('/mesh' → mesh.socioprophet.ai): the Vite
@@ -46,6 +48,47 @@ export async function checkMesh(_base = meshBase()): Promise<MeshStatus> {
 }
 
 export interface MeshChatResult { content: string; model: string; seat?: string }
+
+// Streaming chat through the mesh conductor (OpenAI SSE, stream=true). Calls onDelta for each
+// token chunk so the UI renders as it generates — the Claude/OpenAI feel. Returns the final text.
+export async function meshChatStream(
+  messages: { role: string; content: string }[],
+  onDelta: (t: string) => void,
+): Promise<MeshChatResult> {
+  const token = meshToken();
+  if (!token) throw new Error('no mesh token — set it in Settings → Connections');
+  const res = await fetch(`${MESH_FETCH}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ model: MESH_MODEL, messages, max_tokens: 1024, stream: true }),
+  });
+  if (!res.ok || !res.body) throw new Error(`mesh chat failed: HTTP ${res.status}`);
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '', content = '', model = MESH_MODEL;
+  let seat: string | undefined;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    const lines = buf.split('\n');
+    buf = lines.pop() ?? '';
+    for (const line of lines) {
+      const l = line.trim();
+      if (!l.startsWith('data:')) continue;
+      const p = l.slice(5).trim();
+      if (!p || p === '[DONE]') continue;
+      try {
+        const d = JSON.parse(p);
+        const delta = d?.choices?.[0]?.delta?.content;
+        if (delta) { content += delta; onDelta(delta); }
+        if (d?.model) model = d.model;
+        if (d?.prophet_mesh?.seat) seat = d.prophet_mesh.seat;
+      } catch { /* skip partial frame */ }
+    }
+  }
+  return { content, model, seat };
+}
 
 // Route a chat turn through the mesh conductor (OpenAI /v1/chat/completions). Requires the
 // bearer token from Settings → Connections. Non-streaming for simplicity.

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -1,40 +1,67 @@
-// Prophet Mesh connection.
+// Prophet Mesh connection (ST011) — LIVE on GKE.
 //
-// The hosted Model Choir / Conductor mesh (ST011) at mesh.socioprophet.ai fronts the
-// platform's data + model-routing backend. Setting VITE_MESH_BASE (or the per-browser
-// override saved in Settings → Connections) points the app's API clients at the mesh
-// instead of the local dev proxy, so the same SPA runs against a hosted cloud instance.
+// mesh.socioprophet.ai is the Model Choir / Conductor: an OpenAI-compatible gateway
+// (GET /v1/models, POST /v1/chat/completions) that routes model=prophet-mesh to a
+// vLLM seat. /v1/models is open; chat requires the mesh bearer token (MESH_AUTH_TOKEN,
+// k8s secret prophet-mesh-auth). The operator pastes the token in Settings → Connections;
+// it's stored per-browser and never committed.
 
 const ENV_MESH = (import.meta as any).env?.VITE_MESH_BASE as string | undefined;
-const LS_KEY = 'sp.conn.mesh';
+const LS_BASE = 'sp.conn.mesh';
+const LS_TOKEN = 'sp.conn.mesh-token';
 
 export const DEFAULT_MESH_BASE = 'https://mesh.socioprophet.ai';
+export const MESH_MODEL = 'prophet-mesh';
+
+// The mesh sends no CORS headers, so the browser can't call it cross-origin directly.
+// Fetches go through a SAME-ORIGIN proxy path ('/mesh' → mesh.socioprophet.ai): the Vite
+// dev server proxies it in dev; in prod the serving gateway must proxy /mesh the same way
+// (or the conductor must add CORS). meshBase() below is the logical endpoint shown in the UI.
+const MESH_FETCH = '/mesh';
+
+function ls(key: string): string | null {
+  try { return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null; } catch { return null; }
+}
 
 export function meshBase(): string {
-  let override: string | null = null;
-  try { override = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null; } catch { /* ignore */ }
-  return (override || ENV_MESH || DEFAULT_MESH_BASE).replace(/\/$/, '');
+  return (ls(LS_BASE) || ENV_MESH || DEFAULT_MESH_BASE).replace(/\/$/, '');
 }
+export function setMeshBase(url: string) { try { localStorage.setItem(LS_BASE, url.replace(/\/$/, '')); } catch { /* ignore */ } }
+export function meshToken(): string { return ls(LS_TOKEN) || ''; }
+export function setMeshToken(t: string) { try { localStorage.setItem(LS_TOKEN, t.trim()); } catch { /* ignore */ } }
 
-export function setMeshBase(url: string) {
-  try { localStorage.setItem(LS_KEY, url.replace(/\/$/, '')); } catch { /* ignore */ }
-}
+export interface MeshStatus { ok: boolean; status: number | null; detail: string; models: string[] }
 
-export interface MeshStatus { ok: boolean; status: number | null; detail: string }
-
-// Honest reachability probe. A browser fetch to the mesh will succeed, 404 (host up,
-// route not exposed), or throw (network / CORS). We report exactly what we observe —
-// never a fake "connected".
-export async function checkMesh(base = meshBase()): Promise<MeshStatus> {
-  for (const path of ['/health', '/v1/overview', '/']) {
-    try {
-      const res = await fetch(`${base}${path}`, { method: 'GET', mode: 'cors' });
-      if (res.ok) return { ok: true, status: res.status, detail: `connected (${path})` };
-      // reachable but this route isn't there — keep trying, remember the last status
-      if (path === '/') return { ok: false, status: res.status, detail: `reachable — host up, BFF routes not exposed yet (HTTP ${res.status})` };
-    } catch {
-      if (path === '/') return { ok: false, status: null, detail: 'unreachable from browser (network or CORS)' };
-    }
+// Real reachability probe against the live OpenAI-compatible gateway (via the same-origin proxy).
+export async function checkMesh(_base = meshBase()): Promise<MeshStatus> {
+  try {
+    const res = await fetch(`${MESH_FETCH}/v1/models`, { headers: { accept: 'application/json' } });
+    if (!res.ok) return { ok: false, status: res.status, detail: `reachable — HTTP ${res.status} at /v1/models`, models: [] };
+    const body = await res.json();
+    const models = Array.isArray(body?.data) ? body.data.map((m: any) => m.id) : [];
+    return { ok: true, status: 200, detail: `connected — ${models.length} model(s)`, models };
+  } catch {
+    return { ok: false, status: null, detail: 'unreachable from browser (network or CORS)', models: [] };
   }
-  return { ok: false, status: null, detail: 'unreachable' };
+}
+
+export interface MeshChatResult { content: string; model: string; seat?: string }
+
+// Route a chat turn through the mesh conductor (OpenAI /v1/chat/completions). Requires the
+// bearer token from Settings → Connections. Non-streaming for simplicity.
+export async function meshChat(messages: { role: string; content: string }[]): Promise<MeshChatResult> {
+  const token = meshToken();
+  if (!token) throw new Error('no mesh token — set it in Settings → Connections');
+  const res = await fetch(`${MESH_FETCH}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ model: MESH_MODEL, messages, max_tokens: 512 }),
+  });
+  if (!res.ok) throw new Error(`mesh chat failed: HTTP ${res.status}`);
+  const body = await res.json();
+  return {
+    content: body?.choices?.[0]?.message?.content ?? '',
+    model: body?.model ?? MESH_MODEL,
+    seat: body?.prophet_mesh?.seat,
+  };
 }

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -1,0 +1,40 @@
+// Prophet Mesh connection.
+//
+// The hosted Model Choir / Conductor mesh (ST011) at mesh.socioprophet.ai fronts the
+// platform's data + model-routing backend. Setting VITE_MESH_BASE (or the per-browser
+// override saved in Settings → Connections) points the app's API clients at the mesh
+// instead of the local dev proxy, so the same SPA runs against a hosted cloud instance.
+
+const ENV_MESH = (import.meta as any).env?.VITE_MESH_BASE as string | undefined;
+const LS_KEY = 'sp.conn.mesh';
+
+export const DEFAULT_MESH_BASE = 'https://mesh.socioprophet.ai';
+
+export function meshBase(): string {
+  let override: string | null = null;
+  try { override = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null; } catch { /* ignore */ }
+  return (override || ENV_MESH || DEFAULT_MESH_BASE).replace(/\/$/, '');
+}
+
+export function setMeshBase(url: string) {
+  try { localStorage.setItem(LS_KEY, url.replace(/\/$/, '')); } catch { /* ignore */ }
+}
+
+export interface MeshStatus { ok: boolean; status: number | null; detail: string }
+
+// Honest reachability probe. A browser fetch to the mesh will succeed, 404 (host up,
+// route not exposed), or throw (network / CORS). We report exactly what we observe —
+// never a fake "connected".
+export async function checkMesh(base = meshBase()): Promise<MeshStatus> {
+  for (const path of ['/health', '/v1/overview', '/']) {
+    try {
+      const res = await fetch(`${base}${path}`, { method: 'GET', mode: 'cors' });
+      if (res.ok) return { ok: true, status: res.status, detail: `connected (${path})` };
+      // reachable but this route isn't there — keep trying, remember the last status
+      if (path === '/') return { ok: false, status: res.status, detail: `reachable — host up, BFF routes not exposed yet (HTTP ${res.status})` };
+    } catch {
+      if (path === '/') return { ok: false, status: null, detail: 'unreachable from browser (network or CORS)' };
+    }
+  }
+  return { ok: false, status: null, detail: 'unreachable' };
+}

--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -462,7 +462,7 @@ export const routeRegistry: RouteRegistryEntry[] = [
   },
   {
     path: '/capability/dashboard',
-    label: 'Operator Dashboard',
+    label: 'User Dashboard',
     domain: 'Capabilities',
     maturity: 'L2',
     stateMode: 'fixture',

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -22,6 +22,8 @@ import NewsFeed from './pages/NewsFeed.vue';
 import MarketMonitor from './pages/MarketMonitor.vue';
 import EconomySectorBoard from './pages/EconomySectorBoard.vue';
 import ValueDriverTree from './pages/ValueDriverTree.vue';
+import CausalValuation from './pages/CausalValuation.vue';
+import Settings from './pages/Settings.vue';
 import PeopleDirectory from './pages/PeopleDirectory.vue';
 import SocialSignals from './pages/SocialSignals.vue';
 import LawDocket from './pages/LawDocket.vue';
@@ -123,6 +125,8 @@ const explicitRoutes = [
   { path: '/markets/indices-funds', component: MarketMonitor },
   { path: '/economy/macro-economics', component: EconomySectorBoard },
   { path: '/economy/value-drivers', component: ValueDriverTree },
+  { path: '/economy/causal-valuation', component: CausalValuation },
+  { path: '/settings', component: Settings },
   { path: '/people/search', component: PeopleDirectory },
   { path: '/people/social-networks', component: SocialSignals },
   { path: '/law/international-law', component: LawDocket },

--- a/socioprophet-web/client-vue/src/pages/AlgoTradingBoard.vue
+++ b/socioprophet-web/client-vue/src/pages/AlgoTradingBoard.vue
@@ -14,6 +14,27 @@
       </template>
     </SurfaceHeader>
 
+    <!-- Strategy Copilot — Robinhood-clean input, Claude-grade reasoning -->
+    <div class="at-copilot">
+      <span class="at-copilot-glyph">◇</span>
+      <input
+        v-model="copilotText"
+        class="at-copilot-input"
+        type="text"
+        spellcheck="false"
+        placeholder="Describe a strategy in plain English — e.g. buy semis on breakout with a 3% trailing stop…"
+        @keydown.enter="generateStrategy"
+      />
+      <button class="at-copilot-go" :disabled="!copilotText.trim() || generating" @click="generateStrategy">
+        {{ generating ? 'Generating…' : 'Generate strategy' }}
+      </button>
+    </div>
+    <div class="at-copilot-hints">
+      <span class="at-copilot-try">Try:</span>
+      <button v-for="ex in copilotExamples" :key="ex" class="at-copilot-chip" @click="copilotText = ex; generateStrategy()">{{ ex }}</button>
+      <span class="at-copilot-gov">Paper only · governed · not investment advice</span>
+    </div>
+
     <SplitPane storage-key="algo-trading" label="strategies" :initial="360">
       <template #list>
       <!-- Strategy list -->
@@ -114,12 +135,14 @@ import SurfaceHeader from '../components/SurfaceHeader.vue';
 import SplitPane from '../components/SplitPane.vue';
 import { ref, computed, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-import { strategies, asOf, type Strategy, type StrategyStatus } from '../data/algoTradingFixture';
+import { strategies, asOf, type Strategy, type StrategyStatus, type StrategyClass } from '../data/algoTradingFixture';
 import { sparkPoints, areaPoints } from '../utils/sparkline';
 import { navScopeForPath } from '../config/cockpitNav';
 import { arrowRove } from '../utils/listKeys';
 import { usePortfolio } from '../stores/portfolio';
 import { useCockpit } from '../stores/cockpit';
+import { useSettings } from '../stores/settings';
+import { meshChatStream } from '../config/mesh';
 
 const router = useRouter();
 const route = useRoute();
@@ -133,10 +156,13 @@ const status = ref<(typeof statuses)[number]>('all');
 const selectedId = ref<string>(strategies[0]!.id);
 const listEl = ref<HTMLElement | null>(null);
 
+// Copilot-generated (paper) strategies live above the fixture book.
+const genStrategies = ref<Strategy[]>([]);
+const pool = computed<Strategy[]>(() => [...genStrategies.value, ...strategies]);
 const results = computed<Strategy[]>(() =>
-  status.value === 'all' ? strategies : strategies.filter((s) => s.status === (status.value as StrategyStatus)),
+  status.value === 'all' ? pool.value : pool.value.filter((s) => s.status === (status.value as StrategyStatus)),
 );
-const selected = computed<Strategy | undefined>(() => strategies.find((s) => s.id === selectedId.value));
+const selected = computed<Strategy | undefined>(() => pool.value.find((s) => s.id === selectedId.value));
 watch(results, (r) => { if (!r.some((s) => s.id === selectedId.value) && r[0]) selectedId.value = r[0].id; });
 
 const liveCount = strategies.filter((s) => s.status === 'live').length;
@@ -153,6 +179,74 @@ function signed(n: number): string { return `${n >= 0 ? '+' : ''}${n}`; }
 function openSymbol(sym: string) { if (!/[/]/.test(sym)) router.push({ path: '/markets/indices-funds', query: { sym } }); }
 
 const asOfLabel = new Date(asOf).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+
+// ── Strategy Copilot — describe an algo in plain English; the mesh writes the rationale ──
+const settings = useSettings();
+const copilotText = ref('');
+const generating = ref(false);
+const copilotExamples = [
+  'Buy semis on breakout, 3% trailing stop',
+  'Mean-reversion on oversold megacaps (RSI < 30)',
+  'Market-neutral: long quality, short high-beta',
+];
+function pickClass(t: string): StrategyClass {
+  const s = t.toLowerCase();
+  if (/rsi|revert|revers|oversold|dip|mean/.test(s)) return 'mean-reversion';
+  if (/pairs|neutral|hedge|long.?short/.test(s)) return 'market-neutral';
+  if (/trend|macd|moving average|ma cross/.test(s)) return 'trend';
+  if (/arb|spread|basis/.test(s)) return 'stat-arb';
+  return 'momentum';
+}
+function genCurve(seed: number, n = 40): number[] {
+  const out: number[] = []; let v = 100; let r = seed;
+  const rand = () => { r = (r * 1103515245 + 12345) & 0x7fffffff; return r / 0x7fffffff; };
+  const drift = 0.15 + rand() * 0.5;
+  for (let i = 0; i < n; i++) { v += drift + (rand() - 0.5) * 2.2; out.push(Math.round(v * 100) / 100); }
+  return out;
+}
+function tickersIn(t: string): string { const m = t.toUpperCase().match(/\b[A-Z]{2,5}\b/g); return m ? m.slice(0, 3).join(', ') : 'US equities'; }
+
+async function generateStrategy() {
+  const text = copilotText.value.trim();
+  if (!text || generating.value) return;
+  generating.value = true;
+  const seed = Math.floor(Math.random() * 1e6);
+  const equity = genCurve(seed);
+  const klass = pickClass(text);
+  const s: Strategy = {
+    id: 'gen-' + seed,
+    name: text.length > 42 ? text.slice(0, 42) + '…' : text,
+    klass, status: 'paper', universe: tickersIn(text),
+    returnPct: Math.round((equity[equity.length - 1]! - 100) * 10) / 10,
+    sharpe: Math.round((0.6 + Math.random() * 1.6) * 100) / 100,
+    maxDrawdownPct: -Math.round((3 + Math.random() * 14) * 10) / 10,
+    winRatePct: 48 + Math.floor(Math.random() * 18),
+    trades: 40 + Math.floor(Math.random() * 400),
+    exposurePct: 40 + Math.floor(Math.random() * 60),
+    equity,
+    signals: [{ label: 'generated', tone: 'neutral' }, { label: klass, tone: 'up' }],
+    fills: [],
+    note: 'Generating rationale…',
+  };
+  genStrategies.value = [s, ...genStrategies.value];
+  selectedId.value = s.id;
+  copilotText.value = '';
+  try {
+    if (settings.meshChat) {
+      s.note = '';
+      await meshChatStream(
+        [{ role: 'user', content: `You are a quant strategy copilot. In 2-3 sentences, explain this trading strategy and its main risk. Paper-trading only, NOT investment advice.\n\nStrategy: "${text}"` }],
+        (d) => { s.note += d; },
+      );
+    } else {
+      s.note = `Paper strategy synthesized from your description (${klass}, ${s.universe}). Turn on Prophet Cloud Mesh in Settings → Connections for a live AI rationale. Advisory only — not investment advice.`;
+    }
+  } catch (e) {
+    s.note = `Paper strategy (${klass}). AI rationale unavailable: ${e instanceof Error ? e.message : 'mesh error'}. Not investment advice.`;
+  } finally {
+    generating.value = false;
+  }
+}
 
 // ── Integration: route a strategy's fills into the SHARED portfolio book ──
 function deployToBook() {
@@ -235,4 +329,15 @@ watch(selected, (s) => {
 .at-fill-head { color: var(--text-3); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; cursor: default; }
 .at-sym { font-family: ui-monospace, monospace; font-weight: 600; }
 .at-side.buy { color: var(--up); background: rgba(75, 191, 115, 0.14); justify-self: start; } .at-side.sell { color: var(--down); background: rgba(240, 101, 106, 0.14); justify-self: start; }
+.at-copilot { display: flex; align-items: center; gap: 0.6rem; margin: 0.5rem 0 0.4rem; padding: 0.6rem 0.9rem; background: var(--surface); border: 1px solid var(--line-2); border-radius: 12px; }
+.at-copilot-glyph { color: var(--accent); font-size: 1.05rem; }
+.at-copilot-input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font-size: 0.95rem; }
+.at-copilot-input::placeholder { color: var(--text-3); }
+.at-copilot-go { border: none; background: var(--accent); color: #17130a; border-radius: 8px; padding: 0.45rem 0.9rem; font-size: 0.82rem; font-weight: 700; cursor: pointer; white-space: nowrap; }
+.at-copilot-go:disabled { opacity: 0.5; cursor: default; }
+.at-copilot-hints { display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.6rem; }
+.at-copilot-try { font-size: 0.74rem; color: var(--text-3); }
+.at-copilot-chip { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 999px; padding: 0.2rem 0.6rem; font-size: 0.74rem; cursor: pointer; }
+.at-copilot-chip:hover { color: var(--accent); border-color: var(--accent); }
+.at-copilot-gov { margin-left: auto; font-size: 0.72rem; color: var(--text-3); }
 </style>

--- a/socioprophet-web/client-vue/src/pages/CausalValuation.vue
+++ b/socioprophet-web/client-vue/src/pages/CausalValuation.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue';
 import {
   fetchCausalValuation, recomputeCausalValuation, fetchLocations,
+  fetchStudioValuation, recomputeStudioValuation, fetchStudioTemplates, type StudioParams,
   type CausalValuation, type LocationsPayload, type LoadMode,
 } from '../api/causalValuationApi';
 
@@ -17,6 +18,40 @@ const horizon = ref(5);
 const discountPct = ref(9);
 const q = ref('');
 const selected = ref<string | null>(null);
+
+// ── Value Driver Studio — value any listed company (ticker) or a private company ──
+const studioCtx = ref<StudioParams | null>(null); // null = GYG default; set = Studio subject
+const studioTemplates = ref<Array<{ id: string; industry: string }>>([]);
+const studioTicker = ref('');
+const studioTemplate = ref('software');
+const studioPrivate = ref(false);
+const studioName = ref('');
+const studioEv = ref<number | null>(null);
+
+function applyLoaded(v: CausalValuation) {
+  cv.value = v;
+  overrides.value = Object.fromEntries(v.assumptions_editable.map((a) => [a.kpi, a.delta_pct]));
+  horizon.value = v.timeseries.horizon_years;
+  discountPct.value = Math.round(v.timeseries.discount_rate * 100);
+  dirty.value = false;
+}
+
+async function runStudio() {
+  loading.value = true; error.value = '';
+  try {
+    const p: StudioParams = studioPrivate.value
+      ? { template: studioTemplate.value, name: studioName.value || 'Private company', ev_baseline: studioEv.value || undefined }
+      : { ticker: studioTicker.value.trim(), template: studioTemplate.value };
+    studioCtx.value = p;
+    applyLoaded(await fetchStudioValuation(p));
+  } catch (e) { error.value = e instanceof Error ? e.message : String(e); }
+  finally { loading.value = false; }
+}
+
+async function backToGyg() {
+  studioCtx.value = null;
+  await loadAll();
+}
 
 async function loadAll() {
   loading.value = true; error.value = '';
@@ -34,8 +69,15 @@ async function loadAll() {
 async function recompute() {
   loading.value = true; error.value = '';
   try {
-    cv.value = await recomputeCausalValuation(
-      { kpi_overrides: overrides.value, horizon_years: horizon.value, discount_rate: discountPct.value / 100 }, 'gyg');
+    if (studioCtx.value) {
+      cv.value = await recomputeStudioValuation({
+        ...studioCtx.value, kpi_overrides: overrides.value,
+        horizon_years: horizon.value, discount_rate: discountPct.value / 100,
+      });
+    } else {
+      cv.value = await recomputeCausalValuation(
+        { kpi_overrides: overrides.value, horizon_years: horizon.value, discount_rate: discountPct.value / 100 }, 'gyg');
+    }
     dirty.value = false;
   } catch (e) { error.value = e instanceof Error ? e.message : String(e); }
   finally { loading.value = false; }
@@ -46,7 +88,7 @@ async function searchLocations() {
   loc.value = l.data;
 }
 
-onMounted(loadAll);
+onMounted(async () => { await loadAll(); studioTemplates.value = await fetchStudioTemplates(); });
 
 function money(n: number, c = 'AUD') {
   const a = Math.abs(n);
@@ -99,6 +141,31 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
     </header>
 
     <p v-if="mode === 'unavailable'" class="cv-warn">dashboard-bff unavailable ({{ error }}). Start it on the client-vue data port to load the live causal valuation.</p>
+
+    <!-- Value Driver Studio — value ANY company -->
+    <section class="cv-studio">
+      <div class="cv-studio-row">
+        <span class="cv-studio-eyebrow">Value Driver Studio</span>
+        <label class="cv-studio-toggle"><input type="checkbox" v-model="studioPrivate" /> private company</label>
+        <button v-if="studioCtx" class="cv-btn" @click="backToGyg">← GYG demo</button>
+      </div>
+      <div class="cv-studio-row">
+        <template v-if="!studioPrivate">
+          <input v-model="studioTicker" class="cv-studio-in" placeholder="Any exchange:ticker — e.g. GYG.AX, AAPL, TSLA" @keyup.enter="runStudio" />
+        </template>
+        <template v-else>
+          <input v-model="studioName" class="cv-studio-in" placeholder="Private company name" />
+          <input v-model.number="studioEv" class="cv-studio-in cv-studio-ev" type="number" placeholder="Enterprise value (e.g. 250000000)" />
+        </template>
+        <select v-model="studioTemplate" class="cv-studio-sel" aria-label="Value-driver surface">
+          <option v-for="t in studioTemplates" :key="t.id" :value="t.id">{{ t.industry }}</option>
+        </select>
+        <button class="cv-btn primary" :disabled="loading || (!studioPrivate && !studioTicker.trim())" @click="runStudio">
+          {{ loading ? 'Valuing…' : 'Value company' }}
+        </button>
+      </div>
+      <p class="cv-studio-hint">Listed companies auto-pull free public financials for the EV baseline; private companies use your entered EV. Both run the same canonical engine. Advisory only — not investment advice.</p>
+    </section>
 
     <template v-if="cv">
       <div class="cv-metrics">
@@ -221,6 +288,14 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
 .cv-pill.live { background: #ecfdf5; color: #065f46; border-color: #a7f3d0; }
 .cv-pill.unavailable { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
 .cv-warn { border: 1px solid #fecaca; background: #fef2f2; color: #991b1b; border-radius: 10px; padding: .75rem; }
+.cv-studio { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .75rem .85rem; margin-bottom: 1rem; }
+.cv-studio-row { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .5rem; }
+.cv-studio-eyebrow { font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 700; opacity: .6; }
+.cv-studio-toggle { font-size: .8rem; display: inline-flex; gap: .3rem; align-items: center; margin-left: auto; }
+.cv-studio-in { flex: 1; min-width: 180px; padding: .45rem .7rem; border: 1px solid #cbd5e1; border-radius: 8px; }
+.cv-studio-ev { flex: 0 0 210px; }
+.cv-studio-sel { padding: .45rem .6rem; border: 1px solid #cbd5e1; border-radius: 8px; }
+.cv-studio-hint { font-size: .76rem; opacity: .6; margin: 0; }
 .cv-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: .75rem; margin: 1rem 0; }
 .cv-metric { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; display: flex; flex-direction: column; }
 .cv-m-label { font-size: .72rem; opacity: .6; text-transform: uppercase; letter-spacing: .04em; }

--- a/socioprophet-web/client-vue/src/pages/CausalValuation.vue
+++ b/socioprophet-web/client-vue/src/pages/CausalValuation.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import {
+  fetchCausalValuation, recomputeCausalValuation, fetchLocations,
+  type CausalValuation, type LocationsPayload, type LoadMode,
+} from '../api/causalValuationApi';
+
+const cv = ref<CausalValuation | null>(null);
+const loc = ref<LocationsPayload | null>(null);
+const mode = ref<LoadMode>('live');
+const loading = ref(false);
+const error = ref('');
+const dirty = ref(false);
+
+const overrides = ref<Record<string, number>>({});
+const horizon = ref(5);
+const discountPct = ref(9);
+const q = ref('');
+const selected = ref<string | null>(null);
+
+async function loadAll() {
+  loading.value = true; error.value = '';
+  const [c, l] = await Promise.all([fetchCausalValuation('gyg'), fetchLocations('gyg', q.value)]);
+  cv.value = c.data; loc.value = l.data; mode.value = c.mode;
+  if (c.error) error.value = c.error;
+  if (cv.value) {
+    overrides.value = Object.fromEntries(cv.value.assumptions_editable.map((a) => [a.kpi, a.delta_pct]));
+    horizon.value = cv.value.timeseries.horizon_years;
+    discountPct.value = Math.round(cv.value.timeseries.discount_rate * 100);
+  }
+  dirty.value = false; loading.value = false;
+}
+
+async function recompute() {
+  loading.value = true; error.value = '';
+  try {
+    cv.value = await recomputeCausalValuation(
+      { kpi_overrides: overrides.value, horizon_years: horizon.value, discount_rate: discountPct.value / 100 }, 'gyg');
+    dirty.value = false;
+  } catch (e) { error.value = e instanceof Error ? e.message : String(e); }
+  finally { loading.value = false; }
+}
+
+async function searchLocations() {
+  const l = await fetchLocations('gyg', q.value);
+  loc.value = l.data;
+}
+
+onMounted(loadAll);
+
+function money(n: number, c = 'AUD') {
+  const a = Math.abs(n);
+  if (a >= 1e9) return `${c} ${(n / 1e9).toFixed(2)}B`;
+  if (a >= 1e6) return `${c} ${(n / 1e6).toFixed(1)}M`;
+  return `${c} ${Math.round(n).toLocaleString()}`;
+}
+const bounds = (p: string) => (p === 'lower_better' ? { min: -20, max: 0 } : { min: 0, max: 40 });
+
+const nodeById = computed(() => new Map((cv.value?.causal_graph.nodes ?? []).map((n) => [n.id, n])));
+const supplyNodes = computed(() => (cv.value?.causal_graph.nodes ?? []).filter((n) => n.labels.includes('SupplyChainNode')));
+const causalEdges = computed(() => (cv.value?.causal_graph.edges ?? []).filter((e) => ['CAUSES', 'CONSTRAINS', 'REDUCES'].includes(e.label)));
+const kpis = computed(() => [...(cv.value?.vdt.per_kpi_contribution ?? [])].sort((a, b) => b.value_contribution - a.value_contribution));
+const drivers = computed(() => Object.entries(cv.value?.vdt.per_driver_uplift ?? {}).sort((a, b) => b[1] - a[1]));
+const maxContribution = computed(() => Math.max(1, ...kpis.value.map((k) => k.value_contribution)));
+function drivenBy(id: string) {
+  return causalEdges.value.filter((e) => e.from === id).map((e) => ({ kpi: nodeById.value.get(e.to)?.properties?.name ?? e.to, mechanism: e.properties?.mechanism ?? '', relation: e.label }));
+}
+
+const periods = computed(() => cv.value?.timeseries.periods ?? []);
+const maxProjected = computed(() => Math.max(1, ...periods.value.map((p) => p.projected_enterprise_value)));
+const minBaseline = computed(() => cv.value?.valuation.ev_baseline ?? 0);
+
+const LNG0 = 112.5, LNG1 = 154, LAT_TOP = -10, LAT_BOT = -44, W = 440, H = 360;
+const px = (lng: number) => ((lng - LNG0) / (LNG1 - LNG0)) * W;
+const py = (lat: number) => ((LAT_TOP - lat) / (LAT_TOP - LAT_BOT)) * H;
+const AU_OUTLINE: number[][] = [
+  [142.5,-10.7],[145.5,-16],[149,-21],[153,-25],[153.5,-28.2],[151,-33.9],[150,-37.5],[146,-38.9],[141,-38.4],
+  [139,-35.5],[135,-34.8],[132,-32],[129,-31.7],[126,-32.3],[123,-33.9],[118,-35],[115,-34.5],[114,-28],[113.5,-24],
+  [114,-22],[116,-20.5],[121,-19.5],[123,-16.5],[126,-14],[129,-15],[130.5,-12],[132,-11.5],[135,-12],[137,-16],
+  [140,-17.5],[141,-16],[141.5,-13],[142.5,-10.7],
+];
+const outlinePoints = computed(() => AU_OUTLINE.map(([lng, lat]) => `${px(lng).toFixed(1)},${py(lat).toFixed(1)}`).join(' '));
+const FORMAT_COLOR: Record<string, string> = { drive_thru: '#10b981', strip: '#3b82f6', shopping_centre: '#f59e0b' };
+const dotColor = (f: string) => FORMAT_COLOR[f] ?? '#64748b';
+const dotR = (ff: number) => 3 + Math.sqrt(ff) / 22;
+const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === selected.value) ?? null);
+</script>
+
+<template>
+  <section class="cv" aria-label="Causal Valuation">
+    <header class="cv-top">
+      <div>
+        <p class="cv-eyebrow">Economy &amp; Industry · portfolio-manager persona</p>
+        <h1 class="cv-title">{{ cv?.subject ?? 'Guzman y Gomez (ASX:GYG)' }} — causal valuation
+          <span class="cv-pill" :class="mode">{{ mode }}</span>
+        </h1>
+        <p class="cv-sub">Supply-chain causal graph → economic-prophet value-driver tree → enterprise value. Advisory measurement of a public-sourced scenario — <strong>not investment advice</strong>.</p>
+      </div>
+    </header>
+
+    <p v-if="mode === 'unavailable'" class="cv-warn">dashboard-bff unavailable ({{ error }}). Start it on the client-vue data port to load the live causal valuation.</p>
+
+    <template v-if="cv">
+      <div class="cv-metrics">
+        <div class="cv-metric"><span class="cv-m-label">Enterprise value (baseline)</span><span class="cv-m-val">{{ money(cv.valuation.ev_baseline) }}</span></div>
+        <div class="cv-metric up"><span class="cv-m-label">Projected EV</span><span class="cv-m-val">{{ money(cv.valuation.projected_ev) }}</span></div>
+        <div class="cv-metric up"><span class="cv-m-label">Scenario uplift</span><span class="cv-m-val">+{{ money(cv.valuation.value_uplift) }}</span><span class="cv-m-sub">+{{ (cv.valuation.uplift_fraction * 100).toFixed(2) }}%</span></div>
+      </div>
+
+      <div class="cv-panel">
+        <div class="cv-panel-h">
+          <span>Scenario assumptions <span v-if="cv.recomputed" class="cv-tag">recomputed via engine</span></span>
+          <button class="cv-btn" :class="{ primary: dirty }" :disabled="!dirty || loading" @click="recompute">{{ loading ? 'Recomputing…' : 'Recompute valuation' }}</button>
+        </div>
+        <p class="cv-hint">Move a lever — the value math runs in the economic-prophet engine, not the browser.</p>
+        <div class="cv-controls">
+          <div class="cv-ctrl">
+            <div class="cv-ctrl-h"><strong>Time horizon</strong><span>{{ horizon }} years</span></div>
+            <input type="range" min="1" max="10" step="1" :value="horizon" @input="horizon = Number(($event.target as HTMLInputElement).value); dirty = true" />
+          </div>
+          <div class="cv-ctrl">
+            <div class="cv-ctrl-h"><strong>Discount rate</strong><span>{{ discountPct }}%</span></div>
+            <input type="range" min="0" max="20" step="0.5" :value="discountPct" @input="discountPct = Number(($event.target as HTMLInputElement).value); dirty = true" />
+          </div>
+        </div>
+        <div class="cv-controls">
+          <div class="cv-ctrl" v-for="a in cv.assumptions_editable" :key="a.kpi">
+            <div class="cv-ctrl-h"><span>{{ a.driver }} · {{ a.kpi }}</span><span>{{ overrides[a.kpi] > 0 ? '+' : '' }}{{ overrides[a.kpi] }}%</span></div>
+            <input type="range" :min="bounds(a.polarity).min" :max="bounds(a.polarity).max" step="0.5" :value="overrides[a.kpi]" @input="overrides[a.kpi] = Number(($event.target as HTMLInputElement).value); dirty = true" />
+          </div>
+        </div>
+      </div>
+
+      <div class="cv-grid3">
+        <div class="cv-card">
+          <h3>1 · Supply chain → levers</h3>
+          <div class="cv-sc" v-for="n in supplyNodes" :key="n.id">
+            <div class="cv-sc-name">{{ n.properties.name }}</div>
+            <ul><li v-for="(d, i) in drivenBy(n.id)" :key="i"><code>{{ d.relation }}</code> <strong>{{ d.kpi }}</strong> — {{ d.mechanism }}</li></ul>
+          </div>
+        </div>
+        <div class="cv-card">
+          <h3>2 · KPI contribution</h3>
+          <div class="cv-kpi" v-for="k in kpis" :key="k.kpi">
+            <div class="cv-kpi-h"><span>{{ k.driver }} · {{ k.kpi }}</span><span class="up">+{{ money(k.value_contribution) }}</span></div>
+            <div class="cv-bar"><div :style="{ width: (k.value_contribution / maxContribution * 100) + '%' }"></div></div>
+          </div>
+        </div>
+        <div class="cv-card">
+          <h3>3 · Driver → EV</h3>
+          <div class="cv-drv" v-for="[name, up] in drivers" :key="name"><span>{{ name }}</span><span class="up">+{{ money(up) }}</span></div>
+          <div class="cv-drv total"><span>Enterprise value</span><span>{{ money(cv.valuation.projected_ev) }}</span></div>
+        </div>
+      </div>
+
+      <div class="cv-panel">
+        <div class="cv-panel-h"><span>Projected enterprise value over {{ cv.timeseries.horizon_years }} years</span>
+          <span class="cv-hint">terminal <strong>{{ money(cv.timeseries.terminal_projected_enterprise_value) }}</strong> · PV @ {{ (cv.timeseries.discount_rate*100).toFixed(1) }}% <strong>{{ money(cv.timeseries.present_value_of_uplift) }}</strong></span>
+        </div>
+        <div class="cv-traj">
+          <div class="cv-traj-col" v-for="p in periods" :key="p.year">
+            <div class="cv-traj-v">{{ money(p.projected_enterprise_value) }}</div>
+            <div class="cv-traj-bar" :style="{ height: ((p.projected_enterprise_value - minBaseline*0.98) / (maxProjected - minBaseline*0.98) * 100) + '%' }"></div>
+            <div class="cv-traj-y">y{{ p.year }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cv-panel" v-if="loc">
+        <div class="cv-panel-h"><span>Location intelligence — org digital twin ({{ loc.sample_size }} of {{ loc.network_totals.total_au_restaurants }})</span>
+          <span class="cv-legend"><i style="background:#10b981"></i>drive-thru <i style="background:#3b82f6"></i>strip <i style="background:#f59e0b"></i>centre</span>
+        </div>
+        <div class="cv-search">
+          <input v-model="q" @keyup.enter="searchLocations" placeholder="Search suburb, state, or format (e.g. coast, VIC, drive_thru)" />
+          <button class="cv-btn" @click="searchLocations">Search</button>
+        </div>
+        <div class="cv-grid2">
+          <div class="cv-card">
+            <svg :viewBox="`0 0 ${W} ${H}`" class="cv-map">
+              <polygon :points="outlinePoints" fill="#eef2f7" stroke="#cbd5e1" stroke-width="1" />
+              <circle v-for="l in loc.locations" :key="l.id" :cx="px(l.lng)" :cy="py(l.lat)" :r="dotR(l.modeled_weekly_footfall)"
+                :fill="dotColor(l.format)" :fill-opacity="selected===l.id ? 1 : 0.72" :stroke="selected===l.id ? '#0f172a' : 'white'" :stroke-width="selected===l.id ? 2 : 1"
+                style="cursor:pointer" @click="selected = l.id" />
+            </svg>
+            <p class="cv-hint">Dot size ∝ modeled weekly footfall · click a dot for detail · coordinates approximate.</p>
+          </div>
+          <div class="cv-card">
+            <div class="cv-twin">
+              <div><span class="cv-m-label">Modeled annual sales</span><span class="cv-m-val">{{ money(loc.org_twin.sample_modeled_annual_sales_aud) }}</span></div>
+              <div><span class="cv-m-label">Modeled weekly footfall</span><span class="cv-m-val">{{ loc.org_twin.sample_modeled_weekly_footfall.toLocaleString() }}</span></div>
+            </div>
+            <div class="cv-states"><span v-for="(n, s) in loc.org_twin.by_state" :key="s">{{ s }} · {{ n }}</span></div>
+            <p class="cv-hint">{{ loc.org_twin.network_extrapolation_note }}</p>
+            <div v-if="selectedLoc" class="cv-locsel">
+              <strong>{{ selectedLoc.suburb }}</strong> · {{ selectedLoc.state }} · {{ selectedLoc.format.replace('_',' ') }} · {{ selectedLoc.ownership }}
+              <div class="cv-twin">
+                <div><span class="cv-m-label">Modeled annual sales</span><span class="cv-m-val">{{ money(selectedLoc.est_annual_sales_aud) }}</span></div>
+                <div><span class="cv-m-label">Weekly footfall</span><span class="cv-m-val">{{ selectedLoc.modeled_weekly_footfall.toLocaleString() }}</span></div>
+              </div>
+              <p class="cv-hint">{{ selectedLoc.catchment_profile }} — basis: {{ selectedLoc.basis }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="cv-panel governance">
+        <div class="cv-panel-h"><span>Provenance &amp; measurement boundary</span></div>
+        <p class="cv-hint">Data: <code>{{ cv.vdt.epistemic_status.level }}</code> · confidence {{ cv.vdt.epistemic_status.confidence }} · engine <code>{{ cv.provenance.engine }}</code>. Advisory measurement of a scenario — not a recommendation, target price, or valuation opinion.</p>
+        <ul class="cv-lims"><li v-for="lim in cv.vdt.limitations" :key="lim">{{ lim }}</li></ul>
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.cv { padding: 1rem 1.25rem; max-width: 1100px; font-family: ui-sans-serif, system-ui; }
+.cv-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; opacity: .6; margin: 0; }
+.cv-title { font-size: 1.4rem; font-weight: 700; margin: .25rem 0; display: flex; align-items: center; gap: .5rem; }
+.cv-sub { margin: 0; opacity: .78; max-width: 820px; }
+.cv-pill { font-size: .7rem; padding: .1rem .5rem; border-radius: 999px; border: 1px solid #cbd5e1; text-transform: uppercase; }
+.cv-pill.live { background: #ecfdf5; color: #065f46; border-color: #a7f3d0; }
+.cv-pill.unavailable { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
+.cv-warn { border: 1px solid #fecaca; background: #fef2f2; color: #991b1b; border-radius: 10px; padding: .75rem; }
+.cv-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: .75rem; margin: 1rem 0; }
+.cv-metric { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; display: flex; flex-direction: column; }
+.cv-m-label { font-size: .72rem; opacity: .6; text-transform: uppercase; letter-spacing: .04em; }
+.cv-m-val { font-size: 1.35rem; font-weight: 700; }
+.cv-metric.up .cv-m-val, .up { color: #065f46; }
+.cv-m-sub { font-size: .85rem; opacity: .7; }
+.cv-panel { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; margin-bottom: 1rem; }
+.cv-panel-h { display: flex; justify-content: space-between; align-items: center; gap: .5rem; flex-wrap: wrap; font-weight: 600; }
+.cv-tag { font-size: .7rem; font-weight: 600; color: #065f46; background: #ecfdf5; border: 1px solid #a7f3d0; border-radius: 999px; padding: .1rem .5rem; }
+.cv-hint { font-size: .8rem; opacity: .6; margin: .35rem 0; font-weight: 400; }
+.cv-controls { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: .5rem 1.25rem; margin-top: .5rem; }
+.cv-ctrl-h { display: flex; justify-content: space-between; font-size: .82rem; }
+.cv-ctrl input { width: 100%; }
+.cv-btn { padding: .4rem .8rem; border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; cursor: pointer; }
+.cv-btn.primary { background: #10b981; border-color: #10b981; color: #fff; }
+.cv-btn:disabled { opacity: .5; cursor: default; }
+.cv-grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1rem; }
+.cv-grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+.cv-card { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; }
+.cv-card h3 { margin: 0 0 .5rem; font-size: 1rem; }
+.cv-sc { border: 1px solid #eef2f7; border-radius: 10px; padding: .5rem; margin: .45rem 0; }
+.cv-sc-name { font-weight: 650; }
+.cv-sc ul { margin: .35rem 0 0; padding-left: 1rem; font-size: .82rem; }
+.cv-sc code, .cv-sc-name code { font-size: .72rem; background: #f1f5f9; padding: .05rem .3rem; border-radius: 4px; }
+.cv-kpi { margin: .5rem 0; }
+.cv-kpi-h { display: flex; justify-content: space-between; font-size: .85rem; }
+.cv-bar { height: 8px; background: #eef2f7; border-radius: 6px; margin-top: .25rem; overflow: hidden; }
+.cv-bar div { height: 100%; background: #10b981; }
+.cv-drv { display: flex; justify-content: space-between; padding: .5rem; border: 1px solid #eef2f7; border-radius: 10px; margin: .35rem 0; }
+.cv-drv.total { background: #ecfdf5; border-color: #a7f3d0; font-weight: 750; }
+.cv-traj { display: flex; align-items: flex-end; gap: .5rem; height: 130px; margin-top: 1rem; }
+.cv-traj-col { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: flex-end; height: 100%; }
+.cv-traj-v { font-size: .7rem; font-weight: 600; color: #065f46; }
+.cv-traj-bar { width: 100%; max-width: 46px; background: #10b981; border-radius: 6px 6px 0 0; min-height: 4px; margin-top: .2rem; }
+.cv-traj-y { font-size: .74rem; opacity: .6; margin-top: .25rem; }
+.cv-search { display: flex; gap: .5rem; margin: .5rem 0; }
+.cv-search input { flex: 1; padding: .45rem .7rem; border: 1px solid #cbd5e1; border-radius: 8px; }
+.cv-legend { font-size: .72rem; display: flex; gap: .6rem; align-items: center; font-weight: 400; }
+.cv-legend i { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 2px; }
+.cv-map { width: 100%; height: auto; }
+.cv-twin { display: grid; grid-template-columns: 1fr 1fr; gap: .6rem; }
+.cv-states { display: flex; flex-wrap: wrap; gap: .35rem; margin: .6rem 0; }
+.cv-states span { font-size: .78rem; padding: .15rem .5rem; border: 1px solid #e2e8f0; border-radius: 999px; }
+.cv-locsel { border-top: 1px solid #eef2f7; margin-top: .6rem; padding-top: .6rem; }
+.cv-lims { margin: .25rem 0 0; padding-left: 1rem; font-size: .82rem; opacity: .8; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -61,9 +61,16 @@
                 </div>
               </details>
 
-              <!-- Main content -->
+              <!-- Main content (reasoning split into a collapsible block) -->
               <div class="nx-a-body" :class="{ err: t.error }">
-                <template v-if="t.content">{{ t.content }}<span v-if="t.streaming" class="nx-cursor">▍</span></template>
+                <template v-if="t.content">
+                  <details v-if="splitThink(t.content).reasoning" class="nx-think" :open="splitThink(t.content).thinking">
+                    <summary>{{ splitThink(t.content).thinking ? 'Thinking…' : 'Reasoning' }}</summary>
+                    <div class="nx-think-body">{{ splitThink(t.content).reasoning }}</div>
+                  </details>
+                  <template v-if="splitThink(t.content).answer">{{ splitThink(t.content).answer }}<span v-if="t.streaming" class="nx-cursor">▍</span></template>
+                  <span v-else-if="t.streaming && !splitThink(t.content).reasoning" class="nx-cursor">▍</span>
+                </template>
                 <span v-else-if="t.streaming" class="nx-thinking">
                   <span class="nx-dot" /><span class="nx-dot" /><span class="nx-dot" /> thinking…
                 </span>
@@ -138,6 +145,16 @@ const suggestions = [
 
 function autoGrow() { const el = inputEl.value; if (!el) return; el.style.height = 'auto'; el.style.height = `${Math.min(200, el.scrollHeight)}px`; }
 watch(draft, () => nextTick(autoGrow));
+
+// Qwen3 (and other reasoning models) emit a <think>…</think> block before the answer.
+// Split it out so the UI shows a collapsible "reasoning" section, not raw tags.
+function splitThink(content: string): { reasoning: string; answer: string; thinking: boolean } {
+  const open = content.indexOf('<think>');
+  if (open === -1) return { reasoning: '', answer: content, thinking: false };
+  const close = content.indexOf('</think>');
+  if (close === -1) return { reasoning: content.slice(open + 7), answer: '', thinking: true };
+  return { reasoning: content.slice(open + 7, close).trim(), answer: content.slice(close + 8).trim(), thinking: false };
+}
 
 function scrollToEnd() { const el = scrollEl.value; if (el) el.scrollTop = el.scrollHeight; }
 watch(() => chat.turns.value.map((t) => t.content).join('|'), async () => { await nextTick(); scrollToEnd(); });
@@ -250,6 +267,12 @@ onMounted(() => inputEl.value?.focus());
 .nx-a-body.err { color: #fca5a5; }
 .nx-cursor { color: var(--nblue); }
 .nx-thinking { display: inline-flex; align-items: center; gap: 5px; color: var(--ntext3); font-size: 13px; }
+.nx-think { margin: 0 0 8px; border-left: 2px solid var(--nline-weak); padding-left: 10px; }
+.nx-think > summary { cursor: pointer; color: var(--ntext3); font-size: 12px; list-style: none; user-select: none; }
+.nx-think > summary::-webkit-details-marker { display: none; }
+.nx-think > summary::before { content: '▸ '; }
+.nx-think[open] > summary::before { content: '▾ '; }
+.nx-think-body { color: var(--ntext3); font-size: 13px; line-height: 1.6; white-space: pre-wrap; margin-top: 4px; opacity: 0.85; }
 .nx-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--ntext3); animation: nx-pulse 1.2s infinite ease-in-out; }
 .nx-dot:nth-child(2) { animation-delay: 0.15s; }
 .nx-dot:nth-child(3) { animation-delay: 0.3s; }

--- a/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
+++ b/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
@@ -12,7 +12,7 @@
     <div class="db-ask-wrap">
       <form class="db-ask" @submit.prevent="ask">
         <span class="db-ask-glyph">◇</span>
-        <input v-model="prompt" type="text" placeholder="Ask Noetica or jump to any surface…  (type to search · ⏎ to ask)" spellcheck="false" aria-label="Ask or jump" @focus="askFocused = true" @blur="onAskBlur" />
+        <input v-model="prompt" type="text" placeholder="Ask Noetica or jump to any surface…  (type to search · ⏎ to ask)" spellcheck="false" aria-label="Ask Noetica or jump to any surface" @focus="askFocused = true" @blur="onAskBlur" />
         <button type="submit" class="db-ask-go" :disabled="!prompt.trim()">Ask</button>
       </form>
       <div v-if="askFocused && prompt.trim()" class="db-ask-menu">

--- a/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
+++ b/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
@@ -8,16 +8,25 @@
       <span class="db-asof">as of {{ asOfLabel }}</span>
     </header>
 
-    <!-- Ask Noetica — the social/assistant surface, one line from home -->
-    <form class="db-ask" @submit.prevent="ask">
-      <span class="db-ask-glyph">◇</span>
-      <input v-model="prompt" type="text" placeholder="Ask Noetica anything…  (⏎ to open the chat)" spellcheck="false" aria-label="Ask Noetica" />
-      <button type="submit" class="db-ask-go" :disabled="!prompt.trim()">Ask</button>
-    </form>
+    <!-- Universal bar: jump to any surface OR ask Noetica — anything in one action -->
+    <div class="db-ask-wrap">
+      <form class="db-ask" @submit.prevent="ask">
+        <span class="db-ask-glyph">◇</span>
+        <input v-model="prompt" type="text" placeholder="Ask Noetica or jump to any surface…  (type to search · ⏎ to ask)" spellcheck="false" aria-label="Ask or jump" @focus="askFocused = true" @blur="onAskBlur" />
+        <button type="submit" class="db-ask-go" :disabled="!prompt.trim()">Ask</button>
+      </form>
+      <div v-if="askFocused && prompt.trim()" class="db-ask-menu">
+        <button v-for="m in askMatches" :key="m.to" class="db-ask-item" @mousedown.prevent="jump(m.to)">
+          <span class="db-ask-lbl">→ {{ m.label }}</span><span class="db-ask-grp">{{ m.group }}</span>
+        </button>
+        <button class="db-ask-item ask" @mousedown.prevent="ask"><span class="db-ask-lbl">◇ Ask Noetica: “{{ prompt.trim() }}”</span></button>
+      </div>
+    </div>
 
     <div class="db-grid">
       <!-- Markets -->
-      <article class="db-card">
+      <article v-if="db.visible('markets')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('markets')">✕</button>
         <RouterLink class="db-card-head" to="/markets/indices-funds"><span>Markets</span><span class="db-open">open →</span></RouterLink>
         <button v-for="i in indices" :key="i.symbol" class="db-row" @click="go('/markets/indices-funds', { sym: i.symbol })">
           <span class="db-row-k">{{ i.symbol }}</span>
@@ -36,8 +45,25 @@
         </form>
       </article>
 
+      <!-- Companies & Valuations -->
+      <article v-if="db.visible('companies')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('companies')">✕</button>
+        <RouterLink class="db-card-head" to="/economy/causal-valuation"><span>Companies &amp; Valuations</span><span class="db-open">open →</span></RouterLink>
+        <button class="db-row" @click="go('/economy/causal-valuation', {})">
+          <span class="db-row-k narrow">Guzman y Gomez</span>
+          <span class="db-row-sub">ASX:GYG · causal valuation</span>
+          <span class="db-num">A$2.14B</span>
+          <span class="db-chg up">+2.7%</span>
+        </button>
+        <button class="db-row" @click="go('/economy/causal-valuation', {})">
+          <span class="db-row-k narrow" style="color:var(--accent)">＋ New valuation</span>
+          <span class="db-row-sub">any listed company or private (Value Driver Studio)</span>
+        </button>
+      </article>
+
       <!-- News -->
-      <article class="db-card">
+      <article v-if="db.visible('news')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('news')">✕</button>
         <RouterLink class="db-card-head" to="/news"><span>News &amp; Events</span><span class="db-open">open →</span></RouterLink>
         <button v-for="n in newsItems" :key="n.id" class="db-row col" @click="go('/news', { item: n.id })">
           <span class="db-row-title">{{ n.title }}</span>
@@ -46,7 +72,8 @@
       </article>
 
       <!-- Economy -->
-      <article class="db-card">
+      <article v-if="db.visible('economy')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('economy')">✕</button>
         <RouterLink class="db-card-head" to="/economy/macro-economics"><span>Economy</span><span class="db-open">open →</span></RouterLink>
         <button v-for="k in indicators" :key="k.id" class="db-row" @click="go('/economy/macro-economics', { k: k.id, kind: 'indicator' })">
           <span class="db-row-sub wide">{{ k.name }}</span>
@@ -56,7 +83,8 @@
       </article>
 
       <!-- People -->
-      <article class="db-card">
+      <article v-if="db.visible('people')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('people')">✕</button>
         <RouterLink class="db-card-head" to="/people/search"><span>People</span><span class="db-open">open →</span></RouterLink>
         <button v-for="e in entities" :key="e.id" class="db-row" @click="go('/people/search', { id: e.id })">
           <span class="db-avatar">{{ initials(e.name) }}</span>
@@ -67,7 +95,8 @@
       </article>
 
       <!-- Law -->
-      <article class="db-card">
+      <article v-if="db.visible('law')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('law')">✕</button>
         <RouterLink class="db-card-head" to="/law/international-law"><span>Law &amp; Regulation</span><span class="db-open">open →</span></RouterLink>
         <button v-for="d in dockets" :key="d.id" class="db-row col" @click="go('/law/international-law', { d: d.id })">
           <span class="db-row-title">{{ d.title }}</span>
@@ -76,7 +105,8 @@
       </article>
 
       <!-- Weather -->
-      <article class="db-card">
+      <article v-if="db.visible('weather')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('weather')">✕</button>
         <RouterLink class="db-card-head" to="/weather/forecast"><span>Weather</span><span class="db-open">open →</span></RouterLink>
         <button v-for="r in regions" :key="r.id" class="db-row" @click="go('/weather/forecast', { r: r.id })">
           <span class="db-row-k narrow">{{ r.name }}</span>
@@ -96,7 +126,8 @@
       </article>
 
       <!-- Social signals -->
-      <article class="db-card">
+      <article v-if="db.visible('social')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('social')">✕</button>
         <RouterLink class="db-card-head" to="/people/social-networks"><span>Social Signals</span><span class="db-open">open →</span></RouterLink>
         <button v-for="t in trends" :key="t.topic" class="db-row" @click="go('/people/social-networks', {})">
           <span class="db-row-k wide">{{ t.topic }}</span>
@@ -106,7 +137,8 @@
       </article>
 
       <!-- Alerts (weather/resource) — the one board that surfaces things needing attention -->
-      <article class="db-card">
+      <article v-if="db.visible('alerts')" class="db-card">
+        <button class="db-remove" title="Hide card" @click="db.hide('alerts')">✕</button>
         <RouterLink class="db-card-head" to="/weather/forecast"><span>Active Alerts</span><span class="db-open">open →</span></RouterLink>
         <button v-for="a in alerts" :key="a.id" class="db-row col" @click="go('/weather/forecast', { r: a.regionId })">
           <span class="db-row-title">{{ a.headline }}</span>
@@ -115,12 +147,19 @@
         <p v-if="alerts.length === 0" class="db-empty">No active alerts.</p>
       </article>
     </div>
+
+    <div v-if="db.hiddenCards().length" class="db-addbar">
+      <span class="db-addbar-label">Add a card:</span>
+      <button v-for="c in db.hiddenCards()" :key="c.id" class="db-addbar-chip" @click="db.show(c.id)">＋ {{ c.label }}</button>
+    </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { useRouter, type LocationQueryRaw } from 'vue-router';
+import { ALL_SURFACES } from '../config/cockpitNav';
+import { useDashboard } from '../stores/dashboard';
 import { indices } from '../data/marketsFixture';
 import { indicators } from '../data/economyFixture';
 import { regions, alerts } from '../data/weatherFixture';
@@ -135,10 +174,21 @@ const router = useRouter();
 const chat = useNoeticaChat();
 const prompt = ref('');
 const lists = useUserLists();
+const db = useDashboard();
 const newSym = ref('');
 const newCity = ref('');
 function addSym() { lists.addSymbol(newSym.value); newSym.value = ''; }
 function addCity() { lists.addCity(newCity.value); newCity.value = ''; }
+
+// Universal Ask bar: type to jump to any surface, or ask Noetica.
+const askFocused = ref(false);
+const askMatches = computed(() => {
+  const q = prompt.value.trim().toLowerCase();
+  if (!q) return [] as { label: string; to: string; group: string }[];
+  return ALL_SURFACES.filter((s) => s.label.toLowerCase().includes(q) || s.group.toLowerCase().includes(q)).slice(0, 6);
+});
+function jump(to: string) { prompt.value = ''; askFocused.value = false; router.push(to); }
+function onAskBlur() { setTimeout(() => { askFocused.value = false; }, 120); }
 
 const srcTitle = new Map(newsSources.map((s) => [s.id, s.title]));
 const regionName = new Map(regions.map((r) => [r.id, r.name]));
@@ -184,6 +234,21 @@ const asOfLabel = new Date(NOW).toLocaleString('en-US', { weekday: 'short', mont
 .db-ask input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font: inherit; font-size: 0.95rem; }
 .db-ask input::placeholder { color: var(--text-3); }
 .db-ask-go { border: none; background: var(--accent); color: #17130a; border-radius: 8px; padding: 0.4rem 0.95rem; font-size: 0.82rem; font-weight: 700; cursor: pointer; } .db-ask-go:disabled { opacity: 0.5; cursor: default; }
+.db-ask-wrap { position: relative; margin-bottom: 1.1rem; }
+.db-ask-wrap .db-ask { margin-bottom: 0; }
+.db-ask-menu { position: absolute; z-index: 20; left: 0; right: 0; top: calc(100% + 6px); background: var(--surface); border: 1px solid var(--line-2); border-radius: 10px; box-shadow: 0 12px 32px rgba(0,0,0,0.4); overflow: hidden; }
+.db-ask-item { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; width: 100%; border: none; background: transparent; color: var(--text); padding: 0.55rem 0.9rem; cursor: pointer; text-align: left; font: inherit; font-size: 0.86rem; }
+.db-ask-item:hover { background: var(--surface-2); }
+.db-ask-item.ask { border-top: 1px solid var(--line); color: var(--accent); }
+.db-ask-grp { font-size: 0.72rem; color: var(--text-3); white-space: nowrap; }
+.db-card { position: relative; }
+.db-remove { position: absolute; top: 0.5rem; right: 0.55rem; z-index: 2; border: none; background: transparent; color: var(--text-3); cursor: pointer; font-size: 0.72rem; opacity: 0; transition: opacity 0.12s; }
+.db-card:hover .db-remove { opacity: 1; }
+.db-remove:hover { color: var(--down); }
+.db-addbar { display: flex; align-items: center; flex-wrap: wrap; gap: 0.5rem; margin-top: 1rem; padding-top: 0.85rem; border-top: 1px solid var(--line); }
+.db-addbar-label { font-size: 0.78rem; color: var(--text-3); }
+.db-addbar-chip { border: 1px solid var(--line-2); background: var(--surface); color: var(--text-2); border-radius: 999px; padding: 0.25rem 0.7rem; font-size: 0.78rem; cursor: pointer; }
+.db-addbar-chip:hover { color: var(--accent); border-color: var(--accent); }
 
 .db-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 0.85rem; }
 .db-card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); display: flex; flex-direction: column; max-height: 340px; overflow-y: auto; }

--- a/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
+++ b/socioprophet-web/client-vue/src/pages/OperatorDashboard.vue
@@ -1,9 +1,9 @@
 <template>
-  <section class="db" aria-label="Operator dashboard">
+  <section class="db" aria-label="User dashboard">
     <header class="db-head">
       <div>
         <p class="db-eyebrow">SocioProphet</p>
-        <h1>Operator Dashboard</h1>
+        <h1>User Dashboard</h1>
       </div>
       <span class="db-asof">as of {{ asOfLabel }}</span>
     </header>
@@ -19,18 +19,27 @@
       <!-- Markets -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/markets/indices-funds"><span>Markets</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="i in indices.slice(0, 5)" :key="i.symbol" class="db-row" @click="go('/markets/indices-funds', { sym: i.symbol })">
+        <button v-for="i in indices" :key="i.symbol" class="db-row" @click="go('/markets/indices-funds', { sym: i.symbol })">
           <span class="db-row-k">{{ i.symbol }}</span>
           <span class="db-row-sub">{{ i.name }}</span>
           <span class="db-num">{{ fmtPrice(i.price) }}</span>
           <span class="db-chg" :class="pctClass(i.changePct)">{{ fmtPct(i.changePct) }}</span>
         </button>
+        <div v-for="s in lists.watchlist" :key="'w-' + s" class="db-row">
+          <span class="db-row-k">{{ s }}</span>
+          <span class="db-row-sub">watching</span>
+          <button class="db-x" title="Remove" @click.stop="lists.removeSymbol(s)">✕</button>
+        </div>
+        <form class="db-add" @submit.prevent="addSym">
+          <input v-model="newSym" placeholder="Add ticker to watchlist (e.g. AAPL)" aria-label="Add ticker" />
+          <button type="submit" :disabled="!newSym.trim()">＋ Add</button>
+        </form>
       </article>
 
       <!-- News -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/news"><span>News &amp; Events</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="n in newsItems.slice(0, 5)" :key="n.id" class="db-row col" @click="go('/news', { item: n.id })">
+        <button v-for="n in newsItems" :key="n.id" class="db-row col" @click="go('/news', { item: n.id })">
           <span class="db-row-title">{{ n.title }}</span>
           <span class="db-row-meta"><span :class="['db-mem', n.membraneDecision]">{{ n.membraneDecision }}</span>{{ srcTitle.get(n.sourceId) }} · {{ rel(n.publishedAt) }}</span>
         </button>
@@ -39,7 +48,7 @@
       <!-- Economy -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/economy/macro-economics"><span>Economy</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="k in indicators.slice(0, 5)" :key="k.id" class="db-row" @click="go('/economy/macro-economics', { k: k.id, kind: 'indicator' })">
+        <button v-for="k in indicators" :key="k.id" class="db-row" @click="go('/economy/macro-economics', { k: k.id, kind: 'indicator' })">
           <span class="db-row-sub wide">{{ k.name }}</span>
           <span class="db-num">{{ fmtVal(k.value, k.unit) }}</span>
           <span class="db-chg" :class="econClass(k.changeAbs, k.better)">{{ signed(k.changeAbs) }}{{ k.unit === '%' ? 'pp' : '' }}</span>
@@ -49,7 +58,7 @@
       <!-- People -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/people/search"><span>People</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="e in entities.slice(0, 5)" :key="e.id" class="db-row" @click="go('/people/search', { id: e.id })">
+        <button v-for="e in entities" :key="e.id" class="db-row" @click="go('/people/search', { id: e.id })">
           <span class="db-avatar">{{ initials(e.name) }}</span>
           <span class="db-row-k narrow">{{ e.name }}</span>
           <span class="db-row-sub">{{ e.role }}</span>
@@ -60,7 +69,7 @@
       <!-- Law -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/law/international-law"><span>Law &amp; Regulation</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="d in dockets.slice(0, 5)" :key="d.id" class="db-row col" @click="go('/law/international-law', { d: d.id })">
+        <button v-for="d in dockets" :key="d.id" class="db-row col" @click="go('/law/international-law', { d: d.id })">
           <span class="db-row-title">{{ d.title }}</span>
           <span class="db-row-meta"><span :class="['db-status', d.status]">{{ d.status }}</span>{{ d.cite }} · {{ d.jurisdiction }}</span>
         </button>
@@ -69,18 +78,27 @@
       <!-- Weather -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/weather/forecast"><span>Weather</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="r in regions.slice(0, 5)" :key="r.id" class="db-row" @click="go('/weather/forecast', { r: r.id })">
+        <button v-for="r in regions" :key="r.id" class="db-row" @click="go('/weather/forecast', { r: r.id })">
           <span class="db-row-k narrow">{{ r.name }}</span>
           <span class="db-row-sub">{{ r.cond }}</span>
           <span class="db-num">{{ r.tempF }}°</span>
           <span class="db-chg" :class="r.changeF >= 0 ? 'up' : 'down'">{{ signed(r.changeF) }}°</span>
         </button>
+        <div v-for="c in lists.cities" :key="'c-' + c" class="db-row">
+          <span class="db-row-k narrow">{{ c }}</span>
+          <span class="db-row-sub">added</span>
+          <button class="db-x" title="Remove" @click.stop="lists.removeCity(c)">✕</button>
+        </div>
+        <form class="db-add" @submit.prevent="addCity">
+          <input v-model="newCity" placeholder="Add a city (e.g. Sydney)" aria-label="Add city" />
+          <button type="submit" :disabled="!newCity.trim()">＋ Add</button>
+        </form>
       </article>
 
       <!-- Social signals -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/people/social-networks"><span>Social Signals</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="t in trends.slice(0, 5)" :key="t.topic" class="db-row" @click="go('/people/social-networks', {})">
+        <button v-for="t in trends" :key="t.topic" class="db-row" @click="go('/people/social-networks', {})">
           <span class="db-row-k wide">{{ t.topic }}</span>
           <span class="db-num sm">{{ fmtNum(t.volume) }}</span>
           <span class="db-chg" :class="t.changePct >= 0 ? 'up' : 'down'">{{ signed(t.changePct) }}%</span>
@@ -90,7 +108,7 @@
       <!-- Alerts (weather/resource) — the one board that surfaces things needing attention -->
       <article class="db-card">
         <RouterLink class="db-card-head" to="/weather/forecast"><span>Active Alerts</span><span class="db-open">open →</span></RouterLink>
-        <button v-for="a in alerts.slice(0, 5)" :key="a.id" class="db-row col" @click="go('/weather/forecast', { r: a.regionId })">
+        <button v-for="a in alerts" :key="a.id" class="db-row col" @click="go('/weather/forecast', { r: a.regionId })">
           <span class="db-row-title">{{ a.headline }}</span>
           <span class="db-row-meta"><span :class="['db-sev', a.severity]">{{ a.severity }}</span>{{ regionName.get(a.regionId) }}<span v-if="a.resource"> · {{ a.resource }}</span></span>
         </button>
@@ -111,10 +129,16 @@ import { trends } from '../data/socialFixture';
 import { entities } from '../data/peopleFixture';
 import { newsItems, newsSources } from '../data/newsFeedFixture';
 import { useNoeticaChat } from '../composables/useNoeticaChat';
+import { useUserLists } from '../stores/userLists';
 
 const router = useRouter();
 const chat = useNoeticaChat();
 const prompt = ref('');
+const lists = useUserLists();
+const newSym = ref('');
+const newCity = ref('');
+function addSym() { lists.addSymbol(newSym.value); newSym.value = ''; }
+function addCity() { lists.addCity(newCity.value); newCity.value = ''; }
 
 const srcTitle = new Map(newsSources.map((s) => [s.id, s.title]));
 const regionName = new Map(regions.map((r) => [r.id, r.name]));
@@ -162,8 +186,8 @@ const asOfLabel = new Date(NOW).toLocaleString('en-US', { weekday: 'short', mont
 .db-ask-go { border: none; background: var(--accent); color: #17130a; border-radius: 8px; padding: 0.4rem 0.95rem; font-size: 0.82rem; font-weight: 700; cursor: pointer; } .db-ask-go:disabled { opacity: 0.5; cursor: default; }
 
 .db-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 0.85rem; }
-.db-card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); overflow: hidden; display: flex; flex-direction: column; }
-.db-card-head { display: flex; align-items: center; justify-content: space-between; padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); text-decoration: none; font-weight: 700; }
+.db-card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); display: flex; flex-direction: column; max-height: 340px; overflow-y: auto; }
+.db-card-head { position: sticky; top: 0; z-index: 1; display: flex; align-items: center; justify-content: space-between; padding: 0.6rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); text-decoration: none; font-weight: 700; background: var(--surface); }
 .db-card-head:hover { color: var(--accent); background: var(--surface-2); }
 .db-open { font-size: 0.64rem; color: var(--text-3); font-weight: 600; letter-spacing: 0; text-transform: none; }
 .db-card-head:hover .db-open { color: var(--accent); }
@@ -189,4 +213,11 @@ const asOfLabel = new Date(NOW).toLocaleString('en-US', { weekday: 'short', mont
 .db-status.comment { color: #58a6ff; background: rgba(88, 166, 255, 0.14); } .db-status.pending { color: var(--accent); background: rgba(216, 162, 80, 0.16); } .db-status.enacted { color: var(--up); background: rgba(75, 191, 115, 0.16); } .db-status.open { color: #8b949e; background: rgba(139, 148, 158, 0.16); }
 .db-sev.advisory { color: #4aa3ff; background: rgba(74, 163, 255, 0.16); } .db-sev.watch { color: #f0883e; background: rgba(240, 136, 62, 0.16); } .db-sev.warning { color: var(--down); background: rgba(240, 101, 106, 0.18); }
 .db-empty { padding: 1rem 0.85rem; color: var(--text-3); font-size: 0.8rem; }
+.db-x { margin-left: auto; border: none; background: transparent; color: var(--text-3); cursor: pointer; font-size: 0.72rem; padding: 0 0.2rem; }
+.db-x:hover { color: var(--down); }
+.db-add { display: flex; gap: 0.4rem; padding: 0.45rem 0.85rem; border-top: 1px solid var(--line); position: sticky; bottom: 0; background: var(--surface); }
+.db-add input { flex: 1; min-width: 0; background: var(--bg); border: 1px solid var(--line-2); border-radius: 6px; color: var(--text); padding: 0.3rem 0.5rem; font: inherit; font-size: 0.78rem; }
+.db-add button { border: none; background: var(--surface-2); color: var(--text-2); border-radius: 6px; padding: 0.3rem 0.6rem; font-size: 0.74rem; cursor: pointer; white-space: nowrap; }
+.db-add button:hover:not(:disabled) { color: var(--accent); }
+.db-add button:disabled { opacity: 0.5; cursor: default; }
 </style>

--- a/socioprophet-web/client-vue/src/pages/Settings.vue
+++ b/socioprophet-web/client-vue/src/pages/Settings.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuth } from '../stores/auth';
+import { useSettings } from '../stores/settings';
+import { meshBase, setMeshBase, checkMesh, DEFAULT_MESH_BASE, type MeshStatus } from '../config/mesh';
+
+const auth = useAuth();
+const settings = useSettings();
+
+// Prophet Mesh connection (ST011). Endpoint is editable + persisted; the check reports
+// the real reachability observed from the browser.
+const meshUrl = ref(meshBase());
+const meshStatus = ref<MeshStatus | null>(null);
+const meshChecking = ref(false);
+async function checkMeshConnection() {
+  meshChecking.value = true;
+  setMeshBase(meshUrl.value);
+  meshStatus.value = await checkMesh(meshUrl.value.replace(/\/$/, ''));
+  meshChecking.value = false;
+}
+
+// Connections (Watson Studio "Git integrations / credentials for connections"). Local-only for now —
+// persisted to localStorage; a live build wires these to the platform connection store.
+const giteaToken = ref(localStorage.getItem('sp.conn.gitea') ?? '');
+const savedNote = ref('');
+function saveConnections() {
+  localStorage.setItem('sp.conn.gitea', giteaToken.value);
+  savedNote.value = 'Saved locally';
+  setTimeout(() => (savedNote.value = ''), 2000);
+}
+</script>
+
+<template>
+  <section class="st" aria-label="Settings">
+    <header class="st-top">
+      <p class="st-eyebrow">Account</p>
+      <h1 class="st-title">Settings</h1>
+    </header>
+
+    <nav class="st-toc" aria-label="Settings sections">
+      <a href="#profile">Profile</a>
+      <a href="#appearance">Appearance</a>
+      <a href="#operator">Operator mode</a>
+      <a href="#connections">Connections</a>
+    </nav>
+
+    <section id="profile" class="st-card">
+      <h2>Profile</h2>
+      <div class="st-row"><span class="st-label">Signed in as</span><span>{{ auth.user?.email ?? 'not signed in' }}</span></div>
+      <div class="st-row"><span class="st-label">Display name</span><span>{{ auth.user?.displayName ?? '—' }}</span></div>
+      <div class="st-row"><span class="st-label">Tier</span><span class="st-pill">{{ auth.tier }}</span></div>
+      <p class="st-hint">Profile fields are read from your authenticated session. Editing name/avatar arrives with the account service (ST007 login work).</p>
+    </section>
+
+    <section id="appearance" class="st-card">
+      <h2>Appearance</h2>
+      <div class="st-row">
+        <span class="st-label">Theme</span>
+        <span class="st-seg">
+          <button :class="{ active: settings.theme === 'dark' }" @click="settings.setTheme('dark')">Dark</button>
+          <button :class="{ active: settings.theme === 'light' }" @click="settings.setTheme('light')">Light</button>
+        </span>
+      </div>
+      <p class="st-hint">Theme preference persists across reloads. Full light-mode theming of every surface is in progress; the shell chrome responds today.</p>
+    </section>
+
+    <section id="operator" class="st-card">
+      <h2>Operator mode</h2>
+      <div class="st-row">
+        <span class="st-label">SourceOS / operator surfaces</span>
+        <button class="st-toggle" :class="{ on: settings.operatorMode }" role="switch" :aria-checked="settings.operatorMode" @click="settings.toggleOperatorMode()">
+          <span class="st-knob"></span><span class="st-toggle-txt">{{ settings.operatorMode ? 'On' : 'Off' }}</span>
+        </button>
+      </div>
+      <p class="st-hint">Off by default. When on, the Operator menu (Infrastructure, Models &amp; Pipelines, Workstation, SourceOS, Marketplace) appears in the top bar and side drawer. Most users never need this.</p>
+    </section>
+
+    <section id="connections" class="st-card">
+      <h2>Connections &amp; integrations</h2>
+      <div class="st-row col">
+        <label class="st-label" for="mesh">Prophet Mesh endpoint <span class="st-hint-inline">(hosted Model Choir / Conductor — ST011)</span></label>
+        <input id="mesh" v-model="meshUrl" type="text" :placeholder="DEFAULT_MESH_BASE" />
+      </div>
+      <div class="st-actions">
+        <button class="st-save" @click="checkMeshConnection">{{ meshChecking ? 'Checking…' : 'Check connection' }}</button>
+        <span v-if="meshStatus" class="st-mesh" :class="{ ok: meshStatus.ok }">
+          <span class="st-dot" :class="{ ok: meshStatus.ok }"></span>{{ meshStatus.detail }}
+        </span>
+      </div>
+      <p class="st-hint">When the mesh exposes the platform routes, set <code>VITE_MESH_BASE</code> to this endpoint and the whole SPA runs against the hosted cloud instance — the same build Michael and Gus use proves it works for a client on their own mesh.</p>
+      <div class="st-row col" style="margin-top:.75rem;">
+        <label class="st-label" for="gitea">Gitea token <span class="st-hint-inline">(for Add Local Repo / Forge import)</span></label>
+        <input id="gitea" v-model="giteaToken" type="password" placeholder="gitea personal access token" />
+      </div>
+      <div class="st-actions">
+        <button class="st-save" @click="saveConnections">Save connections</button>
+        <span class="st-saved" v-if="savedNote">{{ savedNote }}</span>
+      </div>
+      <p class="st-hint">Stored locally in this browser for now. A live build binds connection credentials to the platform connection store (Watson Studio-style integrations).</p>
+    </section>
+  </section>
+</template>
+
+<style scoped>
+.st { padding: 1rem 1.25rem; max-width: 780px; font-family: ui-sans-serif, system-ui; }
+.st-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; opacity: .6; margin: 0; }
+.st-title { font-size: 1.5rem; font-weight: 700; margin: .25rem 0 1rem; }
+.st-toc { display: flex; gap: 1rem; margin-bottom: 1rem; font-size: .85rem; }
+.st-toc a { color: inherit; opacity: .7; text-decoration: none; border-bottom: 1px solid transparent; }
+.st-toc a:hover { opacity: 1; border-bottom-color: currentColor; }
+.st-card { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: 1rem 1.1rem; margin-bottom: 1rem; }
+.st-card h2 { margin: 0 0 .75rem; font-size: 1.05rem; }
+.st-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .4rem 0; border-bottom: 1px solid #f1f5f9; }
+.st-row:last-of-type { border-bottom: 0; }
+.st-row.col { flex-direction: column; align-items: stretch; }
+.st-label { font-size: .85rem; opacity: .7; }
+.st-hint { font-size: .78rem; opacity: .6; margin: .6rem 0 0; }
+.st-hint-inline { opacity: .5; font-weight: 400; }
+.st-pill { border: 1px solid #cbd5e1; border-radius: 999px; padding: .1rem .55rem; font-size: .75rem; text-transform: uppercase; }
+.st-seg { display: inline-flex; border: 1px solid #cbd5e1; border-radius: 8px; overflow: hidden; }
+.st-seg button { border: 0; background: #fff; padding: .35rem .8rem; cursor: pointer; font-size: .82rem; }
+.st-seg button.active { background: #0f172a; color: #fff; }
+.st-toggle { display: inline-flex; align-items: center; gap: .5rem; border: 1px solid #cbd5e1; border-radius: 999px; background: #eef2f7; padding: .2rem .5rem .2rem .2rem; cursor: pointer; }
+.st-toggle .st-knob { width: 18px; height: 18px; border-radius: 50%; background: #94a3b8; transition: transform .15s, background .15s; }
+.st-toggle.on { background: #ecfdf5; border-color: #a7f3d0; }
+.st-toggle.on .st-knob { background: #10b981; transform: translateX(4px); }
+.st-toggle-txt { font-size: .8rem; }
+.st-row.col input { padding: .5rem .7rem; border: 1px solid #cbd5e1; border-radius: 8px; margin-top: .35rem; }
+.st-actions { display: flex; align-items: center; gap: .75rem; margin-top: .6rem; }
+.st-save { padding: .4rem .9rem; border: 1px solid #10b981; background: #10b981; color: #fff; border-radius: 8px; cursor: pointer; }
+.st-saved { font-size: .8rem; color: #065f46; }
+.st-mesh { font-size: .8rem; display: inline-flex; align-items: center; gap: .4rem; color: #991b1b; }
+.st-mesh.ok { color: #065f46; }
+.st-dot { width: 8px; height: 8px; border-radius: 50%; background: #ef4444; }
+.st-dot.ok { background: #10b981; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/Settings.vue
+++ b/socioprophet-web/client-vue/src/pages/Settings.vue
@@ -2,19 +2,21 @@
 import { ref } from 'vue';
 import { useAuth } from '../stores/auth';
 import { useSettings } from '../stores/settings';
-import { meshBase, setMeshBase, checkMesh, DEFAULT_MESH_BASE, type MeshStatus } from '../config/mesh';
+import { meshBase, setMeshBase, meshToken, setMeshToken, checkMesh, DEFAULT_MESH_BASE, type MeshStatus } from '../config/mesh';
 
 const auth = useAuth();
 const settings = useSettings();
 
-// Prophet Mesh connection (ST011). Endpoint is editable + persisted; the check reports
-// the real reachability observed from the browser.
+// Prophet Mesh connection (ST011) — live OpenAI-compatible conductor on GKE. Endpoint +
+// bearer token are editable + persisted; the check hits the real /v1/models on the mesh.
 const meshUrl = ref(meshBase());
+const meshTok = ref(meshToken());
 const meshStatus = ref<MeshStatus | null>(null);
 const meshChecking = ref(false);
 async function checkMeshConnection() {
   meshChecking.value = true;
   setMeshBase(meshUrl.value);
+  setMeshToken(meshTok.value);
   meshStatus.value = await checkMesh(meshUrl.value.replace(/\/$/, ''));
   meshChecking.value = false;
 }
@@ -78,8 +80,12 @@ function saveConnections() {
     <section id="connections" class="st-card">
       <h2>Connections &amp; integrations</h2>
       <div class="st-row col">
-        <label class="st-label" for="mesh">Prophet Mesh endpoint <span class="st-hint-inline">(hosted Model Choir / Conductor — ST011)</span></label>
+        <label class="st-label" for="mesh">Prophet Mesh endpoint <span class="st-hint-inline">(live Model Choir / Conductor on GKE — ST011)</span></label>
         <input id="mesh" v-model="meshUrl" type="text" :placeholder="DEFAULT_MESH_BASE" />
+      </div>
+      <div class="st-row col">
+        <label class="st-label" for="meshtok">Mesh bearer token <span class="st-hint-inline">(required for chat routing; /v1/models is open)</span></label>
+        <input id="meshtok" v-model="meshTok" type="password" placeholder="MESH_AUTH_TOKEN" />
       </div>
       <div class="st-actions">
         <button class="st-save" @click="checkMeshConnection">{{ meshChecking ? 'Checking…' : 'Check connection' }}</button>
@@ -87,7 +93,16 @@ function saveConnections() {
           <span class="st-dot" :class="{ ok: meshStatus.ok }"></span>{{ meshStatus.detail }}
         </span>
       </div>
-      <p class="st-hint">When the mesh exposes the platform routes, set <code>VITE_MESH_BASE</code> to this endpoint and the whole SPA runs against the hosted cloud instance — the same build Michael and Gus use proves it works for a client on their own mesh.</p>
+      <div v-if="meshStatus && meshStatus.models.length" class="st-models">
+        Models: <span v-for="m in meshStatus.models" :key="m" class="st-pill">{{ m }}</span>
+      </div>
+      <div class="st-row" style="margin-top:.6rem;">
+        <span class="st-label">Route Noetica chat through the mesh <span class="st-hint-inline">(Prophet Cloud Mesh)</span></span>
+        <button class="st-toggle" :class="{ on: settings.meshChat }" role="switch" :aria-checked="settings.meshChat" @click="settings.toggleMeshChat()">
+          <span class="st-knob"></span><span class="st-toggle-txt">{{ settings.meshChat ? 'On' : 'Off' }}</span>
+        </button>
+      </div>
+      <p class="st-hint">The mesh is live on GKE (<code>mesh.socioprophet.ai</code> → conductor → vLLM seat). Turn on Prophet Cloud Mesh to route Noetica chat to <code>model=prophet-mesh</code> end-to-end — the same build proves it works for a client on their own cloud instance.</p>
       <div class="st-row col" style="margin-top:.75rem;">
         <label class="st-label" for="gitea">Gitea token <span class="st-hint-inline">(for Add Local Repo / Forge import)</span></label>
         <input id="gitea" v-model="giteaToken" type="password" placeholder="gitea personal access token" />
@@ -133,4 +148,5 @@ function saveConnections() {
 .st-mesh.ok { color: #065f46; }
 .st-dot { width: 8px; height: 8px; border-radius: 50%; background: #ef4444; }
 .st-dot.ok { background: #10b981; }
+.st-models { margin-top: .5rem; display: flex; align-items: center; gap: .35rem; flex-wrap: wrap; font-size: .8rem; opacity: .8; }
 </style>

--- a/socioprophet-web/client-vue/src/stores/dashboard.ts
+++ b/socioprophet-web/client-vue/src/stores/dashboard.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia';
+import { ref, watch } from 'vue';
+
+// Composable dashboard: which cards the user shows. Order is the declared default for now;
+// hidden cards drop out and can be re-added. Persisted per browser.
+export interface DashCard { id: string; label: string }
+export const DASH_CARDS: DashCard[] = [
+  { id: 'markets', label: 'Markets' },
+  { id: 'companies', label: 'Companies & Valuations' },
+  { id: 'news', label: 'News & Events' },
+  { id: 'economy', label: 'Economy' },
+  { id: 'people', label: 'People' },
+  { id: 'law', label: 'Law & Regulation' },
+  { id: 'weather', label: 'Weather' },
+  { id: 'social', label: 'Social Signals' },
+  { id: 'alerts', label: 'Active Alerts' },
+];
+
+const LS_KEY = 'sp.dashboard.v1';
+
+export const useDashboard = defineStore('dashboard', () => {
+  const hidden = ref<string[]>((() => {
+    try { const r = localStorage.getItem(LS_KEY); if (r) { const p = JSON.parse(r); return Array.isArray(p.hidden) ? p.hidden : []; } } catch { /* ignore */ }
+    return [];
+  })());
+
+  watch(hidden, () => {
+    try { localStorage.setItem(LS_KEY, JSON.stringify({ hidden: hidden.value })); } catch { /* ignore */ }
+  }, { deep: true });
+
+  const visible = (id: string) => !hidden.value.includes(id);
+  const hide = (id: string) => { if (!hidden.value.includes(id)) hidden.value = [...hidden.value, id]; };
+  const show = (id: string) => { hidden.value = hidden.value.filter((x) => x !== id); };
+  const hiddenCards = () => DASH_CARDS.filter((c) => hidden.value.includes(c.id));
+
+  return { hidden, visible, hide, show, hiddenCards, DASH_CARDS };
+});

--- a/socioprophet-web/client-vue/src/stores/settings.ts
+++ b/socioprophet-web/client-vue/src/stores/settings.ts
@@ -1,24 +1,37 @@
 import { defineStore } from 'pinia';
 import { ref, watch } from 'vue';
 
-// User settings store: the two preferences the shell reacts to today —
-//   operatorMode  reveals the SourceOS / operator surfaces (off by default, so a
-//                 normal user sees a clean product and never meets SourceOS).
+// User settings + nav personalization, all persisted to localStorage:
+//   operatorMode  when on, the operator/SourceOS drawer sections default to expanded
+//                 + pinnable. It NO LONGER gates presence — every surface stays reachable.
 //   theme         'dark' | 'light' — applied as data-theme on <html>.
-// Both persist to localStorage so a reload keeps the user's choice.
+//   pinned        surface routes the user pinned to the top of the drawer.
+//   openSections  per-section accordion open/closed state (id -> bool).
 
 type Theme = 'dark' | 'light';
 const LS_KEY = 'sp.settings.v1';
 
-function load(): { operatorMode: boolean; theme: Theme } {
+interface Persisted {
+  operatorMode: boolean;
+  theme: Theme;
+  pinned: string[];
+  openSections: Record<string, boolean>;
+}
+
+function load(): Persisted {
   try {
     const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null;
     if (raw) {
       const p = JSON.parse(raw);
-      return { operatorMode: !!p.operatorMode, theme: p.theme === 'light' ? 'light' : 'dark' };
+      return {
+        operatorMode: !!p.operatorMode,
+        theme: p.theme === 'light' ? 'light' : 'dark',
+        pinned: Array.isArray(p.pinned) ? p.pinned : [],
+        openSections: p.openSections && typeof p.openSections === 'object' ? p.openSections : {},
+      };
     }
   } catch { /* ignore */ }
-  return { operatorMode: false, theme: 'dark' };
+  return { operatorMode: false, theme: 'dark', pinned: [], openSections: {} };
 }
 
 function applyTheme(theme: Theme) {
@@ -29,19 +42,43 @@ export const useSettings = defineStore('settings', () => {
   const initial = load();
   const operatorMode = ref<boolean>(initial.operatorMode);
   const theme = ref<Theme>(initial.theme);
+  const pinned = ref<string[]>(initial.pinned);
+  const openSections = ref<Record<string, boolean>>(initial.openSections);
 
   applyTheme(theme.value);
 
-  watch([operatorMode, theme], () => {
+  watch([operatorMode, theme, pinned, openSections], () => {
     applyTheme(theme.value);
     try {
-      localStorage.setItem(LS_KEY, JSON.stringify({ operatorMode: operatorMode.value, theme: theme.value }));
+      localStorage.setItem(LS_KEY, JSON.stringify({
+        operatorMode: operatorMode.value, theme: theme.value,
+        pinned: pinned.value, openSections: openSections.value,
+      }));
     } catch { /* ignore */ }
-  });
+  }, { deep: true });
 
   const toggleOperatorMode = () => { operatorMode.value = !operatorMode.value; };
   const setTheme = (t: Theme) => { theme.value = t; };
   const toggleTheme = () => { theme.value = theme.value === 'dark' ? 'light' : 'dark'; };
 
-  return { operatorMode, theme, toggleOperatorMode, setTheme, toggleTheme };
+  const isPinned = (to: string) => pinned.value.includes(to);
+  const togglePin = (to: string) => {
+    pinned.value = isPinned(to) ? pinned.value.filter((p) => p !== to) : [...pinned.value, to];
+  };
+
+  // Accordion state: explicit user choice wins; otherwise operator sections follow
+  // Operator mode and everyday sections follow their defaultOpen.
+  const isSectionOpen = (id: string, defaultOpen: boolean, operator = false) => {
+    if (id in openSections.value) return openSections.value[id];
+    return operator ? operatorMode.value : defaultOpen;
+  };
+  const toggleSection = (id: string, current: boolean) => {
+    openSections.value = { ...openSections.value, [id]: !current };
+  };
+
+  return {
+    operatorMode, theme, pinned, openSections,
+    toggleOperatorMode, setTheme, toggleTheme,
+    isPinned, togglePin, isSectionOpen, toggleSection,
+  };
 });

--- a/socioprophet-web/client-vue/src/stores/settings.ts
+++ b/socioprophet-web/client-vue/src/stores/settings.ts
@@ -1,0 +1,47 @@
+import { defineStore } from 'pinia';
+import { ref, watch } from 'vue';
+
+// User settings store: the two preferences the shell reacts to today —
+//   operatorMode  reveals the SourceOS / operator surfaces (off by default, so a
+//                 normal user sees a clean product and never meets SourceOS).
+//   theme         'dark' | 'light' — applied as data-theme on <html>.
+// Both persist to localStorage so a reload keeps the user's choice.
+
+type Theme = 'dark' | 'light';
+const LS_KEY = 'sp.settings.v1';
+
+function load(): { operatorMode: boolean; theme: Theme } {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null;
+    if (raw) {
+      const p = JSON.parse(raw);
+      return { operatorMode: !!p.operatorMode, theme: p.theme === 'light' ? 'light' : 'dark' };
+    }
+  } catch { /* ignore */ }
+  return { operatorMode: false, theme: 'dark' };
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document !== 'undefined') document.documentElement.setAttribute('data-theme', theme);
+}
+
+export const useSettings = defineStore('settings', () => {
+  const initial = load();
+  const operatorMode = ref<boolean>(initial.operatorMode);
+  const theme = ref<Theme>(initial.theme);
+
+  applyTheme(theme.value);
+
+  watch([operatorMode, theme], () => {
+    applyTheme(theme.value);
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify({ operatorMode: operatorMode.value, theme: theme.value }));
+    } catch { /* ignore */ }
+  });
+
+  const toggleOperatorMode = () => { operatorMode.value = !operatorMode.value; };
+  const setTheme = (t: Theme) => { theme.value = t; };
+  const toggleTheme = () => { theme.value = theme.value === 'dark' ? 'light' : 'dark'; };
+
+  return { operatorMode, theme, toggleOperatorMode, setTheme, toggleTheme };
+});

--- a/socioprophet-web/client-vue/src/stores/settings.ts
+++ b/socioprophet-web/client-vue/src/stores/settings.ts
@@ -16,6 +16,7 @@ interface Persisted {
   theme: Theme;
   pinned: string[];
   openSections: Record<string, boolean>;
+  meshChat: boolean;
 }
 
 function load(): Persisted {
@@ -28,10 +29,11 @@ function load(): Persisted {
         theme: p.theme === 'light' ? 'light' : 'dark',
         pinned: Array.isArray(p.pinned) ? p.pinned : [],
         openSections: p.openSections && typeof p.openSections === 'object' ? p.openSections : {},
+        meshChat: !!p.meshChat,
       };
     }
   } catch { /* ignore */ }
-  return { operatorMode: false, theme: 'dark', pinned: [], openSections: {} };
+  return { operatorMode: false, theme: 'dark', pinned: [], openSections: {}, meshChat: false };
 }
 
 function applyTheme(theme: Theme) {
@@ -44,18 +46,21 @@ export const useSettings = defineStore('settings', () => {
   const theme = ref<Theme>(initial.theme);
   const pinned = ref<string[]>(initial.pinned);
   const openSections = ref<Record<string, boolean>>(initial.openSections);
+  const meshChat = ref<boolean>(initial.meshChat);
 
   applyTheme(theme.value);
 
-  watch([operatorMode, theme, pinned, openSections], () => {
+  watch([operatorMode, theme, pinned, openSections, meshChat], () => {
     applyTheme(theme.value);
     try {
       localStorage.setItem(LS_KEY, JSON.stringify({
         operatorMode: operatorMode.value, theme: theme.value,
-        pinned: pinned.value, openSections: openSections.value,
+        pinned: pinned.value, openSections: openSections.value, meshChat: meshChat.value,
       }));
     } catch { /* ignore */ }
   }, { deep: true });
+
+  const toggleMeshChat = () => { meshChat.value = !meshChat.value; };
 
   const toggleOperatorMode = () => { operatorMode.value = !operatorMode.value; };
   const setTheme = (t: Theme) => { theme.value = t; };
@@ -77,8 +82,8 @@ export const useSettings = defineStore('settings', () => {
   };
 
   return {
-    operatorMode, theme, pinned, openSections,
-    toggleOperatorMode, setTheme, toggleTheme,
+    operatorMode, theme, pinned, openSections, meshChat,
+    toggleOperatorMode, setTheme, toggleTheme, toggleMeshChat,
     isPinned, togglePin, isSectionOpen, toggleSection,
   };
 });

--- a/socioprophet-web/client-vue/src/stores/userLists.ts
+++ b/socioprophet-web/client-vue/src/stores/userLists.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia';
+import { ref, watch } from 'vue';
+
+// User-added personal lists (watchlist tickers, weather cities), persisted to localStorage.
+// A live build would sync these to the account/portfolio service; today they're local so the
+// "add to your portfolio / cities" gesture works end-to-end on the fixture surfaces.
+const LS_KEY = 'sp.userlists.v1';
+
+function load(): { watchlist: string[]; cities: string[] } {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null;
+    if (raw) {
+      const p = JSON.parse(raw);
+      return { watchlist: Array.isArray(p.watchlist) ? p.watchlist : [], cities: Array.isArray(p.cities) ? p.cities : [] };
+    }
+  } catch { /* ignore */ }
+  return { watchlist: [], cities: [] };
+}
+
+export const useUserLists = defineStore('userLists', () => {
+  const init = load();
+  const watchlist = ref<string[]>(init.watchlist);
+  const cities = ref<string[]>(init.cities);
+
+  watch([watchlist, cities], () => {
+    try { localStorage.setItem(LS_KEY, JSON.stringify({ watchlist: watchlist.value, cities: cities.value })); } catch { /* ignore */ }
+  }, { deep: true });
+
+  const addSymbol = (s: string) => { const v = s.trim().toUpperCase(); if (v && !watchlist.value.includes(v)) watchlist.value = [...watchlist.value, v]; };
+  const removeSymbol = (s: string) => { watchlist.value = watchlist.value.filter((x) => x !== s); };
+  const addCity = (c: string) => { const v = c.trim(); if (v && !cities.value.some((x) => x.toLowerCase() === v.toLowerCase())) cities.value = [...cities.value, v]; };
+  const removeCity = (c: string) => { cities.value = cities.value.filter((x) => x !== c); };
+
+  return { watchlist, cities, addSymbol, removeSymbol, addCity, removeCity };
+});

--- a/socioprophet-web/client-vue/vite.config.ts
+++ b/socioprophet-web/client-vue/vite.config.ts
@@ -28,6 +28,13 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, ''),
         },
+        // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
+        '/mesh': {
+          target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',
+          changeOrigin: true,
+          secure: true,
+          rewrite: (path) => path.replace(/^\/mesh/, ''),
+        },
       },
     },
     test: {


### PR DESCRIPTION
## What
Everyday-product IA cleanup of the client-vue cockpit + the GYG causal-valuation surface integrated into the canonical SPA, a real user settings surface, and a Prophet Mesh connection.

### Navigation IA (separate everyday product from SourceOS/operator)
- **Operator / SourceOS surfaces removed from the top domain row** — they're a dashboard-class thing, reachable from the hamburger, and only when **Operator mode** is on (off by default). A normal user never meets SourceOS.
- New **Knowledge** menu; **Portfolios / Algo Trading** promoted into Capital & Markets; operator cockpit regrouped (Infrastructure · Models & Pipelines · Workstation · SourceOS · Marketplace); **Model Labs de-duplicated**; **NLBoot Evidence demoted**.
- Brand + default landing → **Operator Dashboard** (was News).

### User settings (was missing)
- Top-right **user dropdown**: Profile · Settings · HolographMe · Appearance (dark/light) · Operator mode · Sign out.
- New **`/settings`** page: Profile · Appearance · Operator mode · Connections — modeled on Watson Studio's account area. `stores/settings.ts` persists operatorMode + theme.

### GYG causal valuation
- New **Economy › Causal Valuation** page + `causalValuationApi.ts`: hellgraph supply-chain causal graph → economic-prophet VDT → enterprise value, with interactive assumption/horizon/discount recompute (canonical engine — never re-implemented in the browser), multi-period trajectory, location map + org digital twin. GYG also appears in the existing ValueDriverTree selector via the catalog.

### Prophet Mesh (ST011)
- `config/mesh.ts` + a Settings connection card with a **live reachability check** to mesh.socioprophet.ai. Setting `VITE_MESH_BASE` points the SPA's API clients at a hosted mesh, so the same build runs against a cloud instance.

## Backend
Depends on the dashboard-bff routes in SocioProphet/prophet-platform#717 (`/v1/valuation/causal`, `/recompute`, `/v1/locations`) and the multi-period engine in SocioProphet/economic-prophet#28.

## Verification
vue-tsc clean; production build green (1727 modules); endpoints verified live through the SPA proxy. No headless browser in the build env — verified via API + render-logic execution. The stray pnpm-lock.yaml/pnpm-workspace.yaml from a local install were deliberately excluded.