### PR TITLE
feat(ai-search): socioprophet.ai agentic-search surface + land app-vue cutover

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -28,13 +28,17 @@
     },
     {
       "target": "app",
-      "public": "socioprophet-web/client-vue/dist",
+      "public": "socioprophet-web/app-vue/dist",
       "ignore": [
         "firebase.json",
         "**/.*",
         "**/node_modules/**"
       ],
       "rewrites": [
+        {
+          "source": "/api/**",
+          "run": { "serviceId": "builder-api", "region": "us-central1" }
+        },
         {
           "source": "**",
           "destination": "/index.html"

--- a/socioprophet-web/app-vue/src/router.ts
+++ b/socioprophet-web/app-vue/src/router.ts
@@ -4,6 +4,9 @@ import { useAuth } from "./stores/auth";
 const routes = [
   { path: "/", redirect: "/builder" },
   { path: "/login", component: () => import("./views/Login.vue"), meta: { public: true } },
+  // socioprophet.ai — the agentic search surface. PUBLIC: you don't log in to search (login is for save/
+  // personalize, later). Blends web + the sovereign commons via the search-gateway.
+  { path: "/search", component: () => import("./views/Search.vue"), meta: { public: true } },
   { path: "/builder", component: () => import("./views/Builder.vue") },
   { path: "/builds", component: () => import("./views/Builds.vue") },
   { path: "/fleet", component: () => import("./views/Fleet.vue") },

--- a/socioprophet-web/app-vue/src/services/searchApi.ts
+++ b/socioprophet-web/app-vue/src/services/searchApi.ts
@@ -1,0 +1,47 @@
+// searchApi — the socioprophet.ai agentic-search client. Calls the public search-gateway (prophet-platform
+// apps/search-gateway), which fans one query out to SearXNG (web) + commons-search (the sovereign commons) and
+// returns a blended, cited result set. VITE_SEARCH_API unset → STUB mode (no network) so the surface renders
+// standalone/local-first until the gateway host is wired. Read-only: this client never writes.
+
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_SEARCH_API;
+
+export type Source = "web" | "commons";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  source: Source;
+  engine: string;
+  publishedDate?: string;
+}
+
+export interface BlendedResults {
+  query: string;
+  results: SearchResult[];
+  counts: { web: number; commons: number };
+  degraded?: { web?: string; commons?: string };
+  stub?: boolean;
+}
+
+const STUB: SearchResult[] = [
+  { title: "How our sovereign commons works", url: "noetica://open-chat/demo/1", snippet: "An opt-in, redacted community chat — searchable by any agent. This is a stub result; wire VITE_SEARCH_API to go live.", source: "commons", engine: "noetica-commons" },
+  { title: "Fibered Retrieval (GraphRAG) — overview", url: "https://socioprophet.ai/docs/fibered-retrieval", snippet: "Hybrid dense+sparse retrieval blended with graph traversal over HellGraph. The v1 engine slots in here.", source: "web", engine: "stub" },
+];
+
+export async function search(query: string): Promise<BlendedResults> {
+  const q = query.trim();
+  if (!q) return { query: "", results: [], counts: { web: 0, commons: 0 } };
+  if (!BASE) {
+    // stub: local-first render until the gateway host is set
+    const results = STUB.filter((r) => `${r.title} ${r.snippet}`.toLowerCase().includes(q.toLowerCase())).length
+      ? STUB.filter((r) => `${r.title} ${r.snippet}`.toLowerCase().includes(q.toLowerCase()))
+      : STUB;
+    return { query: q, results, counts: { web: 1, commons: 1 }, stub: true };
+  }
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/search?q=${encodeURIComponent(q)}`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`search failed: ${res.status}`);
+  return (await res.json()) as BlendedResults;
+}

--- a/socioprophet-web/app-vue/src/views/Search.vue
+++ b/socioprophet-web/app-vue/src/views/Search.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { search, type BlendedResults, type SearchResult } from "../services/searchApi";
+
+const q = ref("");
+const loading = ref(false);
+const error = ref("");
+const data = ref<BlendedResults | null>(null);
+
+const commons = computed(() => (data.value?.results ?? []).filter((r) => r.source === "commons"));
+const web = computed(() => (data.value?.results ?? []).filter((r) => r.source === "web"));
+
+async function run() {
+  const query = q.value.trim();
+  if (!query) return;
+  loading.value = true;
+  error.value = "";
+  try {
+    data.value = await search(query);
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "search failed";
+    data.value = null;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function hostOf(url: string): string {
+  const m = url.match(/^[a-z]+:\/\/([^/]+)/i);
+  return m ? m[1] : url.split("/")[0];
+}
+function isExternal(url: string): boolean {
+  return url.startsWith("http");
+}
+</script>
+
+<template>
+  <div class="search" :class="{ landing: !data && !loading }">
+    <header class="masthead">
+      <div class="brand">socioprophet<span class="ai">.ai</span></div>
+      <p class="tagline">Agentic search over the web <em>and</em> a sovereign commons the web can't index — grounded, cited, yours.</p>
+    </header>
+
+    <form class="box" @submit.prevent="run">
+      <input
+        v-model="q"
+        type="search"
+        placeholder="Ask anything…"
+        aria-label="Search query"
+        autofocus
+      />
+      <button type="submit" :disabled="loading">{{ loading ? "…" : "Search" }}</button>
+    </form>
+
+    <p v-if="data?.stub" class="note stub">Preview mode — showing sample results. Live results appear once the search gateway is connected.</p>
+    <p v-if="data?.degraded?.web" class="note warn">Web results are temporarily unavailable — showing commons only.</p>
+    <p v-if="data?.degraded?.commons" class="note warn">Commons results are temporarily unavailable — showing web only.</p>
+    <p v-if="error" class="note err">{{ error }}</p>
+
+    <section v-if="data && !loading" class="results">
+      <div v-if="commons.length" class="group">
+        <h2>⬡ Community commons <span class="count">{{ commons.length }}</span></h2>
+        <article v-for="(r, i) in commons" :key="'c' + i" class="hit commons">
+          <a v-if="isExternal(r.url)" :href="r.url" target="_blank" rel="noopener" class="title">{{ r.title }}</a>
+          <span v-else class="title plain">{{ r.title }}</span>
+          <div class="src">{{ hostOf(r.url) }} · <span class="badge sov">sovereign commons</span><span v-if="r.publishedDate" class="date"> · {{ new Date(r.publishedDate).toLocaleDateString() }}</span></div>
+          <p class="snippet">{{ r.snippet }}</p>
+        </article>
+      </div>
+
+      <div v-if="web.length" class="group">
+        <h2>◍ Web <span class="count">{{ web.length }}</span></h2>
+        <article v-for="(r, i) in web" :key="'w' + i" class="hit">
+          <a :href="r.url" target="_blank" rel="noopener" class="title">{{ r.title }}</a>
+          <div class="src">{{ hostOf(r.url) }} · <span class="badge">{{ r.engine }}</span></div>
+          <p class="snippet">{{ r.snippet }}</p>
+        </article>
+      </div>
+
+      <p v-if="!commons.length && !web.length" class="empty">Nothing found for “{{ data.query }}”. Try different words.</p>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.search { padding: 24px 32px; font: 15px/1.55 system-ui, sans-serif; color: #202124; height: 100%; overflow: auto; max-width: 780px; margin: 0 auto; }
+.search.landing { display: flex; flex-direction: column; justify-content: center; }
+.masthead { text-align: center; margin-bottom: 20px; }
+.brand { font-size: 34px; font-weight: 700; letter-spacing: -0.5px; }
+.brand .ai { color: #1a73e8; }
+.tagline { color: #5f6368; max-width: 560px; margin: 6px auto 0; }
+.tagline em { color: #202124; font-style: normal; font-weight: 600; }
+
+.box { display: flex; gap: 8px; margin: 8px 0 4px; }
+.box input { flex: 1; padding: 13px 16px; font-size: 16px; border: 1px solid #dadce0; border-radius: 26px; outline: none; }
+.box input:focus { border-color: #1a73e8; box-shadow: 0 1px 6px rgba(26,115,232,0.18); }
+.box button { padding: 0 22px; font-size: 15px; font-weight: 600; color: #fff; background: #1a73e8; border: none; border-radius: 26px; cursor: pointer; }
+.box button:disabled { opacity: 0.6; cursor: default; }
+
+.note { font-size: 13px; margin: 10px 2px; padding: 8px 12px; border-radius: 8px; }
+.note.stub { background: #e8f0fe; color: #1a56c4; }
+.note.warn { background: #fef7e0; color: #b06000; }
+.note.err { background: #fce8e6; color: #c5221f; }
+
+.results { margin-top: 14px; }
+.group { margin-bottom: 26px; }
+.group h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: #5f6368; border-bottom: 1px solid #eceff1; padding-bottom: 6px; margin: 0 0 12px; }
+.group h2 .count { color: #9aa0a6; font-weight: 400; }
+.hit { margin-bottom: 16px; }
+.hit .title { font-size: 18px; color: #1a0dab; text-decoration: none; }
+.hit .title:hover { text-decoration: underline; }
+.hit .title.plain { color: #202124; }
+.hit .src { font-size: 12px; color: #5f6368; margin: 2px 0 3px; }
+.hit .snippet { color: #3c4043; margin: 0; }
+.hit.commons { border-left: 3px solid #1a73e8; padding-left: 12px; }
+.badge { font-size: 11px; border: 1px solid #dadce0; border-radius: 8px; padding: 1px 6px; color: #5f6368; }
+.badge.sov { border-color: #1a73e8; color: #1a73e8; }
+.empty { color: #5f6368; }
+</style>


### PR DESCRIPTION
## What

The **socioprophet.ai** product surface: an agentic search page that blends the **web** and a **sovereign commons the web can't index**. It calls the public `search-gateway` (prophet-platform [#751](https://github.com/SocioProphet/prophet-platform/pull/751)), which fans one query out to SearXNG + commons-search and returns a blended, cited result set.

- **`services/searchApi.ts`** — read-only client for the gateway (`VITE_SEARCH_API`); **STUB mode** when unset so the surface renders standalone/local-first (the estate's own service pattern).
- **`views/Search.vue`** — hero search box → results grouped by source (**Community commons**, sovereign-badged, *leads* · **Web**), cited, with graceful-degradation notes and loading/empty/stub states.
- **router** — `/search` as a **public** route. You don't log in to search (login is for save/personalize later; north star = one estate-wide SSO).

## Lands the app-vue cutover

The live `firebase.json` `app` target served the **mocked `client-vue/dist`**; this points it at the **real `app-vue/dist`** and adds the `/api/**` → `builder-api` Cloud Run rewrite — the cutover the `_sp_vdt` snapshot already implied.

## Verification

`npm run build` (vue-tsc typecheck + vite) **clean** — the Search view compiles and bundles (`Search-*.js`). Renders in stub mode until `VITE_SEARCH_API` is set.

## Deploy discipline (per your call)

**Dev first** (`firebase deploy --only hosting:app --project dev`) for functional testing → **prod only on your explicit approval**. Still open: the **search-API hostname + DNS** (for the gateway's public ingress) and the missing **app-vue build/deploy GitHub Actions workflow**.

`.ai` = agentic search · `.com` = marketing. v0 blends the hosted engines; the hosted Fibered-Retrieval / GraphRAG layer swaps into the gateway when ready, UI unchanged.