### PR TITLE
feat(hosting): app-vue CI deploy (dev-first) + sovereign hosting scaffold

### DIFF
--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -1,0 +1,68 @@
+# app-vue deploy — builds the real app-vue SPA and deploys it to Firebase Hosting, DEV-FIRST.
+#
+# Closes the gap the deploy audit found: app-vue had NO build/deploy workflow (deploys were manual shell scripts).
+# Dev-vs-prod is the Firebase project alias (dev → socioprophet-web-dev-env, prod → socioprophet-web).
+#
+#   push to master (app-vue/firebase changes) → auto-deploy to DEV
+#   manual run (workflow_dispatch, environment=prod) → deploy to PROD, gated by the `production` GitHub
+#     Environment (add required reviewers there so prod needs an explicit human approval — "prod on my say-so").
+#
+# Required repo secret: FIREBASE_TOKEN (generate once with `firebase login:ci`). Nothing deploys without it.
+name: app-vue deploy
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'socioprophet-web/app-vue/**'
+      - 'firebase.json'
+      - '.firebaserc'
+      - '.github/workflows/app-vue-deploy.yml'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Firebase project alias to deploy'
+        required: true
+        default: dev
+        type: choice
+        options: [dev, prod]
+
+# Least privilege: only needs to read the repo + build.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20', cache: 'npm', cache-dependency-path: socioprophet-web/app-vue/package-lock.json }
+      - name: Build app-vue
+        working-directory: socioprophet-web/app-vue
+        run: |
+          npm ci
+          npm run build
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with: { name: app-vue-dist, path: socioprophet-web/app-vue/dist, retention-days: 3 }
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    # A push to master deploys dev; a manual run deploys the chosen alias. The `prod` alias runs under the
+    # `production` Environment so it inherits that Environment's protection rules (required reviewers).
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.environment == 'prod') && 'production' || 'development' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { name: app-vue-dist, path: socioprophet-web/app-vue/dist }
+      - name: Resolve alias
+        id: env
+        run: echo "alias=${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}" >> "$GITHUB_OUTPUT"
+      - name: Deploy to Firebase Hosting (app target)
+        uses: w9jds/firebase-action@v13.23.1
+        with:
+          args: deploy --only hosting:app --project ${{ steps.env.outputs.alias }}
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/deploy/sovereign/Dockerfile
+++ b/deploy/sovereign/Dockerfile
@@ -1,0 +1,18 @@
+# Sovereign hosting for app-vue — the Firebase-Hosting REPLACEMENT (GKE/nginx), mirroring the auth migration off
+# Firebase. SCAFFOLD: this is the sovereign dev/prod hosting path, staged now, NOT cut over until the Firebase v0
+# is validated. BUILD CONTEXT = repo root.
+FROM node:20-slim AS build
+WORKDIR /app
+COPY socioprophet-web/app-vue/package.json socioprophet-web/app-vue/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY socioprophet-web/app-vue ./
+# VITE_SEARCH_API (and other VITE_* bases) are baked at build time; pass via --build-arg per environment.
+ARG VITE_SEARCH_API=""
+ENV VITE_SEARCH_API=$VITE_SEARCH_API
+RUN npm run build   # → /app/dist
+
+FROM nginx:1.27-alpine
+# Non-root, port 8080 (matches the estate chart contract).
+COPY deploy/sovereign/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080

--- a/deploy/sovereign/README.md
+++ b/deploy/sovereign/README.md
@@ -1,0 +1,21 @@
+# Sovereign hosting for app-vue (Firebase-Hosting replacement)
+
+**Status: SCAFFOLD.** Staged now (parallel track), **not cut over** until the Firebase v0 of the `.ai` search
+surface is validated on dev. This is the sovereign equivalent of Firebase Hosting — the same migration story as
+auth moving off Firebase to socbase.
+
+## What it is
+- `Dockerfile` — multi-stage: `node` builds `socioprophet-web/app-vue` → `nginx:alpine` serves the static dist.
+  `VITE_*` bases (incl. `VITE_SEARCH_API`) are baked per environment via `--build-arg`.
+- `nginx.conf` — SPA fallback (`try_files … /index.html`, the Firebase `**→/index.html` equivalent), `/healthz`,
+  immutable asset caching, security headers. The Firebase `/api/**→builder-api` Cloud Run rewrite has an nginx
+  `proxy_pass` equivalent, held until cutover.
+- `k8s/base` + `k8s/overlays/{dev,prod}` — kustomize; **dev/prod mirror the Firebase project aliases**
+  (`dev`→`socioprophet-web-dev-env`, `prod`→`socioprophet-web`).
+
+## Cutover checklist (do NOT do until Firebase v0 is validated)
+1. Wire the image build (CI: build `Dockerfile`, push `registry.socioprophet.ai/app-vue-web:sha-<commit>`).
+2. Pin that sha in `k8s/base/deployment.yaml` (no moving tags).
+3. Add the Ingress + ManagedCertificate per overlay — **after** the DNS A record resolves (the cert's provisioning
+   clock starts at DNS visibility; creating it early poisons it into `FailedNotVisible`).
+4. Point `.ai` DNS at the sovereign ingress instead of Firebase, dev first.

--- a/deploy/sovereign/k8s/base/deployment.yaml
+++ b/deploy/sovereign/k8s/base/deployment.yaml
@@ -1,0 +1,32 @@
+# app-vue-web — nginx serving the app-vue SPA. SCAFFOLD (sovereign Firebase-Hosting replacement); not live until
+# cutover. Image is built from deploy/sovereign/Dockerfile by CI at cutover; tag pinned per the no-moving-tag rule.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-vue-web
+  labels: { app: app-vue-web }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: app-vue-web } }
+  template:
+    metadata: { labels: { app: app-vue-web } }
+    spec:
+      securityContext: { runAsNonRoot: true, runAsUser: 101, seccompProfile: { type: RuntimeDefault } }  # nginx uid
+      containers:
+        - name: nginx
+          image: registry.socioprophet.ai/app-vue-web:REPLACE_WITH_SHA_AT_CUTOVER
+          ports: [{ name: http, containerPort: 8080 }]
+          securityContext: { allowPrivilegeEscalation: false, readOnlyRootFilesystem: false, capabilities: { drop: ["ALL"] } }
+          readinessProbe: { httpGet: { path: /healthz, port: http }, initialDelaySeconds: 3, periodSeconds: 10 }
+          livenessProbe:  { httpGet: { path: /healthz, port: http }, initialDelaySeconds: 5, periodSeconds: 15 }
+          resources: { requests: { cpu: 20m, memory: 32Mi }, limits: { cpu: 200m, memory: 128Mi } }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-vue-web
+  labels: { app: app-vue-web }
+spec:
+  type: ClusterIP
+  selector: { app: app-vue-web }
+  ports: [{ name: http, port: 8080, targetPort: http }]

--- a/deploy/sovereign/k8s/base/kustomization.yaml
+++ b/deploy/sovereign/k8s/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml

--- a/deploy/sovereign/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/sovereign/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,8 @@
+# DEV overlay — mirrors the Firebase `dev` alias (project socioprophet-web-dev-env). Ingress host + cert added at
+# cutover (a ManagedCertificate's clock starts at DNS — never create it before the record exists).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet-dev
+resources:
+  - ../../base
+# nameSuffix: -dev   # enable when both envs share a cluster/namespace

--- a/deploy/sovereign/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/sovereign/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+# PROD overlay — mirrors the Firebase `prod` alias (project socioprophet-web). Cut over ONLY after dev is validated.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: socioprophet
+resources:
+  - ../../base
+replicas:
+  - { name: app-vue-web, count: 2 }

--- a/deploy/sovereign/nginx.conf
+++ b/deploy/sovereign/nginx.conf
@@ -1,0 +1,29 @@
+# nginx serving the app-vue SPA — the sovereign equivalent of Firebase Hosting's SPA rewrite (`** → /index.html`).
+server {
+  listen 8080;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # /healthz for the k8s probes (the chart contract).
+  location = /healthz { return 200 "ok\n"; add_header content-type text/plain; }
+
+  gzip on;
+  gzip_types text/css application/javascript application/json image/svg+xml;
+
+  # Hashed assets are immutable; cache hard.
+  location /assets/ { expires 1y; add_header cache-control "public, immutable"; try_files $uri =404; }
+
+  # SPA fallback — every non-file route serves index.html (Firebase `** → /index.html` equivalent).
+  location / {
+    try_files $uri $uri/ /index.html;
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+  }
+
+  # CUTOVER TODO (sovereign equivalent of the Firebase `/api/** → builder-api` Cloud Run rewrite): when this
+  # hosting goes live, proxy_pass /api/ to the in-cluster gateway/builder-api so same-origin API calls work here
+  # the way they do on Firebase. Held until cutover so the scaffold stays static-only.
+  # location /api/ { proxy_pass http://builder-api.socioprophet.svc.cluster.local:8080/; }
+}


### PR DESCRIPTION
Two deploy-track pieces for the **socioprophet.ai** surface.

## 1. app-vue CI deploy workflow
`.github/workflows/app-vue-deploy.yml` closes the gap the deploy audit found — app-vue had **no** build/deploy workflow (deploys were manual shell scripts).

- **Push to master** (app-vue/firebase changes) → auto-deploy to **DEV** (Firebase alias `dev` → `socioprophet-web-dev-env`).
- **Manual run** (`workflow_dispatch`, `environment=prod`) → deploy **PROD** under the `production` GitHub Environment → needs an explicit reviewer approval. **"Dev first, prod on your say-so."**
- Requires the `FIREBASE_TOKEN` repo secret (`firebase login:ci`). Nothing deploys without it.

## 2. Sovereign hosting scaffold
`deploy/sovereign/` — the Firebase-Hosting **replacement** (GKE/nginx), the same migration story as auth → socbase.

- Multi-stage `Dockerfile` (node builds app-vue → nginx serves the dist; `VITE_*` baked per env).
- `nginx.conf` — SPA fallback (the Firebase `**→/index.html` equivalent), `/healthz`, immutable asset caching, security headers.
- kustomize `base` + `overlays/{dev,prod}` **mirroring the Firebase project aliases**.

**SCAFFOLD** — staged now (the parallel track you greenlit), **not cut over** until the Firebase v0 is validated on dev. Cutover checklist (image build → sha pin → Ingress/ManagedCertificate **after** DNS → repoint DNS) is in the README.

Verified: kustomize dev + prod overlays build. `.ai` = agentic search · `.com` = marketing.