### PR TITLE
feat(search): wire live sovereign search edge into the .ai surface (dev)

### DIFF
--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -40,6 +40,12 @@ jobs:
         with: { node-version: '20', cache: 'npm', cache-dependency-path: socioprophet-web/app-vue/package-lock.json }
       - name: Build app-vue
         working-directory: socioprophet-web/app-vue
+        # VITE_SEARCH_API bakes the live sovereign search edge into the bundle (public URL, not a secret):
+        # search-api.socioprophet.ai → search-gateway → SearXNG (web) ⊕ commons-search (sovereign commons).
+        # Cert is Active and the endpoint serves real blended results. Studio API stays unset until its
+        # public ingress lands (renders in preview until then).
+        env:
+          VITE_SEARCH_API: https://search-api.socioprophet.ai
         run: |
           npm ci
           npm run build

--- a/socioprophet-web/app-vue/src/components/StudioGraph.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGraph.vue
@@ -1,35 +1,178 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from "vue";
-import { loadGraph, EPISTEMIC_COLORS, type GraphView, type GraphNode } from "../services/studioApi";
+import { ref, shallowRef, computed, onMounted, onBeforeUnmount, watch } from "vue";
+import { loadGraph, EPISTEMIC_COLORS, type GraphView, type GraphNode, type GraphEdge } from "../services/studioApi";
 
 const props = defineProps<{ project: string }>();
 const view = ref<GraphView | null>(null);
 const loading = ref(true);
 const error = ref("");
-const selected = ref<GraphNode | null>(null);
+const selected = ref<SimNode | null>(null);
+const hovered = ref<SimNode | null>(null);
+
+// ── the graph explorer: a real force-directed layout (Bostock's velocity-Verlet, hand-rolled — no
+// external lib) with Tufte layering — edges recede, epistemic-mode colour is the only ink that varies,
+// neighbourhood comes to focus on hover. Bloom colours by label; we colour by EPISTEMIC STATUS + carry
+// provenance per node. That's the moat, drawn on their own field.
+
+const VB_W = 900, VB_H = 560;                 // viewBox coordinate space (SVG scales responsively)
+interface SimNode extends GraphNode { x: number; y: number; vx: number; vy: number; fx: number | null; fy: number | null; deg: number; r: number }
+type SimEdge = { id: string; s: SimNode; t: SimNode; label: string; weight: number };
+
+const simNodes = shallowRef<SimNode[]>([]);
+const simEdges = shallowRef<SimEdge[]>([]);
+const frame = ref(0);                          // one reactive tick per rAF → template re-reads positions
+const transform = ref({ k: 1, x: 0, y: 0 });   // pan/zoom in viewBox units
+
+let raf = 0, alpha = 0;
+const adjacency = new Map<string, Set<string>>();
+
+function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS.unknown; }
+
+// ── build the simulation from a GraphView ─────────────────────────────────────
+function build(v: GraphView) {
+  const nodes: SimNode[] = v.nodes.map((n, i) => {
+    // seed on a circle (deterministic, avoids the degenerate all-at-centre start)
+    const a = (i / Math.max(1, v.nodes.length)) * Math.PI * 2;
+    return { ...n, x: VB_W / 2 + Math.cos(a) * 160, y: VB_H / 2 + Math.sin(a) * 160,
+             vx: 0, vy: 0, fx: null, fy: null, deg: 0, r: 6 };
+  });
+  const byId = new Map(nodes.map((n) => [n.id, n]));
+  const edges: SimEdge[] = [];
+  adjacency.clear();
+  for (const e of (v.edges ?? []) as GraphEdge[]) {
+    const s = byId.get(e.source), t = byId.get(e.target);
+    if (!s || !t) continue;                    // induced subgraph should prevent this, but be safe
+    edges.push({ id: e.id, s, t, label: e.label, weight: e.weight ?? 1 });
+    s.deg++; t.deg++;
+    (adjacency.get(s.id) ?? adjacency.set(s.id, new Set()).get(s.id)!).add(t.id);
+    (adjacency.get(t.id) ?? adjacency.set(t.id, new Set()).get(t.id)!).add(s.id);
+  }
+  for (const n of nodes) n.r = 5 + Math.sqrt(n.deg) * 3;   // radius encodes degree (Tufte: encode the data)
+  simNodes.value = nodes; simEdges.value = edges;
+  reheat();
+}
+
+// ── force tick: charge (repulsion) + links (springs) + gravity + light collision ──
+const L = 92, CHARGE = -520, LINK_K = 0.45, GRAV = 0.028, VDECAY = 0.62;
+function tick() {
+  const ns = simNodes.value, es = simEdges.value;
+  const n = ns.length;
+  // many-body repulsion (O(n²) — fine to a few hundred nodes)
+  for (let i = 0; i < n; i++) {
+    const a = ns[i];
+    for (let j = i + 1; j < n; j++) {
+      const b = ns[j];
+      let dx = a.x - b.x, dy = a.y - b.y, d2 = dx * dx + dy * dy || 1;
+      const f = (CHARGE * alpha) / d2;
+      const d = Math.sqrt(d2); dx /= d; dy /= d;
+      a.vx -= dx * f; a.vy -= dy * f; b.vx += dx * f; b.vy += dy * f;
+      // light collision so labels don't stack
+      const min = a.r + b.r + 6;
+      if (d < min) { const push = (min - d) / d * 0.5 * alpha * 6; a.vx += dx * push; a.vy += dy * push; b.vx -= dx * push; b.vy -= dy * push; }
+    }
+  }
+  // link springs
+  for (const e of es) {
+    let dx = e.t.x - e.s.x, dy = e.t.y - e.s.y, d = Math.hypot(dx, dy) || 1;
+    const f = ((d - L) / d) * LINK_K * alpha;
+    dx *= f; dy *= f;
+    e.s.vx += dx; e.s.vy += dy; e.t.vx -= dx; e.t.vy -= dy;
+  }
+  // centering gravity + integrate
+  for (const p of ns) {
+    p.vx += (VB_W / 2 - p.x) * GRAV * alpha;
+    p.vy += (VB_H / 2 - p.y) * GRAV * alpha;
+    if (p.fx != null) { p.x = p.fx; p.vx = 0; } else { p.vx *= VDECAY; p.x += p.vx; }
+    if (p.fy != null) { p.y = p.fy; p.vy = 0; } else { p.vy *= VDECAY; p.y += p.vy; }
+  }
+  alpha *= 0.985;
+}
+function loop() {
+  tick(); frame.value++;
+  if (alpha > 0.02) raf = requestAnimationFrame(loop); else raf = 0;
+}
+function reheat() { alpha = Math.max(alpha, 0.9); if (!raf) raf = requestAnimationFrame(loop); }
+
+// ── pointer: drag nodes, pan/zoom the field ───────────────────────────────────
+const svgEl = ref<SVGSVGElement | null>(null);
+let dragNode: SimNode | null = null, panning = false, panStart = { x: 0, y: 0, tx: 0, ty: 0 };
+
+function toViewBox(clientX: number, clientY: number) {
+  const svg = svgEl.value!; const r = svg.getBoundingClientRect();
+  return { x: ((clientX - r.left) / r.width) * VB_W, y: ((clientY - r.top) / r.height) * VB_H };
+}
+function toGraph(clientX: number, clientY: number) {
+  const vb = toViewBox(clientX, clientY); const t = transform.value;
+  return { x: (vb.x - t.x) / t.k, y: (vb.y - t.y) / t.k };
+}
+function onNodeDown(n: SimNode, ev: PointerEvent) {
+  ev.stopPropagation(); dragNode = n; n.fx = n.x; n.fy = n.y; reheat();
+  (ev.target as Element).setPointerCapture?.(ev.pointerId);
+}
+function onBgDown(ev: PointerEvent) {
+  panning = true; panStart = { x: ev.clientX, y: ev.clientY, tx: transform.value.x, ty: transform.value.y };
+}
+function onMove(ev: PointerEvent) {
+  if (dragNode) { const g = toGraph(ev.clientX, ev.clientY); dragNode.fx = g.x; dragNode.fy = g.y; reheat(); }
+  else if (panning) {
+    const svg = svgEl.value!; const r = svg.getBoundingClientRect();
+    transform.value = { ...transform.value,
+      x: panStart.tx + ((ev.clientX - panStart.x) / r.width) * VB_W,
+      y: panStart.ty + ((ev.clientY - panStart.y) / r.height) * VB_H };
+  }
+}
+function onUp() { if (dragNode) { dragNode.fx = null; dragNode.fy = null; dragNode = null; } panning = false; }
+function onWheel(ev: WheelEvent) {
+  ev.preventDefault();
+  const vb = toViewBox(ev.clientX, ev.clientY); const t = transform.value;
+  const k = Math.min(4, Math.max(0.3, t.k * (ev.deltaY < 0 ? 1.12 : 1 / 1.12)));
+  // keep the point under the cursor fixed while zooming (Bostock zoom-to-cursor)
+  transform.value = { k, x: vb.x - ((vb.x - t.x) / t.k) * k, y: vb.y - ((vb.y - t.y) / t.k) * k };
+}
+function resetView() { transform.value = { k: 1, x: 0, y: 0 }; reheat(); }
+
+// ── focus: hovered node + its neighbourhood come forward, the rest recede (Tufte layering) ──
+const focusId = computed(() => hovered.value?.id ?? selected.value?.id ?? null);
+function nodeDim(n: SimNode) {
+  const f = focusId.value; if (!f) return false;
+  return n.id !== f && !adjacency.get(f)?.has(n.id);
+}
+function edgeDim(e: SimEdge) {
+  const f = focusId.value; if (!f) return false;
+  return e.s.id !== f && e.t.id !== f;
+}
+const showLabels = computed(() => (simNodes.value.length <= 40) || transform.value.k > 1.4);
+
+// ── data readouts (Tufte: the distribution is a dense strip, not chartjunk) ──
+const dist = computed(() => Object.entries(view.value?.epistemic_distribution ?? {}).sort((a, b) => b[1] - a[1]));
+const total = computed(() => view.value?.count ?? 0);
+const edgeTotal = computed(() => view.value?.edge_count ?? view.value?.edges?.length ?? 0);
 
 async function load() {
-  loading.value = true; error.value = "";
-  try { view.value = await loadGraph(props.project); }
+  loading.value = true; error.value = ""; selected.value = null; hovered.value = null;
+  try { const v = await loadGraph(props.project); view.value = v; build(v); }
   catch (e) { error.value = e instanceof Error ? e.message : "failed to load graph"; }
   finally { loading.value = false; }
 }
 onMounted(load);
 watch(() => props.project, load);
+onBeforeUnmount(() => { if (raf) cancelAnimationFrame(raf); });
 
-const dist = computed(() => Object.entries(view.value?.epistemic_distribution ?? {}).sort((a, b) => b[1] - a[1]));
-const total = computed(() => view.value?.count ?? 0);
-function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS.unknown; }
+// stroke width encodes edge weight (Tufte: encode the datum, keep it thin so edges recede)
+function edgeW(e: SimEdge) { return Math.min(4, 0.8 + Math.sqrt(e.weight)); }
 </script>
 
 <template>
   <div class="ge">
     <header class="ge-head">
       <div>
-        <h2>⧉ Knowledge graph <span class="cnt">{{ total }} nodes</span></h2>
-        <p class="sub">Every node carries its <b>epistemic status</b> and <b>provenance</b> — what a graph explorer shows that Bloom can't.</p>
+        <h2>⧉ Knowledge graph <span class="cnt">{{ total }} nodes · {{ edgeTotal }} edges</span></h2>
+        <p class="sub">A force-directed explorer where every node carries its <b>epistemic status</b> and <b>provenance</b> — what a graph explorer shows that Neo4j Bloom can't.</p>
       </div>
-      <button class="refresh" @click="load" :disabled="loading">↻</button>
+      <div class="tools">
+        <button class="tbtn" @click="resetView" title="reset pan/zoom">⤢</button>
+        <button class="tbtn" @click="load" :disabled="loading" title="reload">↻</button>
+      </div>
     </header>
 
     <!-- epistemic distribution — the governance readout no incumbent surfaces -->
@@ -42,17 +185,34 @@ function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS
       </div>
     </div>
 
-    <p v-if="view?.stub" class="note">Preview — sample provenance nodes. Live once VITE_STUDIO_API is wired.</p>
+    <p v-if="view?.stub" class="note">Preview — sample provenance graph. Live once VITE_STUDIO_API is wired.</p>
     <p v-if="loading" class="msg">Loading graph…</p>
     <p v-else-if="error" class="msg err">{{ error }}</p>
     <p v-else-if="!total" class="msg">Graph is empty for this project. Run an extraction to populate it (Extraction → Run).</p>
 
-    <div v-else class="cloud">
-      <button v-for="n in view!.nodes" :key="n.id" class="node" :class="{ sel: selected?.id === n.id }"
-              :style="{ borderColor: color(n.epistemic_mode), color: color(n.epistemic_mode) }"
-              @click="selected = n" :title="n.epistemic_mode">
-        <span class="dot" :style="{ background: color(n.epistemic_mode) }" />{{ n.name }}
-      </button>
+    <div v-else class="canvas-wrap">
+      <svg ref="svgEl" class="canvas" :viewBox="`0 0 ${VB_W} ${VB_H}`" @pointerdown="onBgDown"
+           @pointermove="onMove" @pointerup="onUp" @pointerleave="onUp" @wheel="onWheel">
+        <g :transform="`translate(${transform.x},${transform.y}) scale(${transform.k})`" :data-frame="frame">
+          <!-- edges recede (thin, muted); dim out of focus -->
+          <g class="edges" stroke-linecap="round">
+            <line v-for="e in simEdges" :key="e.id" :x1="e.s.x" :y1="e.s.y" :x2="e.t.x" :y2="e.t.y"
+                  :stroke-width="edgeW(e)" :class="{ dim: edgeDim(e) }" />
+          </g>
+          <!-- nodes: fill = epistemic mode (the ink that carries meaning), radius = degree -->
+          <g class="nodes">
+            <g v-for="n in simNodes" :key="n.id" :class="{ dim: nodeDim(n), sel: selected?.id === n.id }"
+               :transform="`translate(${n.x},${n.y})`" @pointerdown="onNodeDown(n, $event)"
+               @pointerenter="hovered = n" @pointerleave="hovered = null" @click.stop="selected = n">
+              <circle :r="n.r" :fill="color(n.epistemic_mode)"
+                      :stroke="selected?.id === n.id ? '#202124' : '#fff'" :stroke-width="selected?.id === n.id ? 2 : 1.2" />
+              <text v-if="showLabels || hovered?.id === n.id || selected?.id === n.id"
+                    :x="n.r + 4" y="4" class="lbl">{{ n.name }}</text>
+            </g>
+          </g>
+        </g>
+      </svg>
+      <div class="hint">drag nodes · scroll to zoom · drag background to pan</div>
     </div>
 
     <transition name="slide">
@@ -62,6 +222,7 @@ function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS
         <h3>{{ selected.name }}</h3>
         <dl>
           <div><dt>epistemic mode</dt><dd><span class="pill" :style="{ borderColor: color(selected.epistemic_mode), color: color(selected.epistemic_mode) }">{{ selected.epistemic_mode }}</span></dd></div>
+          <div><dt>degree</dt><dd>{{ selected.deg }} edge(s)</dd></div>
           <div v-if="selected.source"><dt>source</dt><dd>{{ selected.source }}</dd></div>
           <div v-if="selected.extractor"><dt>extractor</dt><dd>{{ selected.extractor }}</dd></div>
           <div><dt>labels</dt><dd>{{ selected.labels.join(", ") }}</dd></div>
@@ -77,25 +238,32 @@ function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS
 .ge { font: 14px/1.5 system-ui, sans-serif; color: #202124; position: relative; }
 .ge-head { display: flex; justify-content: space-between; align-items: flex-start; }
 .ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: #5f6368; font-weight: 400; }
-.ge-head .sub { color: #5f6368; margin: 4px 0 12px; max-width: 620px; } .ge-head .sub b { color: #202124; }
-.refresh { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.ge-head .sub { color: #5f6368; margin: 4px 0 12px; max-width: 640px; } .ge-head .sub b { color: #202124; }
+.tools { display: flex; gap: 6px; }
+.tbtn { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
+.tbtn:hover { background: #f8f9fa; }
 
-.dist { margin: 4px 0 16px; }
+.dist { margin: 4px 0 12px; }
 .dist .bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: #eceff1; }
 .dist .bar span { display: block; }
 .dist .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 12px; color: #5f6368; }
 .dist .lg i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 4px; vertical-align: middle; }
 
-.cloud { display: flex; flex-wrap: wrap; gap: 8px; }
-.node { display: inline-flex; align-items: center; gap: 6px; border: 1.5px solid; background: #fff; border-radius: 18px; padding: 5px 13px; font-size: 13px; font-weight: 500; cursor: pointer; transition: box-shadow .12s; }
-.node:hover { box-shadow: 0 1px 6px rgba(60,64,67,.18); }
-.node.sel { box-shadow: 0 0 0 2px currentColor; }
-.node .dot { width: 8px; height: 8px; border-radius: 50%; }
+.canvas-wrap { position: relative; border: 1px solid #e8eaed; border-radius: 12px; background:
+  radial-gradient(circle at 1px 1px, #f1f3f4 1px, transparent 0) 0 0 / 22px 22px, #fff; overflow: hidden; }
+.canvas { display: block; width: 100%; height: 560px; touch-action: none; cursor: grab; }
+.canvas:active { cursor: grabbing; }
+.edges line { stroke: #c4cad1; transition: opacity .15s; }
+.edges line.dim { opacity: .12; }
+.nodes g { cursor: pointer; transition: opacity .15s; }
+.nodes g.dim { opacity: .18; }
+.nodes .lbl { font: 500 11px/1 system-ui, sans-serif; fill: #202124; paint-order: stroke; stroke: #fff; stroke-width: 3px; stroke-linejoin: round; pointer-events: none; }
+.hint { position: absolute; bottom: 8px; left: 10px; font-size: 11px; color: #9aa0a6; pointer-events: none; }
 
 .note { font-size: 12px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 6px 10px; margin: 0 0 12px; }
 .msg { color: #5f6368; } .msg.err { color: #c5221f; }
 
-.prov { position: absolute; top: 0; right: 0; width: 300px; background: #fff; border: 1px solid #e8eaed; border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
+.prov { position: absolute; top: 74px; right: 8px; width: 300px; background: #fff; border: 1px solid #e8eaed; border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
 .prov .x { position: absolute; top: 10px; right: 12px; border: none; background: none; cursor: pointer; color: #5f6368; }
 .prov .pk { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: #5f6368; }
 .prov h3 { margin: 4px 0 12px; font-size: 17px; }

--- a/socioprophet-web/app-vue/src/components/StudioGraph.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGraph.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from "vue";
+import { loadGraph, EPISTEMIC_COLORS, type GraphView, type GraphNode } from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+const view = ref<GraphView | null>(null);
+const loading = ref(true);
+const error = ref("");
+const selected = ref<GraphNode | null>(null);
+
+async function load() {
+  loading.value = true; error.value = "";
+  try { view.value = await loadGraph(props.project); }
+  catch (e) { error.value = e instanceof Error ? e.message : "failed to load graph"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+const dist = computed(() => Object.entries(view.value?.epistemic_distribution ?? {}).sort((a, b) => b[1] - a[1]));
+const total = computed(() => view.value?.count ?? 0);
+function color(mode: string) { return EPISTEMIC_COLORS[mode] ?? EPISTEMIC_COLORS.unknown; }
+</script>
+
+<template>
+  <div class="ge">
+    <header class="ge-head">
+      <div>
+        <h2>⧉ Knowledge graph <span class="cnt">{{ total }} nodes</span></h2>
+        <p class="sub">Every node carries its <b>epistemic status</b> and <b>provenance</b> — what a graph explorer shows that Bloom can't.</p>
+      </div>
+      <button class="refresh" @click="load" :disabled="loading">↻</button>
+    </header>
+
+    <!-- epistemic distribution — the governance readout no incumbent surfaces -->
+    <div v-if="total" class="dist">
+      <div class="bar">
+        <span v-for="[mode, n] in dist" :key="mode" :style="{ width: (n / total * 100) + '%', background: color(mode) }" :title="`${mode}: ${n}`" />
+      </div>
+      <div class="legend">
+        <span v-for="[mode, n] in dist" :key="mode" class="lg"><i :style="{ background: color(mode) }" /> {{ mode }} · {{ n }}</span>
+      </div>
+    </div>
+
+    <p v-if="view?.stub" class="note">Preview — sample provenance nodes. Live once VITE_STUDIO_API is wired.</p>
+    <p v-if="loading" class="msg">Loading graph…</p>
+    <p v-else-if="error" class="msg err">{{ error }}</p>
+    <p v-else-if="!total" class="msg">Graph is empty for this project. Run an extraction to populate it (Extraction → Run).</p>
+
+    <div v-else class="cloud">
+      <button v-for="n in view!.nodes" :key="n.id" class="node" :class="{ sel: selected?.id === n.id }"
+              :style="{ borderColor: color(n.epistemic_mode), color: color(n.epistemic_mode) }"
+              @click="selected = n" :title="n.epistemic_mode">
+        <span class="dot" :style="{ background: color(n.epistemic_mode) }" />{{ n.name }}
+      </button>
+    </div>
+
+    <transition name="slide">
+      <aside v-if="selected" class="prov">
+        <button class="x" @click="selected = null">✕</button>
+        <div class="pk">Node</div>
+        <h3>{{ selected.name }}</h3>
+        <dl>
+          <div><dt>epistemic mode</dt><dd><span class="pill" :style="{ borderColor: color(selected.epistemic_mode), color: color(selected.epistemic_mode) }">{{ selected.epistemic_mode }}</span></dd></div>
+          <div v-if="selected.source"><dt>source</dt><dd>{{ selected.source }}</dd></div>
+          <div v-if="selected.extractor"><dt>extractor</dt><dd>{{ selected.extractor }}</dd></div>
+          <div><dt>labels</dt><dd>{{ selected.labels.join(", ") }}</dd></div>
+          <div><dt>atom id</dt><dd class="mono">{{ selected.id }}</dd></div>
+        </dl>
+        <div class="acts"><button class="primary" title="replay how this fact was derived (KE-5)">How derived?</button><button title="agents in this project already retrieve this">Share to team</button></div>
+      </aside>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.ge { font: 14px/1.5 system-ui, sans-serif; color: #202124; position: relative; }
+.ge-head { display: flex; justify-content: space-between; align-items: flex-start; }
+.ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: #5f6368; font-weight: 400; }
+.ge-head .sub { color: #5f6368; margin: 4px 0 12px; max-width: 620px; } .ge-head .sub b { color: #202124; }
+.refresh { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+
+.dist { margin: 4px 0 16px; }
+.dist .bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: #eceff1; }
+.dist .bar span { display: block; }
+.dist .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 12px; color: #5f6368; }
+.dist .lg i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 4px; vertical-align: middle; }
+
+.cloud { display: flex; flex-wrap: wrap; gap: 8px; }
+.node { display: inline-flex; align-items: center; gap: 6px; border: 1.5px solid; background: #fff; border-radius: 18px; padding: 5px 13px; font-size: 13px; font-weight: 500; cursor: pointer; transition: box-shadow .12s; }
+.node:hover { box-shadow: 0 1px 6px rgba(60,64,67,.18); }
+.node.sel { box-shadow: 0 0 0 2px currentColor; }
+.node .dot { width: 8px; height: 8px; border-radius: 50%; }
+
+.note { font-size: 12px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 6px 10px; margin: 0 0 12px; }
+.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+
+.prov { position: absolute; top: 0; right: 0; width: 300px; background: #fff; border: 1px solid #e8eaed; border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
+.prov .x { position: absolute; top: 10px; right: 12px; border: none; background: none; cursor: pointer; color: #5f6368; }
+.prov .pk { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: #5f6368; }
+.prov h3 { margin: 4px 0 12px; font-size: 17px; }
+.prov dl { margin: 0; } .prov dl > div { display: flex; gap: 10px; padding: 5px 0; border-bottom: 1px solid #f1f3f4; }
+.prov dt { color: #5f6368; min-width: 96px; font-size: 12px; } .prov dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+.prov .mono { font-family: ui-monospace, monospace; font-size: 11px; }
+.prov .pill { border: 1.5px solid; border-radius: 8px; padding: 0 8px; font-size: 12px; font-weight: 600; }
+.prov .acts { display: flex; gap: 8px; margin-top: 14px; }
+.prov .acts button { border: 1px solid #dadce0; background: #fff; border-radius: 16px; padding: 5px 12px; font-size: 12px; cursor: pointer; }
+.prov .acts button.primary { background: #1a73e8; color: #fff; border-color: #1a73e8; }
+.slide-enter-active, .slide-leave-active { transition: transform .18s, opacity .18s; }
+.slide-enter-from, .slide-leave-to { transform: translateX(16px); opacity: 0; }
+</style>

--- a/socioprophet-web/app-vue/src/router.ts
+++ b/socioprophet-web/app-vue/src/router.ts
@@ -16,6 +16,9 @@ const routes = [
   { path: "/cloud", component: () => import("./views/Cloud.vue") },
   { path: "/code", component: () => import("./views/Code.vue") },
   { path: "/market", component: () => import("./views/Market.vue") },
+  // Lattice Studio — the integrated workbench (notebooks · data + model catalogs · tuning · reproducible
+  // experiments), project-scoped so an agent team retrieves what's here. Authenticated.
+  { path: "/studio", component: () => import("./views/Studio.vue") },
 ];
 
 export const router = createRouter({ history: createWebHistory(), routes });

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -1,48 +1,69 @@
-// studioApi — the client for the Lattice Studio product surface (notebooks + data catalog + model catalog +
-// tuning + experiments), the integrated Watson-Studio-class plane. Calls the studio BFF, which fronts the deployed
-// Tier-9 fabric (lattice-studio notebooks, prophet-core-catalog, model-zoo-api, tritfabric/Ray, governance-ledger).
-// VITE_STUDIO_API unset → STUB mode so the surface renders standalone until the BFF is wired. Everything is
-// PROJECT-SCOPED: a projectId (Noetica proj- collection) threads through so notebooks/data/models/experiments all
-// live in the same knowledge scope an agent team already retrieves.
+// studioApi — client for the Lattice Studio product surface (notebooks + data catalog + model catalog + tuning +
+// reproducible experiments), the integrated Watson-Studio-class plane. Calls the studio BFF, which fronts the
+// deployed Tier-9 fabric (lattice-studio notebooks, prophet-core-catalog, model-zoo-api, tritfabric/Ray,
+// governance-ledger). VITE_STUDIO_API unset → STUB mode so the surface renders standalone until the BFF is wired.
+// Everything is PROJECT-SCOPED: a projectId (Noetica proj- collection) threads through so notebooks/data/models/
+// experiments live in the same knowledge scope an agent team already retrieves.
 
 const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
 
 export type StudioSection = "notebooks" | "data" | "models" | "tuning" | "experiments";
 
-export interface Notebook { id: string; name: string; runtime: string; status: "idle" | "running" | "stopped"; updatedAt: string; kernel?: string }
-export interface DataAsset { id: string; name: string; kind: string; rows?: number; catalog: string; governed: boolean }
-export interface ModelCard { id: string; name: string; task: string; stage: "candidate" | "staged" | "promoted"; metric?: string }
-export interface TuningRun { id: string; name: string; method: "lora" | "sae" | "circuit-probe" | "full"; status: "queued" | "running" | "done" | "failed"; backend: string }
-export interface Experiment { id: string; title: string; reproducible: boolean; provenance: string; createdAt: string }
+export interface Notebook {
+  id: string; name: string; runtime: string; kernel: string;
+  status: "idle" | "running" | "stopped"; updatedAt: string;
+  cells: number; collaborators: string[]; lastCell?: string;
+}
+export interface DataAsset {
+  id: string; name: string; kind: "table" | "dataset" | "stream"; catalog: string; governed: boolean;
+  rows?: number; columns?: number; schema?: { name: string; type: string }[]; lineage?: string[];
+}
+export interface ModelCard {
+  id: string; name: string; task: string; stage: "candidate" | "staged" | "promoted";
+  metrics?: { name: string; value: number; unit?: string }[]; base?: string; lineage?: string[]; servable?: boolean;
+}
+export interface TuningRun {
+  id: string; name: string; method: "lora" | "sae" | "circuit-probe" | "full"; backend: string;
+  status: "queued" | "running" | "done" | "failed"; progress?: number; metric?: { name: string; value: number };
+  target?: string;
+}
+export interface Experiment {
+  id: string; title: string; reproducible: boolean; provenance: string; createdAt: string;
+  steps?: { label: string; hash: string }[]; rerunnable?: boolean;
+}
 
 export interface StudioBundle {
-  notebooks: Notebook[];
-  data: DataAsset[];
-  models: ModelCard[];
-  tuning: TuningRun[];
-  experiments: Experiment[];
+  notebooks: Notebook[]; data: DataAsset[]; models: ModelCard[]; tuning: TuningRun[]; experiments: Experiment[];
   stub?: boolean;
 }
 
+export const SECTION_COUNT = (b: StudioBundle | null, s: StudioSection): number => (b ? (b[s]?.length ?? 0) : 0);
+
+const now = () => new Date().toISOString();
 const STUB: StudioBundle = {
   notebooks: [
-    { id: "nb-1", name: "Exploratory analysis.ipynb", runtime: "prophet-python-ml", status: "idle", updatedAt: new Date().toISOString(), kernel: "python3" },
-    { id: "nb-2", name: "LoRA fine-tune.ipynb", runtime: "prophet-ray-ml", status: "running", updatedAt: new Date().toISOString(), kernel: "ray" },
+    { id: "nb-1", name: "Exploratory analysis", runtime: "prophet-python-ml", kernel: "python3", status: "idle", updatedAt: now(), cells: 24, collaborators: ["you", "analyst-agent"], lastCell: "df.groupby('cohort').agg(...)" },
+    { id: "nb-2", name: "LoRA fine-tune", runtime: "prophet-ray-ml", kernel: "ray", status: "running", updatedAt: now(), cells: 11, collaborators: ["you"], lastCell: "trainer.fit(ray_dataset)" },
+    { id: "nb-3", name: "SAE feature atlas", runtime: "prophet-ray-ml", kernel: "ray", status: "idle", updatedAt: now(), cells: 38, collaborators: ["you", "researcher-agent"], lastCell: "atlas.plot_features(layer=12)" },
   ],
   data: [
-    { id: "da-1", name: "customer_events", kind: "table", rows: 1_240_000, catalog: "prophet-core-catalog", governed: true },
-    { id: "da-2", name: "corpus_v3", kind: "dataset", catalog: "prophet-core-catalog", governed: true },
+    { id: "da-1", name: "customer_events", kind: "table", catalog: "prophet-core-catalog", governed: true, rows: 1_240_000, columns: 18, schema: [{ name: "event_id", type: "uuid" }, { name: "ts", type: "timestamp" }, { name: "cohort", type: "string" }], lineage: ["ingest→dbt→catalog"] },
+    { id: "da-2", name: "corpus_v3", kind: "dataset", catalog: "prophet-core-catalog", governed: true, rows: 890_000, lineage: ["scrape→dedupe→redact→catalog"] },
+    { id: "da-3", name: "telemetry_stream", kind: "stream", catalog: "prophet-core-catalog", governed: false },
   ],
   models: [
-    { id: "m-1", name: "prophet-7b-lora", task: "chat", stage: "staged", metric: "MMLU 64.2" },
-    { id: "m-2", name: "sae-residual-l12", task: "interpretability", stage: "candidate" },
+    { id: "m-1", name: "prophet-7b-lora", task: "chat", stage: "staged", base: "prophet-7b", servable: true, metrics: [{ name: "MMLU", value: 64.2 }, { name: "win-rate", value: 0.58 }], lineage: ["prophet-7b→lora(nb-2)→zoo"] },
+    { id: "m-2", name: "sae-residual-l12", task: "interpretability", stage: "candidate", base: "prophet-7b", metrics: [{ name: "L0", value: 41 }, { name: "recon", value: 0.92 }], lineage: ["prophet-7b→sae(t-1)"] },
+    { id: "m-3", name: "prophet-7b", task: "chat", stage: "promoted", servable: true, metrics: [{ name: "MMLU", value: 61.0 }] },
   ],
   tuning: [
-    { id: "t-1", name: "SAE on residual stream L12", method: "sae", status: "running", backend: "tritfabric/ray" },
-    { id: "t-2", name: "Circuit probe — induction heads", method: "circuit-probe", status: "queued", backend: "tritfabric/ray" },
+    { id: "t-1", name: "SAE on residual stream L12", method: "sae", backend: "tritfabric/ray", status: "running", progress: 0.62, metric: { name: "recon", value: 0.92 }, target: "prophet-7b" },
+    { id: "t-2", name: "Circuit probe — induction heads", method: "circuit-probe", backend: "tritfabric/ray", status: "queued", target: "prophet-7b" },
+    { id: "t-3", name: "LoRA — support tone", method: "lora", backend: "tritfabric/ray", status: "done", progress: 1, metric: { name: "loss", value: 0.31 }, target: "prophet-7b" },
   ],
   experiments: [
-    { id: "e-1", title: "Reproduce: LoRA vs full FT", reproducible: true, provenance: "in-toto + lockfile", createdAt: new Date().toISOString() },
+    { id: "e-1", title: "LoRA vs full fine-tune", reproducible: true, provenance: "in-toto + conda-lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:9a1…" }, { label: "data", hash: "sha256:c4f…" }, { label: "code", hash: "sha256:2e8…" }] },
+    { id: "e-2", title: "SAE sparsity sweep", reproducible: true, provenance: "in-toto + flake.lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:77b…" }, { label: "params", hash: "sha256:1d3…" }] },
   ],
   stub: true,
 };

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -116,6 +116,40 @@ const STUB: StudioBundle = {
   stub: true,
 };
 
+// ── KE-2: the project sub-graph with PROVENANCE per node (the differentiator) ──
+export interface GraphNode { id: string; name: string; epistemic_mode: string; source?: string; extractor?: string; labels: string[] }
+export interface GraphView {
+  project: string; projectCollection: string;
+  nodes: GraphNode[]; count: number; epistemic_distribution: Record<string, number>;
+  degraded?: string | null; stub?: boolean;
+}
+
+// Epistemic-mode → colour (the ladder hypothesis→…→attested). This colouring IS the feature: Bloom shows topology,
+// we show epistemic status per node.
+export const EPISTEMIC_COLORS: Record<string, string> = {
+  hypothesis: "#9aa0a6", observed: "#1a73e8", derived: "#8b5cf6",
+  verified: "#137333", attested: "#00897b", simulated: "#b06000", unknown: "#c0c4c9",
+};
+
+const STUB_GRAPH: GraphView = {
+  project: "demo", projectCollection: "proj-demo",
+  nodes: [
+    { id: "proj-demo:ent:hellgraph", name: "HellGraph", epistemic_mode: "verified", source: "doc:spec", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:neo4j", name: "Neo4j", epistemic_mode: "observed", source: "doc:demo", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:anzo", name: "Anzo", epistemic_mode: "observed", source: "doc:demo", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:sae", name: "SAE feature", epistemic_mode: "derived", source: "notebook:nb-3", extractor: "superconscious", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:claim", name: "Contradiction claim", epistemic_mode: "hypothesis", source: "holmes", extractor: "holmes", labels: ["proj-demo", "Entity"] },
+  ],
+  count: 5, epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, stub: true,
+};
+
+export async function loadGraph(project: string): Promise<GraphView> {
+  if (!BASE) return STUB_GRAPH;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/graph?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`graph load failed: ${res.status}`);
+  return (await res.json()) as GraphView;
+}
+
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {
   if (!BASE) return STUB;
   const q = projectId ? `?project=${encodeURIComponent(projectId)}` : "";

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -7,7 +7,9 @@
 
 const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
 
-export type StudioSection = "notebooks" | "data" | "models" | "tuning" | "experiments";
+export type StudioSection =
+  | "notebooks" | "data" | "models" | "tuning" | "experiments"          // Workbench
+  | "extraction" | "ontology" | "graph" | "retrieval" | "generation";   // Knowledge engineering
 
 export interface Notebook {
   id: string; name: string; runtime: string; kernel: string;
@@ -32,8 +34,28 @@ export interface Experiment {
   steps?: { label: string; hash: string }[]; rerunnable?: boolean;
 }
 
+// ── Knowledge engineering — extraction → ontology → graph → retrieval → generation ──
+export interface ExtractionSource {
+  id: string; name: string; engine: "holmes" | "sherlock" | "doc-ingest"; kind: string;
+  status: "idle" | "running" | "done"; extracted?: number; target: string; // → graph
+}
+export interface OntologyItem {
+  id: string; name: string; kind: "class" | "relation" | "axiom" | "alignment"; engine: "ontogenesis";
+  count?: number; aligned?: boolean;
+}
+export interface GraphStat { id: string; label: string; value: number | string; hint?: string }
+export interface RetrievalIndex {
+  id: string; name: string; method: "fiber" | "graph-rag" | "topic" | "vector" | "lexical";
+  engine: "fibered-retrieval" | "slash-topics" | "hellgraph" | "noetica"; scope: string; ready: boolean;
+}
+export interface GenerationRun {
+  id: string; name: string; engine: "new-hope"; kind: "synthesis" | "generation-tuning" | "distillation";
+  status: "queued" | "running" | "done" | "failed"; grounded?: boolean; output?: string;
+}
+
 export interface StudioBundle {
   notebooks: Notebook[]; data: DataAsset[]; models: ModelCard[]; tuning: TuningRun[]; experiments: Experiment[];
+  extraction: ExtractionSource[]; ontology: OntologyItem[]; graph: GraphStat[]; retrieval: RetrievalIndex[]; generation: GenerationRun[];
   stub?: boolean;
 }
 
@@ -64,6 +86,32 @@ const STUB: StudioBundle = {
   experiments: [
     { id: "e-1", title: "LoRA vs full fine-tune", reproducible: true, provenance: "in-toto + conda-lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:9a1…" }, { label: "data", hash: "sha256:c4f…" }, { label: "code", hash: "sha256:2e8…" }] },
     { id: "e-2", title: "SAE sparsity sweep", reproducible: true, provenance: "in-toto + flake.lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:77b…" }, { label: "params", hash: "sha256:1d3…" }] },
+  ],
+  extraction: [
+    { id: "x-1", name: "Entity & relation extraction — corpus_v3", engine: "holmes", kind: "entities+relations", status: "running", extracted: 48210, target: "project graph" },
+    { id: "x-2", name: "Federated retrieval → facts", engine: "sherlock", kind: "federated search", status: "idle", target: "project graph" },
+    { id: "x-3", name: "Doc ingest — governed", engine: "doc-ingest", kind: "chunks+claims", status: "done", extracted: 12904, target: "proj- collection" },
+  ],
+  ontology: [
+    { id: "o-1", name: "Domain ontology", kind: "class", engine: "ontogenesis", count: 342, aligned: true },
+    { id: "o-2", name: "Relations", kind: "relation", engine: "ontogenesis", count: 118, aligned: true },
+    { id: "o-3", name: "KKO ⇄ project alignment", kind: "alignment", engine: "ontogenesis", aligned: true },
+  ],
+  graph: [
+    { id: "g-1", label: "Entities", value: 61240, hint: "canonical entities in the project graph" },
+    { id: "g-2", label: "Relations", value: 148900 },
+    { id: "g-3", label: "Documents grounded", value: 12904 },
+    { id: "g-4", label: "Engine", value: "HellGraph", hint: "gremlin / sparql over :8090" },
+  ],
+  retrieval: [
+    { id: "r-1", name: "Fibered retrieval (PageIndex ⊕ HellGraph)", method: "fiber", engine: "fibered-retrieval", scope: "project", ready: true },
+    { id: "r-2", name: "Graph-RAG", method: "graph-rag", engine: "hellgraph", scope: "project", ready: true },
+    { id: "r-3", name: "Topic index", method: "topic", engine: "slash-topics", scope: "project", ready: true },
+    { id: "r-4", name: "Semantic + lexical", method: "vector", engine: "noetica", scope: "chat + project", ready: true },
+  ],
+  generation: [
+    { id: "gn-1", name: "Synthesize training set from graph", engine: "new-hope", kind: "synthesis", status: "running", grounded: true, output: "→ annotation set" },
+    { id: "gn-2", name: "Generation-tuning — grounded rewrite", engine: "new-hope", kind: "generation-tuning", status: "queued", grounded: true },
   ],
   stub: true,
 };

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -1,0 +1,56 @@
+// studioApi — the client for the Lattice Studio product surface (notebooks + data catalog + model catalog +
+// tuning + experiments), the integrated Watson-Studio-class plane. Calls the studio BFF, which fronts the deployed
+// Tier-9 fabric (lattice-studio notebooks, prophet-core-catalog, model-zoo-api, tritfabric/Ray, governance-ledger).
+// VITE_STUDIO_API unset → STUB mode so the surface renders standalone until the BFF is wired. Everything is
+// PROJECT-SCOPED: a projectId (Noetica proj- collection) threads through so notebooks/data/models/experiments all
+// live in the same knowledge scope an agent team already retrieves.
+
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
+
+export type StudioSection = "notebooks" | "data" | "models" | "tuning" | "experiments";
+
+export interface Notebook { id: string; name: string; runtime: string; status: "idle" | "running" | "stopped"; updatedAt: string; kernel?: string }
+export interface DataAsset { id: string; name: string; kind: string; rows?: number; catalog: string; governed: boolean }
+export interface ModelCard { id: string; name: string; task: string; stage: "candidate" | "staged" | "promoted"; metric?: string }
+export interface TuningRun { id: string; name: string; method: "lora" | "sae" | "circuit-probe" | "full"; status: "queued" | "running" | "done" | "failed"; backend: string }
+export interface Experiment { id: string; title: string; reproducible: boolean; provenance: string; createdAt: string }
+
+export interface StudioBundle {
+  notebooks: Notebook[];
+  data: DataAsset[];
+  models: ModelCard[];
+  tuning: TuningRun[];
+  experiments: Experiment[];
+  stub?: boolean;
+}
+
+const STUB: StudioBundle = {
+  notebooks: [
+    { id: "nb-1", name: "Exploratory analysis.ipynb", runtime: "prophet-python-ml", status: "idle", updatedAt: new Date().toISOString(), kernel: "python3" },
+    { id: "nb-2", name: "LoRA fine-tune.ipynb", runtime: "prophet-ray-ml", status: "running", updatedAt: new Date().toISOString(), kernel: "ray" },
+  ],
+  data: [
+    { id: "da-1", name: "customer_events", kind: "table", rows: 1_240_000, catalog: "prophet-core-catalog", governed: true },
+    { id: "da-2", name: "corpus_v3", kind: "dataset", catalog: "prophet-core-catalog", governed: true },
+  ],
+  models: [
+    { id: "m-1", name: "prophet-7b-lora", task: "chat", stage: "staged", metric: "MMLU 64.2" },
+    { id: "m-2", name: "sae-residual-l12", task: "interpretability", stage: "candidate" },
+  ],
+  tuning: [
+    { id: "t-1", name: "SAE on residual stream L12", method: "sae", status: "running", backend: "tritfabric/ray" },
+    { id: "t-2", name: "Circuit probe — induction heads", method: "circuit-probe", status: "queued", backend: "tritfabric/ray" },
+  ],
+  experiments: [
+    { id: "e-1", title: "Reproduce: LoRA vs full FT", reproducible: true, provenance: "in-toto + lockfile", createdAt: new Date().toISOString() },
+  ],
+  stub: true,
+};
+
+export async function loadStudio(projectId?: string): Promise<StudioBundle> {
+  if (!BASE) return STUB;
+  const q = projectId ? `?project=${encodeURIComponent(projectId)}` : "";
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio${q}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`studio load failed: ${res.status}`);
+  return (await res.json()) as StudioBundle;
+}

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -118,9 +118,11 @@ const STUB: StudioBundle = {
 
 // ── KE-2: the project sub-graph with PROVENANCE per node (the differentiator) ──
 export interface GraphNode { id: string; name: string; epistemic_mode: string; source?: string; extractor?: string; labels: string[] }
+export interface GraphEdge { id: string; source: string; target: string; label: string; weight?: number }
 export interface GraphView {
   project: string; projectCollection: string;
-  nodes: GraphNode[]; count: number; epistemic_distribution: Record<string, number>;
+  nodes: GraphNode[]; edges?: GraphEdge[]; count: number; edge_count?: number;
+  epistemic_distribution: Record<string, number>;
   degraded?: string | null; stub?: boolean;
 }
 
@@ -140,7 +142,15 @@ const STUB_GRAPH: GraphView = {
     { id: "proj-demo:ent:sae", name: "SAE feature", epistemic_mode: "derived", source: "notebook:nb-3", extractor: "superconscious", labels: ["proj-demo", "Entity"] },
     { id: "proj-demo:ent:claim", name: "Contradiction claim", epistemic_mode: "hypothesis", source: "holmes", extractor: "holmes", labels: ["proj-demo", "Entity"] },
   ],
-  count: 5, epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, stub: true,
+  edges: [
+    { id: "e1", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:neo4j", label: "COMPARED_WITH", weight: 3 },
+    { id: "e2", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:anzo", label: "COMPARED_WITH", weight: 2 },
+    { id: "e3", source: "proj-demo:ent:neo4j", target: "proj-demo:ent:anzo", label: "CO_OCCURS", weight: 1 },
+    { id: "e4", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:sae", label: "GROUNDS", weight: 2 },
+    { id: "e5", source: "proj-demo:ent:sae", target: "proj-demo:ent:claim", label: "SUPPORTS", weight: 1 },
+    { id: "e6", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:claim", label: "GROUNDS", weight: 1 },
+  ],
+  count: 5, edge_count: 6, epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, stub: true,
 };
 
 export async function loadGraph(project: string): Promise<GraphView> {

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { loadStudio, type StudioBundle, type StudioSection } from "../services/studioApi";
+
+const bundle = ref<StudioBundle | null>(null);
+const error = ref("");
+const loading = ref(true);
+const section = ref<StudioSection>("notebooks");
+// Project scope — a notebook/asset/model lives in a project's proj- collection so an agent team already retrieves
+// it. Wired to the active Noetica project when the projects store lands; a placeholder scope until then.
+const project = ref("Untitled project");
+
+const sections: { id: StudioSection; label: string; icon: string; blurb: string }[] = [
+  { id: "notebooks",   label: "Notebooks",     icon: "⬢", blurb: "Ray-backed notebooks — NotebookLM meets Jupyter, in your project scope." },
+  { id: "data",        label: "Data catalog",  icon: "▤", blurb: "Governed datasets + tables from the core catalog." },
+  { id: "models",      label: "Model catalog", icon: "◈", blurb: "The model zoo — candidates, staged, promoted." },
+  { id: "tuning",      label: "Tune",          icon: "✳", blurb: "LoRA, SAEs, transformer-circuit probes — on the Ray fabric." },
+  { id: "experiments", label: "Experiments",   icon: "⟳", blurb: "Reproducible science — provenance + lockfiles, ck.org-style." },
+];
+
+onMounted(async () => {
+  try { bundle.value = await loadStudio(); }
+  catch (e) { error.value = e instanceof Error ? e.message : "failed to load studio"; }
+  finally { loading.value = false; }
+});
+
+const items = computed(() => {
+  const b = bundle.value;
+  if (!b) return [];
+  return (b[section.value] ?? []) as Record<string, unknown>[];
+});
+const activeMeta = computed(() => sections.find((s) => s.id === section.value)!);
+</script>
+
+<template>
+  <div class="studio">
+    <aside class="rail">
+      <div class="head">
+        <div class="title">⬢ Studio</div>
+        <div class="proj" :title="'Project scope — shared with your agent team'">{{ project }}</div>
+      </div>
+      <nav>
+        <button v-for="s in sections" :key="s.id" :class="{ on: section === s.id }" @click="section = s.id">
+          <span class="ic">{{ s.icon }}</span> {{ s.label }}
+        </button>
+      </nav>
+      <div class="foot">
+        <span v-if="bundle?.stub" class="stub">preview · fabric not yet wired</span>
+      </div>
+    </aside>
+
+    <main class="panel">
+      <header>
+        <h1>{{ activeMeta.icon }} {{ activeMeta.label }}</h1>
+        <p class="blurb">{{ activeMeta.blurb }}</p>
+        <div class="actions">
+          <button class="primary">＋ New</button>
+          <button title="Everything here is in the project's collection — your agent team can already read it.">⤳ Share to agent team</button>
+        </div>
+      </header>
+
+      <p v-if="loading" class="msg">Loading…</p>
+      <p v-else-if="error" class="msg err">{{ error }}</p>
+
+      <div v-else class="grid">
+        <!-- notebooks -->
+        <template v-if="section === 'notebooks'">
+          <article v-for="n in (items as any[])" :key="n.id" class="card">
+            <div class="row"><span class="name">{{ n.name }}</span><span class="pill" :class="n.status">{{ n.status }}</span></div>
+            <div class="sub">{{ n.runtime }} · kernel {{ n.kernel }}</div>
+          </article>
+        </template>
+        <!-- data -->
+        <template v-else-if="section === 'data'">
+          <article v-for="d in (items as any[])" :key="d.id" class="card">
+            <div class="row"><span class="name">{{ d.name }}</span><span v-if="d.governed" class="pill ok">governed</span></div>
+            <div class="sub">{{ d.kind }}<span v-if="d.rows"> · {{ d.rows.toLocaleString() }} rows</span> · {{ d.catalog }}</div>
+          </article>
+        </template>
+        <!-- models -->
+        <template v-else-if="section === 'models'">
+          <article v-for="m in (items as any[])" :key="m.id" class="card">
+            <div class="row"><span class="name">{{ m.name }}</span><span class="pill" :class="m.stage">{{ m.stage }}</span></div>
+            <div class="sub">{{ m.task }}<span v-if="m.metric"> · {{ m.metric }}</span></div>
+          </article>
+        </template>
+        <!-- tuning -->
+        <template v-else-if="section === 'tuning'">
+          <article v-for="t in (items as any[])" :key="t.id" class="card">
+            <div class="row"><span class="name">{{ t.name }}</span><span class="pill" :class="t.status">{{ t.status }}</span></div>
+            <div class="sub">{{ t.method }} · {{ t.backend }}</div>
+          </article>
+        </template>
+        <!-- experiments -->
+        <template v-else>
+          <article v-for="x in (items as any[])" :key="x.id" class="card">
+            <div class="row"><span class="name">{{ x.title }}</span><span v-if="x.reproducible" class="pill ok">reproducible</span></div>
+            <div class="sub">{{ x.provenance }}</div>
+          </article>
+        </template>
+
+        <p v-if="!items.length" class="msg">Nothing here yet.</p>
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.studio { display: flex; height: 100%; font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.rail { width: 220px; flex-shrink: 0; border-right: 1px solid #e8eaed; display: flex; flex-direction: column; background: #fafafa; }
+.rail .head { padding: 18px 16px 10px; }
+.rail .title { font-size: 18px; font-weight: 700; }
+.rail .proj { margin-top: 4px; font-size: 12px; color: #1a73e8; background: #e8f0fe; border-radius: 10px; padding: 2px 8px; display: inline-block; }
+.rail nav { display: flex; flex-direction: column; padding: 6px; gap: 2px; }
+.rail nav button { text-align: left; padding: 8px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: #3c4043; font-size: 14px; }
+.rail nav button:hover { background: #f1f3f4; }
+.rail nav button.on { background: #e8f0fe; color: #1a73e8; font-weight: 600; }
+.rail nav .ic { display: inline-block; width: 20px; }
+.rail .foot { margin-top: auto; padding: 12px 16px; }
+.rail .stub { font-size: 11px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 3px 8px; }
+
+.panel { flex: 1; overflow: auto; padding: 24px 28px; }
+.panel header h1 { font-size: 22px; margin: 0; }
+.panel .blurb { color: #5f6368; margin: 4px 0 14px; max-width: 640px; }
+.panel .actions { display: flex; gap: 8px; margin-bottom: 18px; }
+.panel .actions button { border: 1px solid #dadce0; background: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.panel .actions button.primary { background: #1a73e8; color: #fff; border-color: #1a73e8; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
+.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.card .row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.card .name { font-weight: 600; }
+.card .sub { color: #5f6368; font-size: 12px; margin-top: 4px; }
+.pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid #dadce0; color: #5f6368; }
+.pill.ok, .pill.promoted, .pill.done { border-color: #137333; color: #137333; }
+.pill.running { border-color: #1a73e8; color: #1a73e8; }
+.pill.failed { border-color: #c5221f; color: #c5221f; }
+.pill.staged, .pill.queued { border-color: #b06000; color: #b06000; }
+.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+</style>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -11,13 +11,19 @@ const selected = ref<{ kind: StudioSection; item: Record<string, any> } | null>(
 // Project scope — every artifact lives in the project's proj- collection, so the agent team already retrieves it.
 const project = ref("Untitled project");
 
-const sections: { id: StudioSection; label: string; icon: string; blurb: string }[] = [
-  { id: "notebooks",   label: "Notebooks",     icon: "⬢", blurb: "Ray-backed notebooks — authoring + provenance, run as jobs on the fabric." },
-  { id: "data",        label: "Data catalog",  icon: "▤", blurb: "Governed datasets & tables with lineage and reproduce commands." },
-  { id: "models",      label: "Model catalog", icon: "◈", blurb: "The model zoo — factsheets, lineage, promote & serve." },
-  { id: "tuning",      label: "Tune",          icon: "✳", blurb: "LoRA & quantized fine-tunes on the Ray fabric · SAE / circuit probes (roadmap)." },
-  { id: "experiments", label: "Experiments",   icon: "⟳", blurb: "Reproducible science — provenance + lockfiles, one-click re-run." },
+const sections: { id: StudioSection; label: string; icon: string; group: string; blurb: string }[] = [
+  { id: "notebooks",   label: "Notebooks",     icon: "⬢", group: "Workbench", blurb: "Ray-backed notebooks — authoring + provenance, run as jobs on the fabric." },
+  { id: "data",        label: "Data catalog",  icon: "▤", group: "Workbench", blurb: "Governed datasets & tables with lineage and reproduce commands." },
+  { id: "models",      label: "Model catalog", icon: "◈", group: "Workbench", blurb: "The model zoo — factsheets, lineage, promote & serve." },
+  { id: "tuning",      label: "Tune",          icon: "✳", group: "Workbench", blurb: "LoRA & quantized fine-tunes on the Ray fabric · SAE / circuit probes (roadmap)." },
+  { id: "experiments", label: "Experiments",   icon: "⟳", group: "Workbench", blurb: "Reproducible science — provenance + lockfiles, one-click re-run." },
+  { id: "extraction",  label: "Extraction",    icon: "⛏", group: "Knowledge engineering", blurb: "Pull knowledge into the project graph — Holmes entities/relations, Sherlock federated search, governed ingest." },
+  { id: "ontology",    label: "Ontology",      icon: "⬡", group: "Knowledge engineering", blurb: "The schema & alignment layer — Ontogenesis classes, relations, KKO alignment." },
+  { id: "graph",       label: "Graph",         icon: "⧉", group: "Knowledge engineering", blurb: "The project knowledge graph — HellGraph, gremlin/sparql, grounded to your docs." },
+  { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
+  { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
 ];
+const groups = computed(() => [...new Set(sections.map((s) => s.group))]);
 
 onMounted(async () => {
   try { bundle.value = await loadStudio(); }
@@ -45,6 +51,11 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   models:      [{ label: "Promote", hint: "tritfabric /v1/promote" }, { label: "Serve", hint: "tritfabric Serve.Deploy" }, { label: "Factsheet", hint: "governance factsheet" }],
   tuning:      [{ label: "Register model", hint: "→ model zoo" }, { label: "Logs", hint: "job status" }, { label: "Cancel", hint: "cancel job" }],
   experiments: [{ label: "Re-run", hint: "reproduce end-to-end" }, { label: "Provenance", hint: "in-toto chain" }, { label: "Publish", hint: "publication artifact" }],
+  extraction:  [{ label: "Run extraction", hint: "Holmes/Sherlock → project graph" }, { label: "View in graph", hint: "open the graph" }, { label: "Share to team", hint: "in the project collection" }],
+  ontology:    [{ label: "Edit ontology", hint: "Ontogenesis" }, { label: "Align", hint: "map to KKO / project" }, { label: "Apply to graph", hint: "re-type entities" }],
+  graph:       [{ label: "Open graph", hint: "HellGraph gremlin/sparql" }, { label: "Query", hint: "graph-RAG" }, { label: "Export", hint: "sub-graph" }],
+  retrieval:   [{ label: "Query", hint: "run fibered retrieval" }, { label: "Rebuild index", hint: "re-embed" }, { label: "Use in notebook", hint: "attach retriever" }],
+  generation:  [{ label: "Run", hint: "New-Hope grounded synthesis" }, { label: "→ Annotation set", hint: "into the workbench" }, { label: "→ Tune", hint: "generation-tuning" }],
 };
 </script>
 
@@ -66,11 +77,14 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
     <div class="body">
       <!-- section rail -->
       <aside class="rail">
-        <button v-for="s in sections" :key="s.id" :class="{ on: section === s.id }" @click="section = s.id; selected = null">
-          <span class="ic">{{ s.icon }}</span>
-          <span class="lbl">{{ s.label }}</span>
-          <span class="cnt">{{ SECTION_COUNT(bundle, s.id) }}</span>
-        </button>
+        <template v-for="g in groups" :key="g">
+          <div class="rail-group">{{ g }}</div>
+          <button v-for="s in sections.filter((x) => x.group === g)" :key="s.id" :class="{ on: section === s.id }" @click="section = s.id; selected = null">
+            <span class="ic">{{ s.icon }}</span>
+            <span class="lbl">{{ s.label }}</span>
+            <span class="cnt">{{ SECTION_COUNT(bundle, s.id) }}</span>
+          </button>
+        </template>
         <div class="rail-foot">
           <span v-if="bundle?.stub" class="stub">preview · fabric not yet wired</span>
         </div>
@@ -121,10 +135,38 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
               <div v-if="it.metric" class="sub">{{ it.metric.name }}: <b>{{ it.metric.value }}</b></div>
             </template>
             <!-- experiments -->
-            <template v-else>
+            <template v-else-if="section === 'experiments'">
               <div class="row"><span class="name">{{ it.title }}</span><span v-if="it.reproducible" class="pill ok">reproducible</span></div>
               <div class="sub">{{ it.provenance }}</div>
               <div v-if="it.steps" class="prov"><span v-for="st in it.steps" :key="st.label" class="pstep" :title="st.hash">{{ st.label }}</span></div>
+            </template>
+            <!-- extraction (holmes / sherlock / ingest → graph) -->
+            <template v-else-if="section === 'extraction'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>
+              <div class="sub"><span class="method">{{ it.engine }}</span> · {{ it.kind }} → {{ it.target }}</div>
+              <div v-if="it.extracted" class="sub"><b>{{ it.extracted.toLocaleString() }}</b> extracted</div>
+            </template>
+            <!-- ontology (ontogenesis) -->
+            <template v-else-if="section === 'ontology'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="{ ok: it.aligned }">{{ it.kind }}</span></div>
+              <div class="sub"><span class="method">{{ it.engine }}</span><span v-if="it.count"> · {{ it.count.toLocaleString() }}</span><span v-if="it.aligned"> · aligned</span></div>
+            </template>
+            <!-- graph (hellgraph) -->
+            <template v-else-if="section === 'graph'">
+              <div class="row"><span class="name">{{ it.label }}</span></div>
+              <div class="stat">{{ typeof it.value === 'number' ? it.value.toLocaleString() : it.value }}</div>
+              <div v-if="it.hint" class="sub">{{ it.hint }}</div>
+            </template>
+            <!-- retrieval (fiber / graph-rag / topic) -->
+            <template v-else-if="section === 'retrieval'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="{ ok: it.ready }">{{ it.ready ? 'ready' : 'building' }}</span></div>
+              <div class="sub"><span class="method">{{ it.method }}</span> · {{ it.engine }} · scope: {{ it.scope }}</div>
+            </template>
+            <!-- generation (new-hope) -->
+            <template v-else>
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>
+              <div class="sub"><span class="method">{{ it.engine }}</span> · {{ it.kind }}<span v-if="it.grounded" class="dot ok"> ● grounded</span></div>
+              <div v-if="it.output" class="sub">{{ it.output }}</div>
             </template>
           </article>
         </div>
@@ -196,6 +238,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 .bar { height: 5px; background: #eceff1; border-radius: 3px; margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
 .prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; } .pstep { font: 10px/1.4 ui-monospace, monospace; background: #f1f3f4; border-radius: 6px; padding: 1px 7px; color: #3c4043; }
 .dot.ok { color: #137333; font-size: 11px; }
+.stat { font-size: 26px; font-weight: 700; margin-top: 6px; letter-spacing: -0.5px; }
+.rail-group { font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: #9aa0a6; padding: 12px 12px 4px; }
 
 .pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid var(--line); color: var(--sub); white-space: nowrap; }
 .pill.ok, .pill.promoted, .pill.done { border-color: #137333; color: #137333; }

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -1,140 +1,221 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
-import { loadStudio, type StudioBundle, type StudioSection } from "../services/studioApi";
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { loadStudio, SECTION_COUNT, type StudioBundle, type StudioSection } from "../services/studioApi";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
 const loading = ref(true);
 const section = ref<StudioSection>("notebooks");
-// Project scope — a notebook/asset/model lives in a project's proj- collection so an agent team already retrieves
-// it. Wired to the active Noetica project when the projects store lands; a placeholder scope until then.
+const query = ref("");
+const selected = ref<{ kind: StudioSection; item: Record<string, any> } | null>(null);
+// Project scope — every artifact lives in the project's proj- collection, so the agent team already retrieves it.
 const project = ref("Untitled project");
 
 const sections: { id: StudioSection; label: string; icon: string; blurb: string }[] = [
-  { id: "notebooks",   label: "Notebooks",     icon: "⬢", blurb: "Ray-backed notebooks — NotebookLM meets Jupyter, in your project scope." },
-  { id: "data",        label: "Data catalog",  icon: "▤", blurb: "Governed datasets + tables from the core catalog." },
-  { id: "models",      label: "Model catalog", icon: "◈", blurb: "The model zoo — candidates, staged, promoted." },
-  { id: "tuning",      label: "Tune",          icon: "✳", blurb: "LoRA, SAEs, transformer-circuit probes — on the Ray fabric." },
-  { id: "experiments", label: "Experiments",   icon: "⟳", blurb: "Reproducible science — provenance + lockfiles, ck.org-style." },
+  { id: "notebooks",   label: "Notebooks",     icon: "⬢", blurb: "Ray-backed notebooks — authoring + provenance, run as jobs on the fabric." },
+  { id: "data",        label: "Data catalog",  icon: "▤", blurb: "Governed datasets & tables with lineage and reproduce commands." },
+  { id: "models",      label: "Model catalog", icon: "◈", blurb: "The model zoo — factsheets, lineage, promote & serve." },
+  { id: "tuning",      label: "Tune",          icon: "✳", blurb: "LoRA & quantized fine-tunes on the Ray fabric · SAE / circuit probes (roadmap)." },
+  { id: "experiments", label: "Experiments",   icon: "⟳", blurb: "Reproducible science — provenance + lockfiles, one-click re-run." },
 ];
 
 onMounted(async () => {
   try { bundle.value = await loadStudio(); }
   catch (e) { error.value = e instanceof Error ? e.message : "failed to load studio"; }
   finally { loading.value = false; }
+  window.addEventListener("keydown", onKey);
 });
+onUnmounted(() => window.removeEventListener("keydown", onKey));
+function onKey(e: KeyboardEvent) { if (e.key === "Escape") selected.value = null; }
 
-const items = computed(() => {
-  const b = bundle.value;
-  if (!b) return [];
-  return (b[section.value] ?? []) as Record<string, unknown>[];
+const items = computed<Record<string, any>[]>(() => {
+  const b = bundle.value; if (!b) return [];
+  const list = (b[section.value] ?? []) as Record<string, any>[];
+  const q = query.value.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter((it) => JSON.stringify(it).toLowerCase().includes(q));
 });
 const activeMeta = computed(() => sections.find((s) => s.id === section.value)!);
+function pick(item: Record<string, any>) { selected.value = { kind: section.value, item }; }
+
+// Cross-links / actions map to the real tritfabric verbs (tune, promote, serve, reproduce). Wired to the BFF next.
+const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
+  notebooks:   [{ label: "Open", hint: "open the notebook" }, { label: "Run as job", hint: "submit to Ray via tritfabric" }, { label: "Share to team", hint: "in the project collection already" }],
+  data:        [{ label: "New notebook", hint: "start a notebook on this data" }, { label: "Lineage", hint: "view provenance" }, { label: "Reproduce", hint: "run the reproduce command" }],
+  models:      [{ label: "Promote", hint: "tritfabric /v1/promote" }, { label: "Serve", hint: "tritfabric Serve.Deploy" }, { label: "Factsheet", hint: "governance factsheet" }],
+  tuning:      [{ label: "Register model", hint: "→ model zoo" }, { label: "Logs", hint: "job status" }, { label: "Cancel", hint: "cancel job" }],
+  experiments: [{ label: "Re-run", hint: "reproduce end-to-end" }, { label: "Provenance", hint: "in-toto chain" }, { label: "Publish", hint: "publication artifact" }],
+};
 </script>
 
 <template>
   <div class="studio">
-    <aside class="rail">
-      <div class="head">
-        <div class="title">⬢ Studio</div>
-        <div class="proj" :title="'Project scope — shared with your agent team'">{{ project }}</div>
+    <!-- top command bar -->
+    <header class="topbar">
+      <div class="brand">⬢ Studio</div>
+      <button class="proj" :title="'Project scope — shared with your agent team'">{{ project }} <span class="chev">▾</span></button>
+      <div class="search">
+        <span class="mag">⌕</span>
+        <input v-model="query" :placeholder="`Search ${activeMeta.label.toLowerCase()}…`" aria-label="Search" />
       </div>
-      <nav>
-        <button v-for="s in sections" :key="s.id" :class="{ on: section === s.id }" @click="section = s.id">
-          <span class="ic">{{ s.icon }}</span> {{ s.label }}
+      <div class="spacer" />
+      <button class="ghost" title="Everything here is in the project's collection — your agent team already reads it.">⤳ Share to agent team</button>
+      <button class="primary">＋ New <span class="chev">▾</span></button>
+    </header>
+
+    <div class="body">
+      <!-- section rail -->
+      <aside class="rail">
+        <button v-for="s in sections" :key="s.id" :class="{ on: section === s.id }" @click="section = s.id; selected = null">
+          <span class="ic">{{ s.icon }}</span>
+          <span class="lbl">{{ s.label }}</span>
+          <span class="cnt">{{ SECTION_COUNT(bundle, s.id) }}</span>
         </button>
-      </nav>
-      <div class="foot">
-        <span v-if="bundle?.stub" class="stub">preview · fabric not yet wired</span>
-      </div>
-    </aside>
-
-    <main class="panel">
-      <header>
-        <h1>{{ activeMeta.icon }} {{ activeMeta.label }}</h1>
-        <p class="blurb">{{ activeMeta.blurb }}</p>
-        <div class="actions">
-          <button class="primary">＋ New</button>
-          <button title="Everything here is in the project's collection — your agent team can already read it.">⤳ Share to agent team</button>
+        <div class="rail-foot">
+          <span v-if="bundle?.stub" class="stub">preview · fabric not yet wired</span>
         </div>
-      </header>
+      </aside>
 
-      <p v-if="loading" class="msg">Loading…</p>
-      <p v-else-if="error" class="msg err">{{ error }}</p>
+      <!-- main panel -->
+      <main class="panel">
+        <div class="sec-head">
+          <h1>{{ activeMeta.icon }} {{ activeMeta.label }}</h1>
+          <p class="blurb">{{ activeMeta.blurb }}</p>
+        </div>
 
-      <div v-else class="grid">
-        <!-- notebooks -->
-        <template v-if="section === 'notebooks'">
-          <article v-for="n in (items as any[])" :key="n.id" class="card">
-            <div class="row"><span class="name">{{ n.name }}</span><span class="pill" :class="n.status">{{ n.status }}</span></div>
-            <div class="sub">{{ n.runtime }} · kernel {{ n.kernel }}</div>
-          </article>
-        </template>
-        <!-- data -->
-        <template v-else-if="section === 'data'">
-          <article v-for="d in (items as any[])" :key="d.id" class="card">
-            <div class="row"><span class="name">{{ d.name }}</span><span v-if="d.governed" class="pill ok">governed</span></div>
-            <div class="sub">{{ d.kind }}<span v-if="d.rows"> · {{ d.rows.toLocaleString() }} rows</span> · {{ d.catalog }}</div>
-          </article>
-        </template>
-        <!-- models -->
-        <template v-else-if="section === 'models'">
-          <article v-for="m in (items as any[])" :key="m.id" class="card">
-            <div class="row"><span class="name">{{ m.name }}</span><span class="pill" :class="m.stage">{{ m.stage }}</span></div>
-            <div class="sub">{{ m.task }}<span v-if="m.metric"> · {{ m.metric }}</span></div>
-          </article>
-        </template>
-        <!-- tuning -->
-        <template v-else-if="section === 'tuning'">
-          <article v-for="t in (items as any[])" :key="t.id" class="card">
-            <div class="row"><span class="name">{{ t.name }}</span><span class="pill" :class="t.status">{{ t.status }}</span></div>
-            <div class="sub">{{ t.method }} · {{ t.backend }}</div>
-          </article>
-        </template>
-        <!-- experiments -->
-        <template v-else>
-          <article v-for="x in (items as any[])" :key="x.id" class="card">
-            <div class="row"><span class="name">{{ x.title }}</span><span v-if="x.reproducible" class="pill ok">reproducible</span></div>
-            <div class="sub">{{ x.provenance }}</div>
-          </article>
-        </template>
+        <!-- skeletons -->
+        <div v-if="loading" class="grid">
+          <div v-for="i in 4" :key="i" class="card skeleton"><div class="sk-line w60" /><div class="sk-line w40" /></div>
+        </div>
+        <p v-else-if="error" class="msg err">{{ error }}</p>
+        <p v-else-if="!items.length" class="msg empty">Nothing here yet{{ query ? ` for “${query}”` : "" }}.</p>
 
-        <p v-if="!items.length" class="msg">Nothing here yet.</p>
-      </div>
-    </main>
+        <div v-else class="grid">
+          <article v-for="it in items" :key="it.id" class="card" :class="{ sel: selected?.item.id === it.id }" @click="pick(it)">
+            <!-- notebooks -->
+            <template v-if="section === 'notebooks'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>
+              <div class="sub">{{ it.runtime }} · {{ it.cells }} cells</div>
+              <code v-if="it.lastCell" class="mono">{{ it.lastCell }}</code>
+              <div class="chips"><span v-for="c in it.collaborators" :key="c" class="chip">{{ c }}</span></div>
+            </template>
+            <!-- data -->
+            <template v-else-if="section === 'data'">
+              <div class="row"><span class="name">{{ it.name }}</span><span v-if="it.governed" class="pill ok">governed</span><span v-else class="pill warn">ungoverned</span></div>
+              <div class="sub">{{ it.kind }}<span v-if="it.rows"> · {{ it.rows.toLocaleString() }} rows</span><span v-if="it.columns"> · {{ it.columns }} cols</span></div>
+              <div v-if="it.lineage" class="lineage">{{ it.lineage.join(" ") }}</div>
+            </template>
+            <!-- models -->
+            <template v-else-if="section === 'models'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.stage">{{ it.stage }}</span></div>
+              <div class="sub">{{ it.task }}<span v-if="it.base"> · base {{ it.base }}</span><span v-if="it.servable" class="dot ok"> ● servable</span></div>
+              <div v-if="it.metrics" class="metrics">
+                <span v-for="m in it.metrics" :key="m.name" class="metric">{{ m.name }} <b>{{ m.value }}{{ m.unit || "" }}</b></span>
+              </div>
+            </template>
+            <!-- tuning -->
+            <template v-else-if="section === 'tuning'">
+              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>
+              <div class="sub"><span class="method">{{ it.method }}</span> · {{ it.backend }}</div>
+              <div v-if="it.progress != null" class="bar"><span :style="{ width: Math.round(it.progress * 100) + '%' }" /></div>
+              <div v-if="it.metric" class="sub">{{ it.metric.name }}: <b>{{ it.metric.value }}</b></div>
+            </template>
+            <!-- experiments -->
+            <template v-else>
+              <div class="row"><span class="name">{{ it.title }}</span><span v-if="it.reproducible" class="pill ok">reproducible</span></div>
+              <div class="sub">{{ it.provenance }}</div>
+              <div v-if="it.steps" class="prov"><span v-for="st in it.steps" :key="st.label" class="pstep" :title="st.hash">{{ st.label }}</span></div>
+            </template>
+          </article>
+        </div>
+      </main>
+
+      <!-- detail drawer -->
+      <transition name="drawer">
+        <aside v-if="selected" class="drawer">
+          <button class="close" @click="selected = null" aria-label="Close">✕</button>
+          <div class="d-kind">{{ activeMeta.label }}</div>
+          <h2>{{ selected.item.name || selected.item.title }}</h2>
+          <dl class="meta">
+            <template v-for="(v, k) in selected.item" :key="k">
+              <div v-if="k !== 'id' && typeof v !== 'object'" class="mrow"><dt>{{ k }}</dt><dd>{{ v }}</dd></div>
+            </template>
+          </dl>
+          <div v-if="selected.item.lineage" class="d-block"><h3>Lineage</h3><div class="lineage">{{ selected.item.lineage.join(" ") }}</div></div>
+          <div v-if="selected.item.steps" class="d-block"><h3>Provenance</h3><div class="prov"><span v-for="st in selected.item.steps" :key="st.label" class="pstep">{{ st.label }} · {{ st.hash }}</span></div></div>
+          <div class="d-actions">
+            <button v-for="a in actionsFor[selected.kind]" :key="a.label" :title="a.hint" :class="{ primary: a.label === actionsFor[selected.kind][0].label }">{{ a.label }}</button>
+          </div>
+        </aside>
+      </transition>
+    </div>
   </div>
 </template>
 
 <style scoped>
-.studio { display: flex; height: 100%; font: 14px/1.5 system-ui, sans-serif; color: #202124; }
-.rail { width: 220px; flex-shrink: 0; border-right: 1px solid #e8eaed; display: flex; flex-direction: column; background: #fafafa; }
-.rail .head { padding: 18px 16px 10px; }
-.rail .title { font-size: 18px; font-weight: 700; }
-.rail .proj { margin-top: 4px; font-size: 12px; color: #1a73e8; background: #e8f0fe; border-radius: 10px; padding: 2px 8px; display: inline-block; }
-.rail nav { display: flex; flex-direction: column; padding: 6px; gap: 2px; }
-.rail nav button { text-align: left; padding: 8px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: #3c4043; font-size: 14px; }
-.rail nav button:hover { background: #f1f3f4; }
-.rail nav button.on { background: #e8f0fe; color: #1a73e8; font-weight: 600; }
-.rail nav .ic { display: inline-block; width: 20px; }
-.rail .foot { margin-top: auto; padding: 12px 16px; }
+.studio { --line:#e8eaed; --sub:#5f6368; --ink:#202124; --accent:#1a73e8; --accent-bg:#e8f0fe; --card:#fff; --bg:#fafafa;
+  display: flex; flex-direction: column; height: 100%; font: 14px/1.5 system-ui, sans-serif; color: var(--ink); }
+
+.topbar { display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--line); }
+.topbar .brand { font-size: 16px; font-weight: 700; }
+.topbar .proj { border: 1px solid var(--line); background: var(--accent-bg); color: var(--accent); border-radius: 16px; padding: 4px 12px; font-size: 13px; cursor: pointer; }
+.topbar .chev { opacity: .6; font-size: 10px; }
+.topbar .search { flex: 0 1 340px; display: flex; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: 18px; padding: 5px 12px; }
+.topbar .search .mag { color: var(--sub); }
+.topbar .search input { border: none; outline: none; flex: 1; font-size: 14px; background: none; }
+.topbar .spacer { flex: 1; }
+.topbar button.ghost { border: 1px solid var(--line); background: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.topbar button.primary { border: none; background: var(--accent); color: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+
+.body { flex: 1; display: flex; min-height: 0; }
+.rail { width: 208px; flex-shrink: 0; border-right: 1px solid var(--line); background: var(--bg); display: flex; flex-direction: column; padding: 8px; }
+.rail button { display: flex; align-items: center; gap: 10px; text-align: left; padding: 9px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: #3c4043; font-size: 14px; }
+.rail button:hover { background: #f1f3f4; }
+.rail button.on { background: var(--accent-bg); color: var(--accent); font-weight: 600; }
+.rail .ic { width: 18px; } .rail .lbl { flex: 1; } .rail .cnt { font-size: 11px; color: var(--sub); background: #fff; border: 1px solid var(--line); border-radius: 9px; padding: 0 6px; }
+.rail button.on .cnt { background: #fff; }
+.rail-foot { margin-top: auto; padding: 10px 8px; }
 .rail .stub { font-size: 11px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 3px 8px; }
 
-.panel { flex: 1; overflow: auto; padding: 24px 28px; }
-.panel header h1 { font-size: 22px; margin: 0; }
-.panel .blurb { color: #5f6368; margin: 4px 0 14px; max-width: 640px; }
-.panel .actions { display: flex; gap: 8px; margin-bottom: 18px; }
-.panel .actions button { border: 1px solid #dadce0; background: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.panel .actions button.primary { background: #1a73e8; color: #fff; border-color: #1a73e8; }
+.panel { flex: 1; overflow: auto; padding: 20px 24px; min-width: 0; }
+.sec-head h1 { font-size: 20px; margin: 0; } .sec-head .blurb { color: var(--sub); margin: 4px 0 16px; max-width: 680px; }
 
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px; }
-.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 12px; }
+.card { border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; background: var(--card); cursor: pointer; transition: box-shadow .12s, border-color .12s; }
+.card:hover { box-shadow: 0 1px 8px rgba(60,64,67,.12); border-color: #dadce0; }
+.card.sel { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-bg); }
 .card .row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .card .name { font-weight: 600; }
-.card .sub { color: #5f6368; font-size: 12px; margin-top: 4px; }
-.pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid #dadce0; color: #5f6368; }
+.card .sub { color: var(--sub); font-size: 12px; margin-top: 4px; }
+.card .mono { display: block; font: 11px/1.4 ui-monospace, monospace; color: #3c4043; background: #f8f9fa; border-radius: 6px; padding: 5px 8px; margin: 8px 0 6px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.chips, .metrics { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+.chip { font-size: 11px; background: #f1f3f4; border-radius: 8px; padding: 1px 8px; color: #3c4043; }
+.metric { font-size: 12px; color: var(--sub); background: #f8f9fa; border-radius: 8px; padding: 1px 8px; } .metric b { color: var(--ink); }
+.lineage { font: 11px/1.4 ui-monospace, monospace; color: var(--sub); margin-top: 8px; }
+.method { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; font-weight: 600; color: var(--accent); }
+.bar { height: 5px; background: #eceff1; border-radius: 3px; margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
+.prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; } .pstep { font: 10px/1.4 ui-monospace, monospace; background: #f1f3f4; border-radius: 6px; padding: 1px 7px; color: #3c4043; }
+.dot.ok { color: #137333; font-size: 11px; }
+
+.pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid var(--line); color: var(--sub); white-space: nowrap; }
 .pill.ok, .pill.promoted, .pill.done { border-color: #137333; color: #137333; }
-.pill.running { border-color: #1a73e8; color: #1a73e8; }
+.pill.running { border-color: var(--accent); color: var(--accent); }
 .pill.failed { border-color: #c5221f; color: #c5221f; }
-.pill.staged, .pill.queued { border-color: #b06000; color: #b06000; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.pill.warn, .pill.staged, .pill.queued, .pill.candidate { border-color: #b06000; color: #b06000; }
+
+.msg { color: var(--sub); padding: 10px 2px; } .msg.err { color: #c5221f; }
+.skeleton { pointer-events: none; } .sk-line { height: 10px; background: linear-gradient(90deg,#f1f3f4,#e8eaed,#f1f3f4); background-size: 200% 100%; border-radius: 5px; margin: 6px 0; animation: sh 1.2s infinite; } .w60 { width: 60%; } .w40 { width: 40%; }
+@keyframes sh { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+.drawer { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); background: #fff; padding: 18px 20px; overflow: auto; position: relative; }
+.drawer .close { position: absolute; top: 12px; right: 14px; border: none; background: none; font-size: 15px; color: var(--sub); cursor: pointer; }
+.drawer .d-kind { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--sub); }
+.drawer h2 { font-size: 18px; margin: 4px 0 14px; }
+.meta { margin: 0 0 14px; } .mrow { display: flex; gap: 10px; padding: 4px 0; border-bottom: 1px solid #f1f3f4; } .mrow dt { color: var(--sub); min-width: 96px; font-size: 12px; } .mrow dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+.d-block { margin: 12px 0; } .d-block h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--sub); margin: 0 0 6px; }
+.d-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+.d-actions button { border: 1px solid var(--line); background: #fff; border-radius: 16px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.d-actions button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.drawer-enter-active, .drawer-leave-active { transition: transform .18s ease, opacity .18s ease; }
+.drawer-enter-from, .drawer-leave-to { transform: translateX(20px); opacity: 0; }
 </style>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { loadStudio, SECTION_COUNT, type StudioBundle, type StudioSection } from "../services/studioApi";
+import StudioGraph from "../components/StudioGraph.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -92,13 +93,16 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
       <!-- main panel -->
       <main class="panel">
-        <div class="sec-head">
+        <div class="sec-head" v-if="section !== 'graph'">
           <h1>{{ activeMeta.icon }} {{ activeMeta.label }}</h1>
           <p class="blurb">{{ activeMeta.blurb }}</p>
         </div>
 
+        <!-- Graph section = the provenance-first explorer (KE-2) -->
+        <StudioGraph v-if="section === 'graph'" :project="project" />
+
         <!-- skeletons -->
-        <div v-if="loading" class="grid">
+        <div v-else-if="loading" class="grid">
           <div v-for="i in 4" :key="i" class="card skeleton"><div class="sk-line w60" /><div class="sk-line w40" /></div>
         </div>
         <p v-else-if="error" class="msg err">{{ error }}</p>
@@ -151,12 +155,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
               <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="{ ok: it.aligned }">{{ it.kind }}</span></div>
               <div class="sub"><span class="method">{{ it.engine }}</span><span v-if="it.count"> · {{ it.count.toLocaleString() }}</span><span v-if="it.aligned"> · aligned</span></div>
             </template>
-            <!-- graph (hellgraph) -->
-            <template v-else-if="section === 'graph'">
-              <div class="row"><span class="name">{{ it.label }}</span></div>
-              <div class="stat">{{ typeof it.value === 'number' ? it.value.toLocaleString() : it.value }}</div>
-              <div v-if="it.hint" class="sub">{{ it.hint }}</div>
-            </template>
+            <!-- graph: handled by the StudioGraph explorer at the panel level (provenance-first) -->
             <!-- retrieval (fiber / graph-rag / topic) -->
             <template v-else-if="section === 'retrieval'">
               <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="{ ok: it.ready }">{{ it.ready ? 'ready' : 'building' }}</span></div>


### PR DESCRIPTION
Cert is **Active** and `search-api.socioprophet.ai/search?q=` serves **real blended web + commons results**. app-vue's `searchApi.ts` already calls `${BASE}/search?q=` — so baking `VITE_SEARCH_API` into the build is the only wiring needed. Merge → dev Firebase deploy → **.ai agentic search live on dev**. Studio API stays unset until its public ingress lands.