### PR TITLE
fix(ci): pin firebase-action to a real tag → app-vue dev deploy actually runs

### DIFF
--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -67,7 +67,7 @@ jobs:
         id: env
         run: echo "alias=${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}" >> "$GITHUB_OUTPUT"
       - name: Deploy to Firebase Hosting (app target)
-        uses: w9jds/firebase-action@v13.23.1
+        uses: w9jds/firebase-action@v15.24.0
         with:
           args: deploy --only hosting:app --project ${{ steps.env.outputs.alias }}
         env:

--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -40,6 +40,12 @@ jobs:
         with: { node-version: '20', cache: 'npm', cache-dependency-path: socioprophet-web/app-vue/package-lock.json }
       - name: Build app-vue
         working-directory: socioprophet-web/app-vue
+        # VITE_SEARCH_API bakes the live sovereign search edge into the bundle (public URL, not a secret):
+        # search-api.socioprophet.ai → search-gateway → SearXNG (web) ⊕ commons-search (sovereign commons).
+        # Cert is Active and the endpoint serves real blended results. Studio API stays unset until its
+        # public ingress lands (renders in preview until then).
+        env:
+          VITE_SEARCH_API: https://search-api.socioprophet.ai
         run: |
           npm ci
           npm run build


### PR DESCRIPTION
The app-vue-deploy workflow had `startup_failure` on **every** run — it pinned `w9jds/firebase-action@v13.23.1`, a **non-existent tag** (real tags start at v15.x), so GitHub couldn't resolve the action and the workflow never started. Pinned to `v15.24.0`. Combined with the `VITE_SEARCH_API` wiring on this branch, merging → the dev Firebase deploy runs → **.ai search surface live on dev** (assuming the `FIREBASE_TOKEN` secret is set).