### PR TITLE
feat(studio): proof-carrying query IDE UI (WS#30)

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioQuery.vue
+++ b/socioprophet-web/app-vue/src/components/StudioQuery.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { runQuery, EPISTEMIC_COLORS, type QueryLang, type QueryResult } from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const LANGS: QueryLang[] = ["sparql", "cypher", "gremlin"];
+const SAMPLES: Record<QueryLang, string> = {
+  sparql: "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 25",
+  cypher: "MATCH (n)-[r]->(m) RETURN n, type(r), m LIMIT 25",
+  gremlin: "g.V().limit(25)",
+};
+
+const lang = ref<QueryLang>("sparql");
+const text = ref(SAMPLES.sparql);
+const result = ref<QueryResult | null>(null);
+const loading = ref(false);
+const err = ref("");
+
+function setLang(l: QueryLang) {
+  lang.value = l;
+  if (!text.value.trim() || Object.values(SAMPLES).includes(text.value)) text.value = SAMPLES[l];
+}
+
+async function run() {
+  if (!text.value.trim()) return;
+  loading.value = true; err.value = "";
+  try { result.value = await runQuery(props.project, lang.value, text.value); }
+  catch (e) { err.value = e instanceof Error ? e.message : "query failed"; result.value = null; }
+  finally { loading.value = false; }
+}
+
+function epiOf(v: unknown): string | null { return result.value?.epistemic[String(v)] ?? null; }
+function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "#c0c4c9"; }
+</script>
+
+<template>
+  <div class="qide">
+    <div class="qbar">
+      <div class="seg">
+        <button v-for="l in LANGS" :key="l" :class="{ on: lang === l }" @click="setLang(l)">{{ l }}</button>
+      </div>
+      <div class="spacer" />
+      <button class="run" :disabled="loading" @click="run">{{ loading ? "Running…" : "▷ Run" }}</button>
+    </div>
+
+    <textarea v-model="text" class="qed mono" spellcheck="false" rows="5"
+      @keydown.ctrl.enter="run" @keydown.meta.enter="run"
+      :placeholder="`Write ${lang}…  (⌘/Ctrl+Enter to run)`"></textarea>
+
+    <p v-if="err" class="qerr">{{ err }}</p>
+
+    <div v-else-if="result" class="qres">
+      <!-- THE BEAT: every result is replayable + proof-carrying -->
+      <div class="qproof">
+        <span class="pf" :class="{ ok: result.proof.replayable }" title="replayable, proof-carrying result">
+          {{ result.proof.replayable ? "◆ replayable" : "◇ not replayable" }}
+        </span>
+        <span v-if="result.proof.query_hash" class="pfh mono" title="query hash — this exact result can be replayed">{{ result.proof.query_hash }}</span>
+        <span v-if="result.proof.evaluated_at_seq != null" class="pfs">@ seq {{ result.proof.evaluated_at_seq }}</span>
+        <span class="spacer" />
+        <span class="rc">{{ result.row_count }} rows</span>
+      </div>
+
+      <div v-if="result.columns.length" class="qscroll">
+        <table class="qgrid">
+          <thead><tr><th v-for="c in result.columns" :key="c">{{ c }}</th></tr></thead>
+          <tbody>
+            <tr v-for="(r, i) in result.rows" :key="i">
+              <td v-for="c in result.columns" :key="c">
+                <span class="val">{{ r[c] }}</span>
+                <span v-if="epiOf(r[c])" class="epi" :style="{ background: color(epiOf(r[c])!) }" :title="`epistemic: ${epiOf(r[c])}`" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p v-if="!result.rows.length" class="qempty">No rows.</p>
+      </div>
+      <pre v-else class="qraw mono">{{ JSON.stringify(result.raw, null, 2) }}</pre>
+
+      <p class="qnote">Rows you can <b>replay and prove</b>, and whose facts carry their <b>epistemic status</b> (the coloured dots) — what Stardog / Neo4j Bloom return can't.</p>
+    </div>
+
+    <p v-else class="qhint">Run a query against the live kernel. Results are <b>replayable</b> (proof-carrying) and <b>epistemically enriched</b> — the beat over Stardog / Bloom.</p>
+  </div>
+</template>
+
+<style scoped>
+.qide { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.qbar { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.qbar .spacer { flex: 1; }
+.seg { display: inline-flex; border: 1px solid #dadce0; border-radius: 8px; overflow: hidden; }
+.seg button { border: 0; background: #fff; padding: 6px 12px; font-size: 12px; text-transform: capitalize; cursor: pointer; color: #5f6368; }
+.seg button.on { background: #1a73e8; color: #fff; }
+.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 16px; font-size: 13px; cursor: pointer; }
+.run:disabled { opacity: .6; cursor: default; }
+.qed { width: 100%; resize: vertical; border: 1px solid #dadce0; border-radius: 10px; padding: 12px; font-size: 13px; background: #fbfcfe; box-sizing: border-box; }
+.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+.qerr { color: #c5221f; font-size: 13px; margin: 10px 0 0; }
+.qres { margin-top: 12px; }
+.qproof { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background: #f1f6ee; border: 1px solid #d7e8cf; border-radius: 9px; font-size: 12px; }
+.qproof .spacer { flex: 1; }
+.pf { font-weight: 700; color: #5f6368; } .pf.ok { color: #137333; }
+.pfh { color: #137333; } .pfs { color: #5f6368; } .rc { color: #5f6368; }
+.qscroll { overflow-x: auto; margin-top: 10px; border: 1px solid #e8eaed; border-radius: 10px; }
+.qgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
+.qgrid th { text-align: left; padding: 8px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
+.qgrid td { padding: 8px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; }
+.qgrid tr:last-child td { border-bottom: 0; }
+.qgrid td .epi { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 6px; vertical-align: middle; }
+.qraw { margin-top: 10px; background: #0e1116; color: #d7e0ea; padding: 12px; border-radius: 10px; overflow-x: auto; font-size: 12px; max-height: 320px; }
+.qempty, .qhint, .qnote { color: #5f6368; font-size: 12.5px; }
+.qnote { margin-top: 8px; } .qnote b { color: #202124; } .qhint b { color: #202124; }
+.qhint { margin-top: 12px; }
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -8,8 +8,8 @@
 const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
 
 export type StudioSection =
-  | "notebooks" | "data" | "models" | "tuning" | "experiments"          // Workbench
-  | "extraction" | "ontology" | "graph" | "retrieval" | "generation";   // Knowledge engineering
+  | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
+  | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation"; // Knowledge engineering
 
 export interface Notebook {
   id: string; name: string; runtime: string; kernel: string;
@@ -64,7 +64,8 @@ export interface StudioBundle {
   moat?: Moat; stub?: boolean;
 }
 
-export const SECTION_COUNT = (b: StudioBundle | null, s: StudioSection): number => (b ? (b[s]?.length ?? 0) : 0);
+// graph/query are custom-rendered sections with no list payload in the bundle → defensive index.
+export const SECTION_COUNT = (b: StudioBundle | null, s: StudioSection): number => (b ? ((b as unknown as Record<string, unknown[]>)[s]?.length ?? 0) : 0);
 
 const now = () => new Date().toISOString();
 const STUB: StudioBundle = {
@@ -250,6 +251,41 @@ export async function loadReceipts(limit = 12): Promise<Receipts> {
   const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/receipts?limit=${limit}`, { headers: { accept: "application/json" } });
   if (!res.ok) throw new Error(`receipts failed: ${res.status}`);
   return (await res.json()) as Receipts;
+}
+
+// ── WS#30: the proof-carrying query IDE (SPARQL/Cypher/Gremlin). Results carry replay proof + per-fact epistemic. ──
+export type QueryLang = "sparql" | "cypher" | "gremlin";
+export interface QueryProof { query_hash?: string | null; evaluated_at_seq?: number | null; replayable: boolean }
+export interface QueryResult {
+  project: string; lang: QueryLang; columns: string[]; rows: Record<string, unknown>[]; row_count: number;
+  epistemic: Record<string, string>; proof: QueryProof; raw?: unknown;
+}
+
+const STUB_QUERY = (lang: QueryLang): QueryResult => ({
+  project: "demo", lang,
+  columns: ["entity", "epistemic"],
+  rows: [
+    { entity: "proj-demo:ent:hellgraph", epistemic: "verified" },
+    { entity: "proj-demo:ent:neo4j", epistemic: "observed" },
+    { entity: "proj-demo:ent:anzo", epistemic: "observed" },
+  ],
+  row_count: 3,
+  epistemic: { "proj-demo:ent:hellgraph": "verified", "proj-demo:ent:neo4j": "observed", "proj-demo:ent:anzo": "observed" },
+  proof: { query_hash: "qh-demo-8f2a", evaluated_at_seq: 128, replayable: true },
+});
+
+export async function runQuery(project: string, lang: QueryLang, query: string, params?: Record<string, string>): Promise<QueryResult> {
+  if (!BASE) return STUB_QUERY(lang);
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/query`, {
+    method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ project, lang, query, params }),
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try { const j = await res.json(); detail = (j as { detail?: string }).detail ?? detail; } catch { /* */ }
+    throw new Error(`query failed: ${detail}`);
+  }
+  return (await res.json()) as QueryResult;
 }
 
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { loadStudio, loadReceipts, SECTION_COUNT, EPISTEMIC_COLORS, type StudioBundle, type StudioSection, type Receipts } from "../services/studioApi";
 import StudioGraph from "../components/StudioGraph.vue";
+import StudioQuery from "../components/StudioQuery.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -33,6 +34,7 @@ const sections: { id: StudioSection; label: string; icon: string; group: string;
   { id: "extraction",  label: "Extraction",    icon: "⛏", group: "Knowledge engineering", blurb: "Pull knowledge into the project graph — Holmes entities/relations, Sherlock federated search, governed ingest." },
   { id: "ontology",    label: "Ontology",      icon: "⬡", group: "Knowledge engineering", blurb: "The schema & alignment layer — Ontogenesis classes, relations, KKO alignment." },
   { id: "graph",       label: "Graph",         icon: "⧉", group: "Knowledge engineering", blurb: "The project knowledge graph — HellGraph, gremlin/sparql, grounded to your docs." },
+  { id: "query",       label: "Query",         icon: "⌗", group: "Knowledge engineering", blurb: "SPARQL / Cypher / Gremlin over the live kernel — results you can replay (proof-carrying) and whose facts carry epistemic status." },
   { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
   { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
 ];
@@ -49,7 +51,7 @@ function onKey(e: KeyboardEvent) { if (e.key === "Escape") selected.value = null
 
 const items = computed<Record<string, any>[]>(() => {
   const b = bundle.value; if (!b) return [];
-  const list = (b[section.value] ?? []) as Record<string, any>[];
+  const list = ((b as Record<string, any>)[section.value] ?? []) as Record<string, any>[];
   const q = query.value.trim().toLowerCase();
   if (!q) return list;
   return list.filter((it) => JSON.stringify(it).toLowerCase().includes(q));
@@ -67,6 +69,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   extraction:  [{ label: "Run extraction", hint: "Holmes/Sherlock → project graph" }, { label: "View in graph", hint: "open the graph" }, { label: "Share to team", hint: "in the project collection" }],
   ontology:    [{ label: "Edit ontology", hint: "Ontogenesis" }, { label: "Align", hint: "map to KKO / project" }, { label: "Apply to graph", hint: "re-type entities" }],
   graph:       [{ label: "Open graph", hint: "HellGraph gremlin/sparql" }, { label: "Query", hint: "graph-RAG" }, { label: "Export", hint: "sub-graph" }],
+  query:       [{ label: "Run", hint: "SPARQL/Cypher/Gremlin over the kernel" }, { label: "Replay", hint: "re-evaluate by query hash" }, { label: "Export", hint: "results + proof" }],
   retrieval:   [{ label: "Query", hint: "run fibered retrieval" }, { label: "Rebuild index", hint: "re-embed" }, { label: "Use in notebook", hint: "attach retriever" }],
   generation:  [{ label: "Run", hint: "New-Hope grounded synthesis" }, { label: "→ Annotation set", hint: "into the workbench" }, { label: "→ Tune", hint: "generation-tuning" }],
 };
@@ -150,6 +153,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
         <!-- Graph section = the provenance-first explorer (KE-2) -->
         <StudioGraph v-if="section === 'graph'" :project="project" />
+        <!-- Query section = the proof-carrying query IDE (WS#30) -->
+        <StudioQuery v-else-if="section === 'query'" :project="project" />
 
         <!-- skeletons -->
         <div v-else-if="loading" class="grid">


### PR DESCRIPTION
**Wave 2 · WS#30** frontend — pairs with BFF **prophet-platform#812**. A new **Query** section brings Studio to parity with Stardog Studio / Bloom's query surface, then beats it:

- **Editor**: SPARQL / Cypher / Gremlin toggle, sample queries, ⌘/Ctrl+Enter to run
- **Results grid**: columns + rows from the live kernel
- **BEAT #1 — replay proof**: each result shows a **◆ replayable** badge with the query hash + evaluated-at seq. Not a snapshot — a result you can prove and re-run.
- **BEAT #2 — epistemic per cell**: any value that's a known project entity gets an **epistemic-status dot** (coloured by the shared ladder).

Bad syntax surfaces the kernel's 400 detail (never a silently-empty grid). Stub-aware so it demos standalone. **Typecheck clean.**