### PR TITLE
feat(studio): experiments view — runs as proof-carrying graph facts (WS#32)

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioExperiments.vue
+++ b/socioprophet-web/app-vue/src/components/StudioExperiments.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue";
+import { loadExperiments, logExperiment, EPISTEMIC_COLORS, type Experiments } from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const data = ref<Experiments | null>(null);
+const loading = ref(true);
+const err = ref("");
+
+const showLog = ref(false);
+const fName = ref("");
+const fParams = ref('{"lr": 0.01}');
+const fMetrics = ref('{"acc": 0.9}');
+const token = ref("");
+const logging = ref(false);
+const logMsg = ref("");
+const logErr = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try { data.value = await loadExperiments(props.project); }
+  catch (e) { err.value = e instanceof Error ? e.message : "failed to load"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+function parseJson(s: string): Record<string, unknown> {
+  try { const o = JSON.parse(s); if (o && typeof o === "object") return o as Record<string, unknown>; throw 0; }
+  catch { throw new Error("params/metrics must be valid JSON objects"); }
+}
+
+async function submitLog() {
+  logging.value = true; logMsg.value = ""; logErr.value = "";
+  try {
+    if (!fName.value.trim()) throw new Error("name required");
+    const run = await logExperiment(
+      { project: props.project, name: fName.value.trim(), params: parseJson(fParams.value), metrics: parseJson(fMetrics.value) as Record<string, number>, status: "finished" },
+      token.value,
+    );
+    logMsg.value = `Logged ${run.run_id}`; fName.value = "";
+    await load();
+  } catch (e) { logErr.value = e instanceof Error ? e.message : "log failed"; }
+  finally { logging.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function kv(o: Record<string, unknown>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
+</script>
+
+<template>
+  <div class="xp">
+    <div class="xbar">
+      <span class="cnt">{{ data?.count ?? 0 }} runs</span>
+      <div class="spacer" />
+      <button class="run" @click="showLog = !showLog">＋ Log run</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+    </div>
+
+    <div v-if="showLog" class="logbox">
+      <div class="lrow">
+        <input v-model="fName" placeholder="run name" />
+        <input v-model="fParams" class="j mono" placeholder="params JSON" />
+        <input v-model="fMetrics" class="j mono" placeholder="metrics JSON" />
+        <input v-model="token" type="password" class="tok" placeholder="write token" />
+        <button class="primary" @click="submitLog" :disabled="logging">{{ logging ? "…" : "Log" }}</button>
+      </div>
+      <p v-if="logErr" class="lfeedback err">{{ logErr }}</p>
+      <p v-else-if="logMsg" class="lfeedback ok">✓ {{ logMsg }} — persisted as a proof-carrying graph fact</p>
+    </div>
+
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading runs…</p>
+    <p v-else-if="!data?.runs.length" class="msg">No runs yet. Log one — it lands as a fact in the knowledge graph, queryable in the IDE.</p>
+
+    <div v-else class="xscroll">
+      <table class="xgrid">
+        <thead><tr><th>Run</th><th>Status</th><th>Params</th><th>Metrics</th><th>Epistemic</th><th>When</th></tr></thead>
+        <tbody>
+          <tr v-for="r in data.runs" :key="r.run_id">
+            <td class="nm">{{ r.name }}</td>
+            <td><span class="pill" :class="r.status">{{ r.status }}</span></td>
+            <td class="mono">{{ kv(r.params) }}</td>
+            <td class="mono met">{{ kv(r.metrics) }}</td>
+            <td><span class="epi" :style="{ borderColor: color(r.epistemic_mode), color: color(r.epistemic_mode) }">{{ r.epistemic_mode }}</span></td>
+            <td class="when">{{ r.created_at }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-if="data?.runs.length" class="note">Runs are <b>graph facts</b>, not rows in a side DB — query them in the IDE, link them to data/models, and every metric carries its provenance.</p>
+  </div>
+</template>
+
+<style scoped>
+.xp { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.xbar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.xbar .cnt { color: #5f6368; font-size: 12px; } .xbar .spacer { flex: 1; }
+.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.logbox { border: 1px solid #dadce0; border-radius: 10px; background: #f8f9fa; padding: 10px 12px; margin-bottom: 12px; }
+.lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.lrow input { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input.j { flex: 1; min-width: 140px; } .lrow input.tok { width: 120px; }
+.lrow button.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary:disabled { opacity: .6; cursor: default; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: #137333; } .lfeedback.err { color: #c5221f; }
+.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.xscroll { overflow-x: auto; border: 1px solid #e8eaed; border-radius: 10px; }
+.xgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
+.xgrid th { text-align: left; padding: 8px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
+.xgrid td { padding: 8px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; }
+.xgrid tr:last-child td { border-bottom: 0; }
+.xgrid .nm { font-weight: 600; } .xgrid .met { color: #137333; }
+.pill { font-size: 10.5px; border-radius: 10px; padding: 1px 8px; background: #eef0f3; color: #5f6368; }
+.pill.finished { background: #eaf5ee; color: #137333; } .pill.running { background: #e8f0fe; color: #1a73e8; } .pill.failed { background: #fbe9e8; color: #c5221f; }
+.epi { font-size: 10.5px; border: 1px solid; border-radius: 10px; padding: 1px 8px; }
+.when { color: #5f6368; font-size: 11px; }
+.note { color: #5f6368; font-size: 12.5px; margin-top: 8px; } .note b { color: #202124; }
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -288,6 +288,41 @@ export async function runQuery(project: string, lang: QueryLang, query: string, 
   return (await res.json()) as QueryResult;
 }
 
+// ── WS#32: experiment tracking — runs are first-class proof-carrying graph facts (params/metrics + epistemic). ──
+export interface ExperimentRun {
+  run_id: string; name: string; status: string; params: Record<string, unknown>; metrics: Record<string, number>;
+  created_at?: string | null; epistemic_mode?: string; extractor?: string | null; source?: string | null;
+}
+export interface Experiments { project: string; runs: ExperimentRun[]; count: number; degraded?: string | null }
+
+const STUB_EXPERIMENTS: Experiments = {
+  project: "demo", count: 2,
+  runs: [
+    { run_id: "proj-demo:run:8f2a", name: "sweep-lr", status: "finished", params: { lr: 0.01, batch: 64 }, metrics: { acc: 0.912, loss: 0.28 }, created_at: "2m ago", epistemic_mode: "observed", extractor: "studio/experiment-v0" },
+    { run_id: "proj-demo:run:71c9", name: "baseline", status: "finished", params: { lr: 0.001 }, metrics: { acc: 0.874 }, created_at: "1h ago", epistemic_mode: "observed", extractor: "studio/experiment-v0" },
+  ],
+};
+
+export async function loadExperiments(project: string): Promise<Experiments> {
+  if (!BASE) return STUB_EXPERIMENTS;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/experiments?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`experiments failed: ${res.status}`);
+  return (await res.json()) as Experiments;
+}
+
+export async function logExperiment(
+  input: { project: string; name: string; params?: Record<string, unknown>; metrics?: Record<string, number>; status?: string },
+  token: string,
+): Promise<ExperimentRun> {
+  if (!BASE) throw new Error("Studio backend not connected (set VITE_STUDIO_API)");
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/experiments`, {
+    method: "POST", headers: writeHeaders(token), body: JSON.stringify(input),
+  });
+  if (!res.ok) throw writeError("log experiment failed", res.status);
+  return (await res.json()) as ExperimentRun;
+}
+
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {
   if (!BASE) return STUB;
   const q = projectId ? `?project=${encodeURIComponent(projectId)}` : "";

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted, onUnmounted } from "vue";
 import { loadStudio, loadReceipts, SECTION_COUNT, EPISTEMIC_COLORS, type StudioBundle, type StudioSection, type Receipts } from "../services/studioApi";
 import StudioGraph from "../components/StudioGraph.vue";
 import StudioQuery from "../components/StudioQuery.vue";
+import StudioExperiments from "../components/StudioExperiments.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -155,6 +156,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
         <StudioGraph v-if="section === 'graph'" :project="project" />
         <!-- Query section = the proof-carrying query IDE (WS#30) -->
         <StudioQuery v-else-if="section === 'query'" :project="project" />
+        <!-- Experiments = runs as proof-carrying graph facts (WS#32) -->
+        <StudioExperiments v-else-if="section === 'experiments'" :project="project" />
 
         <!-- skeletons -->
         <div v-else-if="loading" class="grid">
@@ -193,12 +196,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
               <div v-if="it.progress != null" class="bar"><span :style="{ width: Math.round(it.progress * 100) + '%' }" /></div>
               <div v-if="it.metric" class="sub">{{ it.metric.name }}: <b>{{ it.metric.value }}</b></div>
             </template>
-            <!-- experiments -->
-            <template v-else-if="section === 'experiments'">
-              <div class="row"><span class="name">{{ it.title }}</span><span v-if="it.reproducible" class="pill ok">reproducible</span></div>
-              <div class="sub">{{ it.provenance }}</div>
-              <div v-if="it.steps" class="prov"><span v-for="st in it.steps" :key="st.label" class="pstep" :title="st.hash">{{ st.label }}</span></div>
-            </template>
+            <!-- experiments now render via the StudioExperiments panel (WS#32) -->
             <!-- extraction (holmes / sherlock / ingest → graph) -->
             <template v-else-if="section === 'extraction'">
               <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>


### PR DESCRIPTION
**Wave 3 · WS#32** frontend — pairs with BFF **prophet-platform#813**. The **Experiments** section becomes a real MLflow-style tracker, then beats it.

- **Runs table** loaded live: name · status · params · metrics · **epistemic status** · when
- **＋ Log run** form: name + params/metrics JSON + write token → persists the run
- **BEAT**: a run is a **Run+Experiment node in the proof-carrying graph** — queryable in the query IDE, linkable to the data/models it touched, every metric carrying provenance. MLflow's runs live in a side DB; ours are graph facts.

Removed the old spine-fed experiments card. **Typecheck clean.**