### PR TITLE
Studio: Commons panel — the proof-carrying knowledge commons in-product (WS#36–39)

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioCommons.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCommons.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+// The proof-carrying knowledge COMMONS panel (WS#36–39): surfaces preservation/versioning, FAIR+ metadata,
+// scholarly + agent ecosystem hooks, commons-at-scale stats, and epistemic-weighted community curation —
+// the repository fundamentals (Zenodo/OSF/Wikidata) MET, then BEATEN with our epistemic + provenance layer.
+import { ref, onMounted, watch } from "vue";
+import {
+  loadCommons, loadFair, loadEcosystem, loadVersions, loadCuration, endorse, EPISTEMIC_COLORS,
+  type Commons, type Fair, type Ecosystem, type Versions, type Curation,
+} from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const commons = ref<Commons | null>(null);
+const fair = ref<Fair | null>(null);
+const eco = ref<Ecosystem | null>(null);
+const versions = ref<Versions | null>(null);
+const curation = ref<Curation | null>(null);
+const loading = ref(true);
+const err = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try {
+    [commons.value, fair.value, eco.value, versions.value, curation.value] = await Promise.all([
+      loadCommons(props.project), loadFair(props.project), loadEcosystem(props.project),
+      loadVersions(props.project), loadCuration(props.project),
+    ]);
+  } catch (e) { err.value = e instanceof Error ? e.message : "failed to load commons"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+// endorse form
+const showEndorse = ref(false);
+const eTarget = ref("");
+const eEndorser = ref("");
+const eNote = ref("");
+const eToken = ref("");
+const posting = ref(false);
+const eMsg = ref(""); const eErr = ref("");
+async function submitEndorse() {
+  posting.value = true; eMsg.value = ""; eErr.value = "";
+  try {
+    if (!eTarget.value.trim() || !eEndorser.value.trim()) throw new Error("target and endorser required");
+    const r = await endorse({ project: props.project, target: eTarget.value.trim(), endorser: eEndorser.value.trim(), note: eNote.value.trim() || undefined }, eToken.value);
+    eMsg.value = `Endorsed ${r.target}`; eTarget.value = ""; eNote.value = "";
+    await load();
+  } catch (e) { eErr.value = e instanceof Error ? e.message : "endorse failed"; }
+  finally { posting.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
+</script>
+
+<template>
+  <div class="cm">
+    <div class="cbar">
+      <span class="cnt" v-if="commons">{{ commons.scale.facts }} facts · {{ commons.scale.preserved_versions }} versions · {{ commons.scale.endorsements }} endorsements</span>
+      <div class="spacer" />
+      <button class="run" @click="showEndorse = !showEndorse">＋ Endorse a fact</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+    </div>
+
+    <div v-if="showEndorse" class="logbox">
+      <div class="lrow">
+        <input v-model="eTarget" class="j mono" placeholder="target node id (e.g. proj-x:ent:hellgraph)" />
+        <input v-model="eEndorser" class="j" placeholder="endorser (ORCID / sovereign id)" />
+        <input v-model="eNote" class="j" placeholder="note (optional)" />
+        <input v-model="eToken" type="password" class="tok" placeholder="write token" />
+        <button class="primary" @click="submitEndorse" :disabled="posting">{{ posting ? "…" : "Endorse" }}</button>
+      </div>
+      <p v-if="eErr" class="lfeedback err">{{ eErr }}</p>
+      <p v-else-if="eMsg" class="lfeedback ok">✓ {{ eMsg }} — a governed, revocable, proof-carrying endorsement</p>
+    </div>
+
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading the commons…</p>
+
+    <div v-else class="grid">
+      <!-- FAIR+ scorecard -->
+      <section class="card" v-if="fair">
+        <header class="ch"><span class="ci">◈</span> FAIR<span class="plus">+</span> metadata<span class="score" :class="{ hi: fair.fair.score >= 0.75 }">{{ Math.round(fair.fair.score * 100) }}%</span></header>
+        <div class="fair">
+          <span class="fq" :class="{ on: fair.fair.findable }">{{ fairFlag(fair.fair.findable) }} Findable</span>
+          <span class="fq" :class="{ on: fair.fair.accessible }">{{ fairFlag(fair.fair.accessible) }} Accessible</span>
+          <span class="fq" :class="{ on: fair.fair.interoperable }">{{ fairFlag(fair.fair.interoperable) }} Interoperable</span>
+          <span class="fq" :class="{ on: fair.fair.reusable }">{{ fairFlag(fair.fair.reusable) }} Reusable</span>
+        </div>
+        <div class="plusrow">
+          <span class="ptag" v-if="fair.fair_plus.epistemic">epistemic status</span>
+          <span class="ptag" v-if="fair.fair_plus.provenance_chain">provenance chain</span>
+          <span class="ptag" v-if="fair.fair_plus.hash_sealed">hash-sealed</span>
+        </div>
+        <p v-if="fair.hint" class="hint">→ {{ fair.hint }}</p>
+        <div class="ids" v-if="fair.doi || fair.pid">
+          <code v-if="fair.doi" class="mono" :title="'DataCite DOI'">DOI {{ fair.doi }}</code>
+          <code v-if="fair.pid" class="mono" :title="'sovereign persistent id'">{{ fair.pid }}</code>
+        </div>
+        <p class="sub">schema.org/Dataset · DataCite · PROV-O Turtle — beats a bare metadata record: the record carries epistemic status + a verifiable provenance chain.</p>
+      </section>
+
+      <!-- commons at scale + epistemic quality -->
+      <section class="card" v-if="commons">
+        <header class="ch"><span class="ci">◎</span> Commons at scale<span v-if="commons.epistemic_quality_index != null" class="score hi" :title="'epistemic quality index (0–1)'">Q {{ commons.epistemic_quality_index }}</span></header>
+        <div class="scale">
+          <div class="st"><b>{{ commons.scale.facts }}</b><span>facts</span></div>
+          <div class="st"><b>{{ commons.scale.citations }}</b><span>citations</span></div>
+          <div class="st"><b>{{ commons.scale.preserved_versions }}</b><span>versions</span></div>
+          <div class="st"><b>{{ commons.scale.endorsements }}</b><span>endorsements</span></div>
+          <div class="st"><b>{{ commons.scale.contributors }}</b><span>contributors</span></div>
+        </div>
+        <span class="mb-bar" v-if="commons.scale.facts" title="epistemic distribution of the commons">
+          <i v-for="(n, mode) in commons.epistemic_distribution" :key="mode"
+             :style="{ width: (n / commons.scale.facts * 100) + '%', background: color(mode) }" :title="mode + ': ' + n" />
+        </span>
+        <p class="sub">The <b>quality index</b> weights facts by epistemic status — a signal a volume-only repository can't show.</p>
+      </section>
+
+      <!-- preservation chain -->
+      <section class="card" v-if="versions">
+        <header class="ch"><span class="ci">⛭</span> Preservation<span class="score">{{ versions.count }} sealed</span></header>
+        <ul class="vlist" v-if="versions.versions.length">
+          <li v-for="v in versions.versions" :key="v.snapshot_id">
+            <span class="vv">v{{ v.version }}</span>
+            <code class="mono hash" :title="'content hash — re-hash to verify'">{{ (v.content_hash || '').slice(0, 12) }}</code>
+            <span class="when">{{ v.sealed_at }}</span>
+            <span v-if="v.note" class="vnote">{{ v.note }}</span>
+          </li>
+        </ul>
+        <p v-else class="msg">No snapshots yet — Preserve seals a tamper-evident, versioned copy.</p>
+        <p class="sub">Content-addressed &amp; chained (each links its predecessor). An archived fact stays proof-carrying.</p>
+      </section>
+
+      <!-- scholarly + agent ecosystem -->
+      <section class="card" v-if="eco">
+        <header class="ch"><span class="ci">⌘</span> Ecosystem hooks</header>
+        <div class="row2">
+          <a v-if="eco.scholarly.doi_url" class="link mono" :href="eco.scholarly.doi_url" target="_blank" rel="noopener">DOI ↗</a>
+          <span v-if="eco.scholarly.openaire.harvestable" class="ptag">OpenAIRE-harvestable</span>
+        </div>
+        <div class="orcids" v-if="eco.scholarly.orcid_contributors.length">
+          <a v-for="c in eco.scholarly.orcid_contributors" :key="c.orcid" class="orcid" :href="c.orcid_url" target="_blank" rel="noopener" :title="c.orcid">
+            <span class="oic">iD</span> {{ c.name }}
+          </a>
+        </div>
+        <div class="manifest">
+          <span class="mtitle">agent manifest <span v-if="eco.agent_manifest.proof_carrying" class="ptag sm">proof-carrying</span></span>
+          <div class="verbs">
+            <span v-for="vb in eco.agent_manifest.access" :key="vb.name" class="verb" :class="{ off: !vb.endpoint }" :title="vb.endpoint || 'not available'">
+              {{ vb.name }}<i v-if="vb.verifiable && vb.endpoint" class="vok">✓</i>
+            </span>
+          </div>
+        </div>
+        <p class="sub">Discovery repos expose to <i>humans</i>, we also expose to <i>agents</i>: a machine-readable card of verifiable access verbs.</p>
+      </section>
+
+      <!-- community curation -->
+      <section class="card wide" v-if="curation">
+        <header class="ch"><span class="ci">✶</span> Community curation<span class="score" :title="'epistemic-weighted curation score'">score {{ curation.curation_score }}</span></header>
+        <div v-if="curation.endorsements.length" class="cscroll">
+          <table class="cgrid">
+            <thead><tr><th>Endorsed fact</th><th>Endorser</th><th>Note</th><th>When</th></tr></thead>
+            <tbody>
+              <tr v-for="(e, i) in curation.endorsements" :key="i">
+                <td class="mono">{{ e.target }}</td>
+                <td class="mono nm">{{ e.endorser }}</td>
+                <td>{{ e.note || "—" }}</td>
+                <td class="when">{{ e.at }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p v-else class="msg">No endorsements yet — endorse a fact above; it lands as a governed, revocable graph fact.</p>
+        <p class="sub">The score is <b>epistemic-weighted</b>: endorsing an <i>attested</i> fact counts more than a <i>hypothesis</i> — curation follows grounding, not popularity. Revoked endorsements never count.</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cm { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.cbar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.cbar .cnt { color: #5f6368; font-size: 12px; } .cbar .spacer { flex: 1; }
+.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.logbox { border: 1px solid #dadce0; border-radius: 10px; background: #f8f9fa; padding: 10px 12px; margin-bottom: 14px; }
+.lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.lrow input { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input.j { flex: 1; min-width: 150px; } .lrow input.tok { width: 120px; }
+.lrow button.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary:disabled { opacity: .6; cursor: default; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: #137333; } .lfeedback.err { color: #c5221f; }
+.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
+.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: #1a73e8; } .ch .plus { color: #1a73e8; font-weight: 700; }
+.score { margin-left: auto; font-size: 11px; color: #5f6368; background: #f1f3f4; border-radius: 10px; padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.score.hi { color: #137333; background: #eaf5ee; }
+.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.sub { color: #5f6368; font-size: 12px; margin: 10px 0 0; } .sub b { color: #202124; }
+
+.fair { display: flex; flex-wrap: wrap; gap: 6px; }
+.fq { font-size: 12px; border: 1px solid #e8eaed; color: #9aa0a6; border-radius: 8px; padding: 3px 9px; }
+.fq.on { color: #137333; border-color: #cbe6d3; background: #f4fbf6; }
+.plusrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.ptag { font-size: 10.5px; color: #1a73e8; background: #e8f0fe; border-radius: 8px; padding: 2px 8px; }
+.ptag.sm { font-size: 9.5px; padding: 1px 6px; }
+.hint { color: #b06000; font-size: 12px; margin: 8px 0 0; }
+.ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.ids code { background: #f8f9fa; border: 1px solid #eceef1; border-radius: 6px; padding: 2px 7px; }
+
+.scale { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 10px; }
+.st { display: flex; flex-direction: column; } .st b { font-size: 20px; font-variant-numeric: tabular-nums; } .st span { font-size: 11px; color: #5f6368; }
+.mb-bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: #f1f3f4; } .mb-bar i { display: block; height: 100%; }
+
+.vlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.vlist li { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
+.vv { font-weight: 700; color: #1a73e8; } .hash { background: #f8f9fa; border-radius: 5px; padding: 1px 6px; }
+.when { color: #5f6368; font-size: 11px; } .vnote { color: #5f6368; font-style: italic; }
+
+.row2 { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 8px; }
+.link { color: #1a73e8; text-decoration: none; } .link:hover { text-decoration: underline; }
+.orcids { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: #202124; text-decoration: none; border: 1px solid #e8eaed; border-radius: 8px; padding: 2px 8px; }
+.orcid .oic { background: #a6ce39; color: #fff; font-size: 9px; font-weight: 700; border-radius: 3px; padding: 1px 3px; }
+.manifest { border-top: 1px solid #f1f3f4; padding-top: 8px; }
+.mtitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; display: flex; align-items: center; gap: 6px; }
+.verbs { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.verb { font-size: 11.5px; background: #f1f3f4; border-radius: 7px; padding: 2px 8px; color: #202124; } .verb.off { color: #b0b4b9; }
+.verb .vok { color: #137333; font-style: normal; margin-left: 3px; }
+
+.cscroll { overflow-x: auto; border: 1px solid #e8eaed; border-radius: 10px; }
+.cgrid { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+.cgrid th { text-align: left; padding: 7px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
+.cgrid td { padding: 7px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; } .cgrid tr:last-child td { border-bottom: 0; }
+.cgrid .nm { font-weight: 600; }
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -9,7 +9,8 @@ const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_
 
 export type StudioSection =
   | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
-  | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation"; // Knowledge engineering
+  | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation" // Knowledge engineering
+  | "commons";                                                                  // Commons (WS#36–39)
 
 export interface Notebook {
   id: string; name: string; runtime: string; kernel: string;
@@ -352,6 +353,103 @@ export async function mintCitation(
   });
   if (!res.ok) throw writeError("cite failed", res.status);
   return (await res.json()) as Citation;
+}
+
+// ── WS#36–39: the proof-carrying knowledge COMMONS — preservation, FAIR, scholarly/agent hooks, curation. ──
+export interface SnapshotVersion { snapshot_id: string; version: number; content_hash: string; sealed_at?: string | null; parent?: string | null; note?: string | null; epistemic_mode?: string }
+export interface Versions { project: string; target: string; versions: SnapshotVersion[]; count: number; degraded?: string | null }
+
+export interface Fair {
+  project: string; target: string; title: string; pid?: string | null; doi?: string | null;
+  version?: number | null; content_hash?: string | null;
+  fair: { findable: boolean; accessible: boolean; interoperable: boolean; reusable: boolean; score: number };
+  fair_plus: { epistemic: boolean; provenance_chain: boolean; hash_sealed: boolean };
+  hint?: string | null;
+}
+
+export interface OrcidContributor { name: string; orcid: string; orcid_url: string }
+export interface AgentVerb { name: string; endpoint: string | null; verifiable: boolean }
+export interface Ecosystem {
+  project: string; target: string;
+  scholarly: { doi?: string | null; doi_url?: string | null; orcid_contributors: OrcidContributor[]; openaire: { harvestable: boolean; datacite_doi?: string | null; metadata: string } };
+  agent_manifest: { "@type": string; identifier?: string | null; proof_carrying: boolean; epistemic_status: boolean; sovereign: boolean; access: AgentVerb[]; consume_note: string };
+}
+
+export interface Commons {
+  project: string; collection: string;
+  scale: { facts: number; citations: number; preserved_versions: number; endorsements: number; contributors: number };
+  epistemic_distribution: Record<string, number>; epistemic_quality_index?: number | null; degraded?: string | null;
+}
+
+export interface Endorsement { target: string; endorser: string; note?: string | null; at?: string | null }
+export interface Curation { project: string; target?: string | null; endorsements: Endorsement[]; count: number; curation_score: number; epistemic_weighted: boolean; degraded?: string | null }
+
+const STUB_COMMONS: Commons = {
+  project: "demo", collection: "proj-demo",
+  scale: { facts: 128, citations: 3, preserved_versions: 4, endorsements: 7, contributors: 2 },
+  epistemic_distribution: { attested: 18, verified: 41, observed: 63, hypothesis: 6 }, epistemic_quality_index: 0.71,
+};
+const STUB_FAIR: Fair = {
+  project: "demo", target: "proj-demo", title: "demo — knowledge graph", pid: "sp:proj-demo/graph/8f2ad4c1b9e0",
+  doi: "10.82044/proj-demo.graph.8f2ad4c1", version: 4, content_hash: "8f2ad4c1b9e0",
+  fair: { findable: true, accessible: true, interoperable: true, reusable: true, score: 1.0 },
+  fair_plus: { epistemic: true, provenance_chain: true, hash_sealed: true }, hint: null,
+};
+const STUB_ECOSYSTEM: Ecosystem = {
+  project: "demo", target: "proj-demo",
+  scholarly: { doi: "10.82044/proj-demo.graph.8f2ad4c1", doi_url: "https://doi.org/10.82044/proj-demo.graph.8f2ad4c1",
+    orcid_contributors: [{ name: "M. Heller", orcid: "0000-0002-1825-0097", orcid_url: "https://orcid.org/0000-0002-1825-0097" }],
+    openaire: { harvestable: true, datacite_doi: "10.82044/proj-demo.graph.8f2ad4c1", metadata: "/api/studio/fair?project=demo" } },
+  agent_manifest: { "@type": "AgentCapabilityManifest", identifier: "sp:proj-demo/graph/8f2ad4c1b9e0", proof_carrying: true, epistemic_status: true, sovereign: true,
+    access: [
+      { name: "resolve", endpoint: "/api/studio/resolve?pid=sp:proj-demo/graph/8f2ad4c1b9e0", verifiable: true },
+      { name: "query", endpoint: "/api/studio/query", verifiable: true },
+      { name: "provenance", endpoint: "/api/studio/provenance", verifiable: true },
+      { name: "receipts", endpoint: "/api/studio/receipts", verifiable: true },
+      { name: "rdf", endpoint: "/api/studio/graph.ttl?project=demo", verifiable: true },
+      { name: "fair", endpoint: "/api/studio/fair?project=demo", verifiable: true },
+    ], consume_note: "every result carries a queryHash + epistemic status; verify via the receipts/provenance verbs" },
+};
+const STUB_VERSIONS: Versions = {
+  project: "demo", target: "proj-demo", count: 2,
+  versions: [
+    { snapshot_id: "proj-demo:snap:8f2ad4c1b9e0", version: 2, content_hash: "8f2ad4c1b9e0", sealed_at: "2m ago", parent: "proj-demo:snap:71c9", note: "post-review", epistemic_mode: "attested" },
+    { snapshot_id: "proj-demo:snap:71c9", version: 1, content_hash: "71c9aa02", sealed_at: "1h ago", parent: null, note: "initial", epistemic_mode: "attested" },
+  ],
+};
+const STUB_CURATION: Curation = {
+  project: "demo", target: null, epistemic_weighted: true, count: 2, curation_score: 1.6,
+  endorsements: [
+    { target: "proj-demo:ent:hellgraph", endorser: "0000-0002-1825-0097", note: "verified independently", at: "5m ago" },
+    { target: "proj-demo:ent:provenance", endorser: "curator:noetica", note: null, at: "1h ago" },
+  ],
+};
+
+async function _read<T>(path: string, stub: T): Promise<T> {
+  if (!BASE) return stub;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}${path}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export const loadCommons = (project: string) => _read(`/api/studio/commons?project=${encodeURIComponent(project)}`, STUB_COMMONS);
+export const loadFair = (project: string) => _read(`/api/studio/fair?project=${encodeURIComponent(project)}`, STUB_FAIR);
+export const loadEcosystem = (project: string) => _read(`/api/studio/ecosystem?project=${encodeURIComponent(project)}`, STUB_ECOSYSTEM);
+export const loadVersions = (project: string) => _read(`/api/studio/versions?project=${encodeURIComponent(project)}`, STUB_VERSIONS);
+export const loadCuration = (project: string, target?: string) =>
+  _read(`/api/studio/curation?project=${encodeURIComponent(project)}${target ? `&target=${encodeURIComponent(target)}` : ""}`, STUB_CURATION);
+
+export async function endorse(
+  input: { project: string; target: string; endorser: string; note?: string; revoke?: boolean },
+  token: string,
+): Promise<{ endorsement_id: string; target: string; endorser: string; revoked: boolean; proof_carrying: boolean }> {
+  if (!BASE) return { endorsement_id: `stub:endorse:${input.target}`, target: input.target, endorser: input.endorser, revoked: !!input.revoke, proof_carrying: true };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/endorse`, {
+    method: "POST", headers: writeHeaders(token), body: JSON.stringify(input),
+  });
+  if (!res.ok) throw writeError("endorse failed", res.status);
+  return await res.json();
 }
 
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -4,6 +4,7 @@ import { loadStudio, loadReceipts, mintCitation, SECTION_COUNT, EPISTEMIC_COLORS
 import StudioGraph from "../components/StudioGraph.vue";
 import StudioQuery from "../components/StudioQuery.vue";
 import StudioExperiments from "../components/StudioExperiments.vue";
+import StudioCommons from "../components/StudioCommons.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -56,6 +57,7 @@ const sections: { id: StudioSection; label: string; icon: string; group: string;
   { id: "query",       label: "Query",         icon: "⌗", group: "Knowledge engineering", blurb: "SPARQL / Cypher / Gremlin over the live kernel — results you can replay (proof-carrying) and whose facts carry epistemic status." },
   { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
   { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
+  { id: "commons",     label: "Commons",       icon: "◆", group: "Commons", blurb: "The proof-carrying knowledge commons — FAIR+ metadata, sovereign DOIs, immutable preservation, ORCID/OpenAIRE + agent hooks, and epistemic-weighted community curation." },
 ];
 const groups = computed(() => [...new Set(sections.map((s) => s.group))]);
 
@@ -91,6 +93,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   query:       [{ label: "Run", hint: "SPARQL/Cypher/Gremlin over the kernel" }, { label: "Replay", hint: "re-evaluate by query hash" }, { label: "Export", hint: "results + proof" }],
   retrieval:   [{ label: "Query", hint: "run fibered retrieval" }, { label: "Rebuild index", hint: "re-embed" }, { label: "Use in notebook", hint: "attach retriever" }],
   generation:  [{ label: "Run", hint: "New-Hope grounded synthesis" }, { label: "→ Annotation set", hint: "into the workbench" }, { label: "→ Tune", hint: "generation-tuning" }],
+  commons:     [{ label: "Cite", hint: "mint a sovereign DOI" }, { label: "Preserve", hint: "seal an immutable version" }, { label: "Export FAIR", hint: "schema.org / DataCite / PROV-O" }],
 };
 </script>
 
@@ -203,6 +206,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
         <StudioQuery v-else-if="section === 'query'" :project="project" />
         <!-- Experiments = runs as proof-carrying graph facts (WS#32) -->
         <StudioExperiments v-else-if="section === 'experiments'" :project="project" />
+        <!-- Commons = the proof-carrying knowledge commons (WS#36–39) -->
+        <StudioCommons v-else-if="section === 'commons'" :project="project" />
 
         <!-- skeletons -->
         <div v-else-if="loading" class="grid">


### PR DESCRIPTION
Makes the Wave 5 backend (already merged in prophet-platform: PRs #815–818) **real in the product**. New **Commons** section in Studio surfacing:

- **FAIR+ scorecard** — Findable/Accessible/Interoperable/Reusable + the beat: epistemic status, provenance chain, hash-sealed tags, plus the sovereign PID + DataCite DOI.
- **Commons at scale** — facts / citations / versions / endorsements / contributors, the epistemic distribution bar, and the **epistemic quality index** (quality, not just volume).
- **Preservation chain** — sealed, content-addressed versions (re-hashable), newest first.
- **Ecosystem hooks** — DOI ↗, ORCID contributors, OpenAIRE-harvestable, and the **agent capability manifest** (verifiable access verbs — discovery for agents, not just humans).
- **Community curation** — the endorsement table + an **epistemic-weighted curation score**, with a governed (write-token, revocable) *Endorse a fact* form.

New `studioApi` funcs with dev-mode stubs (works in the mocked `!BASE` shell). `vue-tsc --noEmit` clean (exit 0).