### PR TITLE
Studio: Operations cockpit — make pipelines/registry/catalog/compute operable in-product

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioOps.vue
+++ b/socioprophet-web/app-vue/src/components/StudioOps.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+// The Operations cockpit — the Foundry-Workshop answer: makes the studio's data plane OPERABLE, not just
+// callable. Pipelines (run), model registry (promote), data catalog, pay-gated compute (submit an execution),
+// and GraphRAG communities — every action proof-carrying and, for compute, entitlement-gated like Databricks/
+// Foundry but sovereign + multi-backend.
+import { ref, onMounted, watch } from "vue";
+import {
+  loadPipelines, runPipeline, loadModels, promoteModel, loadCatalog, loadCompute, execute, loadCommunities,
+  EPISTEMIC_COLORS,
+  type Pipeline, type ModelEntry, type Dataset, type Compute, type Community, type ExecResult,
+} from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const pipelines = ref<Pipeline[]>([]);
+const models = ref<ModelEntry[]>([]);
+const datasets = ref<Dataset[]>([]);
+const compute = ref<Compute | null>(null);
+const communities = ref<Community[]>([]);
+const loading = ref(true);
+const err = ref("");
+const token = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try {
+    const [p, m, c, cp, cm] = await Promise.all([
+      loadPipelines(props.project), loadModels(props.project), loadCatalog(props.project),
+      loadCompute(props.project), loadCommunities(props.project),
+    ]);
+    pipelines.value = p.pipelines; models.value = m.models; datasets.value = c.datasets;
+    compute.value = cp; communities.value = cm.communities;
+  } catch (e) { err.value = e instanceof Error ? e.message : "failed to load operations"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+const STAGES = ["none", "staging", "production", "archived"];
+const busy = ref(""); const flash = ref("");
+function say(msg: string) { flash.value = msg; setTimeout(() => (flash.value = ""), 2600); }
+
+async function doPromote(name: string, version: string, stage: string) {
+  busy.value = `${name}:${version}`;
+  try { const r = await promoteModel({ project: props.project, name, version, stage }, token.value); say(`${name} v${version} → ${r.stage}`); await load(); }
+  catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
+  finally { busy.value = ""; }
+}
+async function doRun(pipeline: string) {
+  busy.value = pipeline;
+  try { const r = await runPipeline({ project: props.project, pipeline }, token.value); say(`Ran ${pipeline} · ${r.status}`); }
+  catch (e) { say(e instanceof Error ? e.message : "run failed"); }
+  finally { busy.value = ""; }
+}
+
+// compute / execute
+const exBackend = ref("mesh-k8s");
+const exKind = ref("notebook-cell");
+const exRef = ref("");
+const exResult = ref<ExecResult | null>(null);
+const exBusy = ref(false);
+async function submitExec() {
+  exBusy.value = true; exResult.value = null;
+  try { exResult.value = await execute({ project: props.project, kind: exKind.value, backend: exBackend.value, ref: exRef.value || undefined }, token.value); }
+  catch (e) { say(e instanceof Error ? e.message : "execute failed"); }
+  finally { exBusy.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function kv(o: Record<string, number>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
+</script>
+
+<template>
+  <div class="ops">
+    <div class="obar">
+      <span class="cnt">Operations · pipelines · registry · catalog · compute · communities</span>
+      <div class="spacer" />
+      <input v-model="token" type="password" class="tok" placeholder="write token" title="required for run / promote / execute" />
+      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+    </div>
+    <p v-if="flash" class="flash">{{ flash }}</p>
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading operations…</p>
+
+    <div v-else class="grid">
+      <!-- Pay-gated compute -->
+      <section class="card wide" v-if="compute">
+        <header class="ch"><span class="ci">⚙</span> Compute<span class="tagline">pay-gated · sovereign · multi-backend</span></header>
+        <div class="backends">
+          <label v-for="b in compute.backends" :key="b.id" class="backend" :class="{ sel: exBackend === b.id, ent: b.entitled }">
+            <input type="radio" name="backend" :value="b.id" v-model="exBackend" />
+            <span class="bn">{{ b.id }}<i class="bk">{{ b.kind }}</i></span>
+            <span class="bnote">{{ b.note }}</span>
+            <span class="bstate" :class="{ on: b.entitled }">{{ b.entitled ? "entitled" : "available" }}</span>
+          </label>
+        </div>
+        <div class="exrow">
+          <select v-model="exKind" class="sel-k">
+            <option>notebook-cell</option><option>pipeline-step</option><option>job</option><option>query</option>
+          </select>
+          <input v-model="exRef" class="ref" placeholder="ref (notebook / pipeline id) — optional" />
+          <button class="primary" @click="submitExec" :disabled="exBusy">{{ exBusy ? "…" : "Submit run" }}</button>
+        </div>
+        <div v-if="exResult" class="exres" :class="{ gated: !exResult.ok }">
+          <template v-if="exResult.ok">
+            ✓ dispatched to <b>{{ exResult.backend }}</b> · receipt <code class="mono">{{ exResult.receipt.correlation_id }}</code>
+            <span class="rep">replayable</span>
+          </template>
+          <template v-else>
+            🔒 <b>entitlement required</b> — {{ exResult.message }}
+          </template>
+        </div>
+        <p class="sub">Same pay-gated model as Databricks/Foundry — <b>capability available, runtime provisioned only when entitled</b> — but the compute is sovereign (your mesh) or bring-your-own, and every run emits a governed, replayable receipt.</p>
+      </section>
+
+      <!-- Model registry -->
+      <section class="card" v-if="models.length">
+        <header class="ch"><span class="ci">◈</span> Model registry<span class="score">{{ models.reduce((n, m) => n + m.versions.length, 0) }} versions</span></header>
+        <div v-for="m in models" :key="m.name" class="model">
+          <div class="mname">{{ m.name }}</div>
+          <div v-for="v in m.versions" :key="v.model_id" class="mver">
+            <span class="vv">v{{ v.version }}</span>
+            <span class="stage" :class="v.stage">{{ v.stage }}</span>
+            <span class="mono met">{{ kv(v.metrics) }}</span>
+            <span v-if="v.run" class="lineage mono" :title="'produced_by → run'">↳ {{ v.run.split(':').pop() }}</span>
+            <select class="promote" :disabled="busy === `${m.name}:${v.version}`"
+                    @change="e => doPromote(m.name, v.version, (e.target as HTMLSelectElement).value)">
+              <option value="" disabled selected>promote…</option>
+              <option v-for="s in STAGES" :key="s" :value="s" :disabled="s === v.stage">{{ s }}</option>
+            </select>
+          </div>
+        </div>
+        <p class="sub">Versions carry their <b>producing run</b> (provenance travels with the model); stage transitions are governed events — beats MLflow.</p>
+      </section>
+
+      <!-- Pipelines -->
+      <section class="card" v-if="pipelines.length">
+        <header class="ch"><span class="ci">⛓</span> Pipelines<span class="score">{{ pipelines.length }}</span></header>
+        <div v-for="p in pipelines" :key="p.pipeline_id" class="pipe">
+          <div class="prow">
+            <span class="pname">{{ p.name }}</span>
+            <button class="run" @click="doRun(p.name)" :disabled="busy === p.name">▷ Run</button>
+          </div>
+          <div class="dag">
+            <template v-for="(s, i) in p.steps" :key="s.id">
+              <span class="step" :title="s.kind">{{ s.id }}</span><span v-if="i < p.steps.length - 1" class="arrow">→</span>
+            </template>
+          </div>
+        </div>
+        <p class="sub">A proof-carrying DAG with a governed run ledger; lineage IS the graph — beats Databricks Workflows / Foundry Pipeline Builder.</p>
+      </section>
+
+      <!-- Data catalog -->
+      <section class="card" v-if="datasets.length">
+        <header class="ch"><span class="ci">▤</span> Data catalog<span class="score">{{ datasets.length }}</span></header>
+        <table class="cat">
+          <tbody>
+            <tr v-for="d in datasets" :key="d.id">
+              <td class="nm">{{ d.name }}</td>
+              <td><span v-if="d.connector" class="pill">{{ d.connector }}</span></td>
+              <td class="mono cols">{{ d.columns.join(", ") }}</td>
+              <td><span class="epi" :style="{ borderColor: color(d.epistemic_mode), color: color(d.epistemic_mode) }">{{ d.epistemic_mode }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="sub">Datasets are proof-carrying graph nodes — provenance + epistemic status native, not a bolt-on catalog.</p>
+      </section>
+
+      <!-- GraphRAG communities -->
+      <section class="card wide" v-if="communities.length">
+        <header class="ch"><span class="ci">◍</span> GraphRAG communities<span class="score">{{ communities.length }} · {{ communities[0] ? 'louvain' : '' }}</span></header>
+        <div class="comms">
+          <div v-for="c in communities" :key="c.community" class="comm">
+            <div class="crow"><b>{{ c.size }}</b> nodes
+              <span class="mb-bar" v-if="c.size">
+                <i v-for="(n, mode) in c.epistemic_distribution" :key="mode" :style="{ width: (n / c.size * 100) + '%', background: color(mode) }" :title="mode + ': ' + n" />
+              </span>
+            </div>
+            <div class="top">{{ c.top_members.map(t => t.label).join(" · ") }}</div>
+          </div>
+        </div>
+        <p class="sub">Communities detected over the <b>proof-carrying</b> graph (deterministic Louvain); each carries its epistemic profile — summaries attach next, frontier-authored.</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ops { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.obar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.obar .cnt { color: #5f6368; font-size: 12px; } .obar .spacer { flex: 1; }
+.obar .tok { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 130px; }
+.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.flash { background: #eaf5ee; color: #137333; border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
+.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: #1a73e8; } .ch .tagline { margin-left: auto; font-size: 10.5px; color: #1a73e8; background: #e8f0fe; border-radius: 10px; padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: #5f6368; background: #f1f3f4; border-radius: 10px; padding: 2px 9px; }
+.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.sub { color: #5f6368; font-size: 12px; margin: 10px 0 0; } .sub b { color: #202124; }
+
+/* compute */
+.backends { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 8px; margin-bottom: 10px; }
+.backend { display: grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto; gap: 2px 8px; align-items: center;
+  border: 1px solid #e8eaed; border-radius: 10px; padding: 8px 10px; cursor: pointer; }
+.backend.sel { border-color: #1a73e8; background: #f6f9fe; } .backend.ent { }
+.backend input { grid-row: 1 / 3; } .bn { font-weight: 600; font-size: 13px; } .bn .bk { font-style: normal; font-size: 10px; color: #5f6368; margin-left: 6px; }
+.bnote { grid-column: 2; font-size: 11px; color: #5f6368; } .bstate { grid-column: 2; font-size: 10px; color: #b06000; } .bstate.on { color: #137333; }
+.exrow { display: flex; gap: 6px; margin-bottom: 8px; }
+.exrow .sel-k { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.exrow .ref { flex: 1; border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.primary:disabled { opacity: .6; }
+.exres { font-size: 12.5px; border-radius: 8px; padding: 8px 10px; background: #eaf5ee; color: #137333; }
+.exres.gated { background: #fef7e0; color: #b06000; }
+.exres .rep { margin-left: 6px; font-size: 10px; background: #fff; border-radius: 8px; padding: 1px 6px; }
+
+/* models */
+.model { margin-bottom: 8px; } .mname { font-weight: 600; margin-bottom: 3px; }
+.mver { display: flex; align-items: center; gap: 8px; font-size: 12.5px; padding: 3px 0; flex-wrap: wrap; }
+.vv { font-weight: 700; color: #1a73e8; }
+.stage { font-size: 10px; border-radius: 8px; padding: 1px 7px; background: #f1f3f4; color: #5f6368; }
+.stage.production { background: #eaf5ee; color: #137333; } .stage.staging { background: #e8f0fe; color: #1a73e8; } .stage.archived { background: #f1f3f4; color: #80868b; }
+.met { color: #137333; } .lineage { color: #5f6368; }
+.promote { margin-left: auto; border: 1px solid #dadce0; border-radius: 8px; font-size: 11.5px; padding: 2px 6px; }
+
+/* pipelines */
+.pipe { margin-bottom: 8px; } .prow { display: flex; align-items: center; gap: 8px; }
+.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid #1a73e8; background: #fff; color: #1a73e8; border-radius: 8px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
+.dag { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; margin-top: 5px; }
+.step { font-size: 11.5px; background: #f1f3f4; border-radius: 7px; padding: 2px 9px; } .arrow { color: #9aa0a6; }
+
+/* catalog */
+.cat { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.cat td { padding: 5px 8px; border-bottom: 1px solid #f1f3f4; } .cat tr:last-child td { border-bottom: 0; }
+.cat .nm { font-weight: 600; } .cat .cols { color: #5f6368; } .pill { font-size: 10px; background: #eef0f3; border-radius: 8px; padding: 1px 7px; color: #5f6368; }
+.epi { font-size: 10px; border: 1px solid; border-radius: 8px; padding: 1px 7px; }
+
+/* communities */
+.comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
+.comm { border: 1px solid #f1f3f4; border-radius: 10px; padding: 8px 10px; }
+.crow { display: flex; align-items: center; gap: 8px; font-size: 12.5px; } .crow b { font-size: 16px; }
+.mb-bar { display: flex; height: 7px; flex: 1; border-radius: 5px; overflow: hidden; background: #f1f3f4; } .mb-bar i { display: block; height: 100%; }
+.top { font-size: 11.5px; color: #5f6368; margin-top: 5px; }
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -10,6 +10,7 @@ const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_
 export type StudioSection =
   | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
   | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation" // Knowledge engineering
+  | "operations"                                                                // Operations cockpit (WS#45–48/#31)
   | "commons";                                                                  // Commons (WS#36–39)
 
 export interface Notebook {
@@ -450,6 +451,89 @@ export async function endorse(
   });
   if (!res.ok) throw writeError("endorse failed", res.status);
   return await res.json();
+}
+
+// ── Operations panel (Databricks/Foundry-parity): pipelines · model registry · catalog · compute · communities ──
+export interface PipelineStepDef { id: string; kind: string; inputs?: string[]; outputs?: string[] }
+export interface Pipeline { pipeline_id: string; name: string; steps: PipelineStepDef[]; step_count: number }
+export interface ModelVersion { model_id: string; version: string; stage: string; metrics: Record<string, number>; run?: string | null }
+export interface ModelEntry { name: string; versions: ModelVersion[] }
+export interface Dataset { id: string; name: string; labels: string[]; connector?: string | null; epistemic_mode: string; columns: string[] }
+export interface ComputeBackend { id: string; kind: string; note: string; entitled: boolean; default?: boolean }
+export interface Compute { backends: ComputeBackend[]; entitled_any: boolean; model: string }
+export interface Community { community: string; size: number; top_members: { id: string; label: string; degree: number }[]; epistemic_distribution: Record<string, number> }
+export interface ExecReceipt { correlation_id: string; backend: string; replayable: boolean; bundle_ref: string; payload_sha256: string }
+export type ExecResult =
+  | { ok: true; execution_id: string; backend: string; status: string; receipt: ExecReceipt }
+  | { ok: false; entitlement_required: true; backend: string; message: string };
+
+const STUB_PIPELINES: { pipelines: Pipeline[]; count: number } = {
+  count: 1,
+  pipelines: [{ pipeline_id: "proj-demo:pipeline:etl_train", name: "ETL → train", step_count: 3,
+    steps: [{ id: "load", kind: "extract", outputs: ["raw"] }, { id: "clean", kind: "transform", inputs: ["raw"], outputs: ["tidy"] }, { id: "fit", kind: "train", inputs: ["tidy"] }] }],
+};
+const STUB_MODELS: { models: ModelEntry[]; count: number } = {
+  count: 2,
+  models: [{ name: "classifier", versions: [
+    { model_id: "proj-demo:model:classifier:2", version: "2", stage: "production", metrics: { acc: 0.93 }, run: "proj-demo:run:abc" },
+    { model_id: "proj-demo:model:classifier:1", version: "1", stage: "archived", metrics: { acc: 0.88 }, run: "proj-demo:run:aa0" }] }],
+};
+const STUB_CATALOG: { datasets: Dataset[]; count: number } = {
+  count: 2,
+  datasets: [
+    { id: "proj-demo:ingest:people", name: "people", labels: ["Person", "Ingested"], connector: "csv", epistemic_mode: "observed", columns: ["id", "name", "age"] },
+    { id: "proj-demo:ingest:orders", name: "orders", labels: ["Order", "Ingested"], connector: "postgres", epistemic_mode: "observed", columns: ["order_id", "total"] }],
+};
+const STUB_COMPUTE: Compute = {
+  entitled_any: false,
+  model: "pay-gated full service — capability available, runtime provisioned only when entitled",
+  backends: [
+    { id: "mesh-k8s", kind: "sovereign", default: true, note: "self-hosted sandbox on the paid mesh (kind / k3s / k8s / DinD)", entitled: false },
+    { id: "spark", kind: "sovereign", note: "a small Spark namespace on the mesh", entitled: false },
+    { id: "databricks", kind: "external", note: "connect to your own Databricks workspace", entitled: false }],
+};
+const STUB_COMMUNITIES: { communities: Community[]; count: number; inter_community_edges: number; algorithm: string } = {
+  count: 2, inter_community_edges: 3, algorithm: "louvain-modularity (deterministic, single-level)",
+  communities: [
+    { community: "proj-demo:community:a1b2", size: 7, epistemic_distribution: { verified: 3, observed: 4 }, top_members: [{ id: "proj-demo:ent:hellgraph", label: "HellGraph", degree: 6 }, { id: "proj-demo:ent:provenance", label: "provenance", degree: 4 }] },
+    { community: "proj-demo:community:c3d4", size: 4, epistemic_distribution: { observed: 4 }, top_members: [{ id: "proj-demo:ent:foundry", label: "Foundry", degree: 3 }] }],
+};
+
+export const loadPipelines = (project: string) => _read(`/api/studio/pipelines?project=${encodeURIComponent(project)}`, STUB_PIPELINES);
+export const loadModels = (project: string) => _read(`/api/studio/models?project=${encodeURIComponent(project)}`, STUB_MODELS);
+export const loadCatalog = (project: string) => _read(`/api/studio/catalog?project=${encodeURIComponent(project)}`, STUB_CATALOG);
+export const loadCompute = (project: string) => _read(`/api/studio/compute?project=${encodeURIComponent(project)}`, STUB_COMPUTE);
+export const loadCommunities = (project: string) => _read(`/api/studio/communities?project=${encodeURIComponent(project)}`, STUB_COMMUNITIES);
+
+export async function runPipeline(input: { project: string; pipeline: string; status?: string }, token: string): Promise<{ run_id: string; status: string }> {
+  if (!BASE) return { run_id: `stub:run:${input.pipeline}`, status: input.status ?? "finished" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/pipeline/run`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("pipeline run failed", res.status);
+  return await res.json();
+}
+
+export async function promoteModel(input: { project: string; name: string; version: string; stage: string }, token: string): Promise<{ model_id: string; stage: string; from_stage: string }> {
+  if (!BASE) return { model_id: `stub:model:${input.name}:${input.version}`, stage: input.stage, from_stage: "staging" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/model/promote`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("promote failed", res.status);
+  return await res.json();
+}
+
+export async function execute(
+  input: { project: string; kind: string; backend: string; ref?: string; code?: string },
+  token: string,
+): Promise<ExecResult> {
+  if (!BASE) return { ok: false, entitlement_required: true, backend: input.backend, message: "compute is a paid, provisioned service — provision an entitlement to run (dev stub)" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/execute`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (res.status === 402) {
+    const d = (await res.json().catch(() => ({}))) as { detail?: { message?: string } };
+    return { ok: false, entitlement_required: true, backend: input.backend, message: d.detail?.message ?? "compute entitlement required" };
+  }
+  if (!res.ok) throw writeError("execute failed", res.status);
+  return { ok: true, ...(await res.json()) };
 }
 
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -5,6 +5,7 @@ import StudioGraph from "../components/StudioGraph.vue";
 import StudioQuery from "../components/StudioQuery.vue";
 import StudioExperiments from "../components/StudioExperiments.vue";
 import StudioCommons from "../components/StudioCommons.vue";
+import StudioOps from "../components/StudioOps.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -57,6 +58,7 @@ const sections: { id: StudioSection; label: string; icon: string; group: string;
   { id: "query",       label: "Query",         icon: "⌗", group: "Knowledge engineering", blurb: "SPARQL / Cypher / Gremlin over the live kernel — results you can replay (proof-carrying) and whose facts carry epistemic status." },
   { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
   { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
+  { id: "operations",  label: "Operations",    icon: "⚙", group: "Operations", blurb: "The operations cockpit — run pipelines, promote models, browse the data catalog, submit pay-gated compute, and inspect GraphRAG communities. Every action proof-carrying; compute entitlement-gated (sovereign + multi-backend)." },
   { id: "commons",     label: "Commons",       icon: "◆", group: "Commons", blurb: "The proof-carrying knowledge commons — FAIR+ metadata, sovereign DOIs, immutable preservation, ORCID/OpenAIRE + agent hooks, and epistemic-weighted community curation." },
 ];
 const groups = computed(() => [...new Set(sections.map((s) => s.group))]);
@@ -94,6 +96,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   retrieval:   [{ label: "Query", hint: "run fibered retrieval" }, { label: "Rebuild index", hint: "re-embed" }, { label: "Use in notebook", hint: "attach retriever" }],
   generation:  [{ label: "Run", hint: "New-Hope grounded synthesis" }, { label: "→ Annotation set", hint: "into the workbench" }, { label: "→ Tune", hint: "generation-tuning" }],
   commons:     [{ label: "Cite", hint: "mint a sovereign DOI" }, { label: "Preserve", hint: "seal an immutable version" }, { label: "Export FAIR", hint: "schema.org / DataCite / PROV-O" }],
+  operations:  [{ label: "Run pipeline", hint: "governed run ledger" }, { label: "Promote model", hint: "staging → production" }, { label: "Submit compute", hint: "entitlement-gated execution" }],
 };
 </script>
 
@@ -206,6 +209,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
         <StudioQuery v-else-if="section === 'query'" :project="project" />
         <!-- Experiments = runs as proof-carrying graph facts (WS#32) -->
         <StudioExperiments v-else-if="section === 'experiments'" :project="project" />
+        <!-- Operations = the operable cockpit: pipelines/registry/catalog/compute/communities (WS#45–48/#31) -->
+        <StudioOps v-else-if="section === 'operations'" :project="project" />
         <!-- Commons = the proof-carrying knowledge commons (WS#36–39) -->
         <StudioCommons v-else-if="section === 'commons'" :project="project" />
 


### PR DESCRIPTION
The **ergonomics** leap — the Foundry-Workshop answer. All the Databricks/Foundry-parity backend (PRs #825–828) was *callable* but not *operable*; this makes it a cockpit.

New **Operations** section in Studio (`StudioOps.vue` + `studioApi` functions):

- **Pay-gated Compute** — backend picker (mesh-k8s / spark / databricks) with per-project **entitlement status**, and a *Submit run* that renders the **402 entitlement gate gracefully** ("🔒 entitlement required") vs. a dispatched receipt — the honest pay-gated model, sovereign + multi-backend.
- **Model registry** — versions with stage chips + **producing-run lineage** + a **Promote** control (staging → production, governed).
- **Pipelines** — the step DAG + a **Run** button (governed run ledger).
- **Data catalog** — datasets with connector + columns + epistemic status.
- **GraphRAG communities** — Louvain communities with epistemic-profile bars.

Every action is proof-carrying; writes need the token; compute is entitlement-gated. Dev-mode stubs so it renders in the mocked `!BASE` shell. `vue-tsc --noEmit` clean.

> This is the wedge-closing move: the proof-carrying moat only *converts* if the surface is operable. Next FE step toward Foundry parity: ontology **actions/writeback** (Workshop-style app building).