### PR TITLE
Epistemic-Carbon design system across app-vue (token spine)

### DIFF
--- a/socioprophet-web/app-vue/src/components/AppLauncher.vue
+++ b/socioprophet-web/app-vue/src/components/AppLauncher.vue
@@ -20,13 +20,13 @@ const open = ref(false);
 
 <style scoped>
 .launcher { position: relative; display: inline-flex; }
-.waffle { background: none; border: 0; cursor: pointer; color: #1a73e8; font-size: 21px; line-height: 1; padding: 4px; }
+.waffle { background: none; border: 0; cursor: pointer; color: var(--accent); font-size: 21px; line-height: 1; padding: 4px; }
 .backdrop { position: fixed; inset: 0; z-index: 40; }
-.grid { position: absolute; top: 36px; right: 0; z-index: 50; width: 312px; background: #fff; border: 0.5px solid #e0e0e0;
+.grid { position: absolute; top: 36px; right: 0; z-index: 50; width: 312px; background: #fff; border: 0.5px solid var(--hairline);
   border-radius: 12px; box-shadow: 0 8px 30px rgba(0,0,0,0.18); padding: 14px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px; }
 .tile { display: flex; flex-direction: column; align-items: center; gap: 5px; padding: 12px 4px; border-radius: 8px;
-  text-decoration: none; color: #3c4043; font-size: 12px; position: relative; }
-.tile:hover { background: #f5f5f5; }
+  text-decoration: none; color: var(--ink-2); font-size: 12px; position: relative; }
+.tile:hover { background: var(--sunken); }
 .tile .ti { font-size: 26px; }
-.st { position: absolute; top: 4px; right: 6px; font-size: 9px; color: #b0b0b0; font-style: normal; }
+.st { position: absolute; top: 4px; right: 6px; font-size: 9px; color: var(--faint); font-style: normal; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioCommons.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCommons.vue
@@ -50,7 +50,7 @@ async function submitEndorse() {
   finally { posting.value = false; }
 }
 
-function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
 function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
 </script>
 
@@ -180,63 +180,63 @@ function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
 </template>
 
 <style scoped>
-.cm { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.cm { font: 14px/1.5 var(--ui); color: var(--ink); }
 .cbar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.cbar .cnt { color: #5f6368; font-size: 12px; } .cbar .spacer { flex: 1; }
-.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.logbox { border: 1px solid #dadce0; border-radius: 10px; background: #f8f9fa; padding: 10px 12px; margin-bottom: 14px; }
+.cbar .cnt { color: var(--muted); font-size: 12px; } .cbar .spacer { flex: 1; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin-bottom: 14px; }
 .lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-.lrow input { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
 .lrow input.j { flex: 1; min-width: 150px; } .lrow input.tok { width: 120px; }
-.lrow button.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .lrow button.primary:disabled { opacity: .6; cursor: default; }
-.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: #137333; } .lfeedback.err { color: #c5221f; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
 
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
-.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; }
 .card.wide { grid-column: 1 / -1; }
 .ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
-.ch .ci { color: #1a73e8; } .ch .plus { color: #1a73e8; font-weight: 700; }
-.score { margin-left: auto; font-size: 11px; color: #5f6368; background: #f1f3f4; border-radius: 10px; padding: 2px 9px; font-variant-numeric: tabular-nums; }
-.score.hi { color: #137333; background: #eaf5ee; }
+.ch .ci { color: var(--accent); } .ch .plus { color: var(--accent); font-weight: 700; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: 10px; padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.score.hi { color: var(--ok); background: var(--ok-wash); }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
-.sub { color: #5f6368; font-size: 12px; margin: 10px 0 0; } .sub b { color: #202124; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
 
 .fair { display: flex; flex-wrap: wrap; gap: 6px; }
-.fq { font-size: 12px; border: 1px solid #e8eaed; color: #9aa0a6; border-radius: 8px; padding: 3px 9px; }
-.fq.on { color: #137333; border-color: #cbe6d3; background: #f4fbf6; }
+.fq { font-size: 12px; border: 1px solid var(--hairline); color: var(--faint); border-radius: 8px; padding: 3px 9px; }
+.fq.on { color: var(--ok); border-color: var(--ok-wash); background: var(--ok-wash); }
 .plusrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
-.ptag { font-size: 10.5px; color: #1a73e8; background: #e8f0fe; border-radius: 8px; padding: 2px 8px; }
+.ptag { font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 8px; padding: 2px 8px; }
 .ptag.sm { font-size: 9.5px; padding: 1px 6px; }
-.hint { color: #b06000; font-size: 12px; margin: 8px 0 0; }
+.hint { color: var(--warn); font-size: 12px; margin: 8px 0 0; }
 .ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
-.ids code { background: #f8f9fa; border: 1px solid #eceef1; border-radius: 6px; padding: 2px 7px; }
+.ids code { background: var(--sunken); border: 1px solid var(--hairline); border-radius: 6px; padding: 2px 7px; }
 
 .scale { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 10px; }
-.st { display: flex; flex-direction: column; } .st b { font-size: 20px; font-variant-numeric: tabular-nums; } .st span { font-size: 11px; color: #5f6368; }
-.mb-bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: #f1f3f4; } .mb-bar i { display: block; height: 100%; }
+.st { display: flex; flex-direction: column; } .st b { font-size: 20px; font-variant-numeric: tabular-nums; } .st span { font-size: 11px; color: var(--muted); }
+.mb-bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
 
 .vlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .vlist li { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
-.vv { font-weight: 700; color: #1a73e8; } .hash { background: #f8f9fa; border-radius: 5px; padding: 1px 6px; }
-.when { color: #5f6368; font-size: 11px; } .vnote { color: #5f6368; font-style: italic; }
+.vv { font-weight: 700; color: var(--accent); } .hash { background: var(--sunken); border-radius: 5px; padding: 1px 6px; }
+.when { color: var(--muted); font-size: 11px; } .vnote { color: var(--muted); font-style: italic; }
 
 .row2 { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 8px; }
-.link { color: #1a73e8; text-decoration: none; } .link:hover { text-decoration: underline; }
+.link { color: var(--accent); text-decoration: none; } .link:hover { text-decoration: underline; }
 .orcids { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
-.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: #202124; text-decoration: none; border: 1px solid #e8eaed; border-radius: 8px; padding: 2px 8px; }
+.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink); text-decoration: none; border: 1px solid var(--hairline); border-radius: 8px; padding: 2px 8px; }
 .orcid .oic { background: #a6ce39; color: #fff; font-size: 9px; font-weight: 700; border-radius: 3px; padding: 1px 3px; }
-.manifest { border-top: 1px solid #f1f3f4; padding-top: 8px; }
-.mtitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; display: flex; align-items: center; gap: 6px; }
+.manifest { border-top: 1px solid var(--sunken); padding-top: 8px; }
+.mtitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); display: flex; align-items: center; gap: 6px; }
 .verbs { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
-.verb { font-size: 11.5px; background: #f1f3f4; border-radius: 7px; padding: 2px 8px; color: #202124; } .verb.off { color: #b0b4b9; }
-.verb .vok { color: #137333; font-style: normal; margin-left: 3px; }
+.verb { font-size: 11.5px; background: var(--sunken); border-radius: 7px; padding: 2px 8px; color: var(--ink); } .verb.off { color: var(--faint); }
+.verb .vok { color: var(--ok); font-style: normal; margin-left: 3px; }
 
-.cscroll { overflow-x: auto; border: 1px solid #e8eaed; border-radius: 10px; }
+.cscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: 10px; }
 .cgrid { border-collapse: collapse; width: 100%; font-size: 12.5px; }
-.cgrid th { text-align: left; padding: 7px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
-.cgrid td { padding: 7px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; } .cgrid tr:last-child td { border-bottom: 0; }
+.cgrid th { text-align: left; padding: 7px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.cgrid td { padding: 7px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; } .cgrid tr:last-child td { border-bottom: 0; }
 .cgrid .nm { font-weight: 600; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioExperiments.vue
+++ b/socioprophet-web/app-vue/src/components/StudioExperiments.vue
@@ -45,7 +45,7 @@ async function submitLog() {
   finally { logging.value = false; }
 }
 
-function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
 function kv(o: Record<string, unknown>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
 </script>
 
@@ -94,29 +94,29 @@ function kv(o: Record<string, unknown>): string { return Object.entries(o).map((
 </template>
 
 <style scoped>
-.xp { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.xp { font: 14px/1.5 var(--ui); color: var(--ink); }
 .xbar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
-.xbar .cnt { color: #5f6368; font-size: 12px; } .xbar .spacer { flex: 1; }
-.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.xbar .cnt { color: var(--muted); font-size: 12px; } .xbar .spacer { flex: 1; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
-.logbox { border: 1px solid #dadce0; border-radius: 10px; background: #f8f9fa; padding: 10px 12px; margin-bottom: 12px; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin-bottom: 12px; }
 .lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-.lrow input { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
 .lrow input.j { flex: 1; min-width: 140px; } .lrow input.tok { width: 120px; }
-.lrow button.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .lrow button.primary:disabled { opacity: .6; cursor: default; }
-.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: #137333; } .lfeedback.err { color: #c5221f; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
-.xscroll { overflow-x: auto; border: 1px solid #e8eaed; border-radius: 10px; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+.xscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: 10px; }
 .xgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
-.xgrid th { text-align: left; padding: 8px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
-.xgrid td { padding: 8px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; }
+.xgrid th { text-align: left; padding: 8px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.xgrid td { padding: 8px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; }
 .xgrid tr:last-child td { border-bottom: 0; }
-.xgrid .nm { font-weight: 600; } .xgrid .met { color: #137333; }
-.pill { font-size: 10.5px; border-radius: 10px; padding: 1px 8px; background: #eef0f3; color: #5f6368; }
-.pill.finished { background: #eaf5ee; color: #137333; } .pill.running { background: #e8f0fe; color: #1a73e8; } .pill.failed { background: #fbe9e8; color: #c5221f; }
+.xgrid .nm { font-weight: 600; } .xgrid .met { color: var(--ok); }
+.pill { font-size: 10.5px; border-radius: 10px; padding: 1px 8px; background: var(--hairline); color: var(--muted); }
+.pill.finished { background: var(--ok-wash); color: var(--ok); } .pill.running { background: var(--accent-wash); color: var(--accent); } .pill.failed { background: var(--fail-wash); color: var(--fail); }
 .epi { font-size: 10.5px; border: 1px solid; border-radius: 10px; padding: 1px 8px; }
-.when { color: #5f6368; font-size: 11px; }
-.note { color: #5f6368; font-size: 12.5px; margin-top: 8px; } .note b { color: #202124; }
+.when { color: var(--muted); font-size: 11px; }
+.note { color: var(--muted); font-size: 12.5px; margin-top: 8px; } .note b { color: var(--ink); }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioGovernance.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGovernance.vue
@@ -82,7 +82,7 @@ async function doHdtPromote(o: HdtObservation, to_state: string, actor_kind: str
   } catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
 }
 
-function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
 </script>
 
 <template>
@@ -215,51 +215,51 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
 </template>
 
 <style scoped>
-.gov { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.gov { font: 14px/1.5 var(--ui); color: var(--ink); }
 .gbar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.gbar .cnt { color: #5f6368; font-size: 12px; } .gbar .spacer { flex: 1; }
-.gbar .tok { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 120px; }
-.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.flash { background: #eaf5ee; color: #137333; border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.gbar .cnt { color: var(--muted); font-size: 12px; } .gbar .spacer { flex: 1; }
+.gbar .tok { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 120px; }
+.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 12px; }
-.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; } .card.wide { grid-column: 1 / -1; }
+.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; } .card.wide { grid-column: 1 / -1; }
 .ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
-.ch .ci { color: #1a73e8; } .ch .tagline { margin-left: auto; font-size: 10.5px; color: #1a73e8; background: #e8f0fe; border-radius: 10px; padding: 2px 9px; font-weight: 500; }
-.score { margin-left: auto; font-size: 11px; color: #137333; background: #eaf5ee; border-radius: 10px; padding: 2px 9px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 10px; padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--ok); background: var(--ok-wash); border-radius: 10px; padding: 2px 9px; }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
-.sub { color: #5f6368; font-size: 12px; margin: 10px 0 0; } .sub b { color: #202124; }
-.j { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.mini { border: 1px solid #dadce0; background: #fff; border-radius: 7px; padding: 3px 9px; font-size: 11.5px; cursor: pointer; }
-.mini.go { border-color: #1a73e8; color: #1a73e8; } .mini.danger { border-color: #e0a44a; color: #b06000; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
+.j { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.mini { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 7px; padding: 3px 9px; font-size: 11.5px; cursor: pointer; }
+.mini.go { border-color: var(--accent); color: var(--accent); } .mini.danger { border-color: var(--warn); color: var(--warn); }
 
 .orow { display: flex; gap: 6px; margin-bottom: 8px; } .orow .j { flex: 1; }
 .clist { list-style: none; margin: 0 0 8px; padding: 0; }
 .clist li { display: flex; align-items: center; gap: 8px; padding: 3px 6px; border-radius: 6px; cursor: pointer; }
-.clist li:hover, .clist li.sel { background: #f6f9fe; } .clist .pc { margin-left: auto; font-size: 11px; color: #80868b; }
-.cdetail { border-top: 1px solid #f1f3f4; padding-top: 8px; margin-top: 6px; }
-.cd-h { display: flex; gap: 8px; align-items: baseline; } .cd-h .sub { font-size: 11px; color: #5f6368; }
+.clist li:hover, .clist li.sel { background: var(--accent-wash); } .clist .pc { margin-left: auto; font-size: 11px; color: var(--faint); }
+.cdetail { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; }
+.cd-h { display: flex; gap: 8px; align-items: baseline; } .cd-h .sub { font-size: 11px; color: var(--muted); }
 .props { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
-.prop { font-size: 10.5px; background: #f1f3f4; border-radius: 6px; padding: 1px 6px; font-family: ui-monospace, Menlo, monospace; }
-.prop.object { background: #e8f0fe; color: #1a73e8; } .prop i { font-style: normal; opacity: .6; }
+.prop { font-size: 10.5px; background: var(--sunken); border-radius: 6px; padding: 1px 6px; font-family: ui-monospace, Menlo, monospace; }
+.prop.object { background: var(--accent-wash); color: var(--accent); } .prop i { font-style: normal; opacity: .6; }
 
-.action { border: 1px solid #f1f3f4; border-radius: 8px; padding: 6px 8px; margin-bottom: 6px; }
-.arow { display: flex; align-items: center; gap: 8px; } .arow .tt { margin-left: auto; background: #f1f3f4; border-radius: 6px; padding: 1px 6px; }
-.eff { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 4px; } .eff .e { font-size: 10.5px; color: #5f6368; background: #f8f9fa; border-radius: 6px; padding: 1px 6px; }
-.invoke { border-top: 1px solid #f1f3f4; padding-top: 8px; margin-top: 6px; display: flex; flex-direction: column; gap: 6px; }
+.action { border: 1px solid var(--sunken); border-radius: 8px; padding: 6px 8px; margin-bottom: 6px; }
+.arow { display: flex; align-items: center; gap: 8px; } .arow .tt { margin-left: auto; background: var(--sunken); border-radius: 6px; padding: 1px 6px; }
+.eff { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 4px; } .eff .e { font-size: 10.5px; color: var(--muted); background: var(--sunken); border-radius: 6px; padding: 1px 6px; }
+.invoke { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; display: flex; flex-direction: column; gap: 6px; }
 .irow { display: flex; gap: 6px; } .irow .j { flex: 1; } .invoke .j { width: 100%; }
 
 .membrane { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
-.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid #e8eaed; border-radius: 8px; padding: 5px 9px; }
-.mstate.canon { border-color: #cbe6d3; background: #f4fbf6; }
-.ms-n { font-weight: 600; font-size: 12px; } .ms-epi { font-size: 10.5px; } .ms-arrow { color: #9aa0a6; margin: 0 2px; }
-.invariant { background: #fef7e0; color: #b06000; border-radius: 8px; padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
+.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid var(--hairline); border-radius: 8px; padding: 5px 9px; }
+.mstate.canon { border-color: var(--ok-wash); background: var(--ok-wash); }
+.ms-n { font-weight: 600; font-size: 12px; } .ms-epi { font-size: 10.5px; } .ms-arrow { color: var(--faint); margin: 0 2px; }
+.invariant { background: var(--warn-wash); color: var(--warn); border-radius: 8px; padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
 .submit { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
 .wgrid { width: 100%; border-collapse: collapse; font-size: 12.5px; }
-.wgrid th { text-align: left; padding: 6px 8px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 10.5px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
-.wgrid td { padding: 6px 8px; border-bottom: 1px solid #f1f3f4; } .wgrid .nm { font-weight: 600; }
-.state { font-size: 10.5px; border-radius: 8px; padding: 1px 8px; background: #f1f3f4; color: #5f6368; } .state.canon { background: #eaf5ee; color: #137333; }
+.wgrid th { text-align: left; padding: 6px 8px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 10.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.wgrid td { padding: 6px 8px; border-bottom: 1px solid var(--sunken); } .wgrid .nm { font-weight: 600; }
+.state { font-size: 10.5px; border-radius: 8px; padding: 1px 8px; background: var(--sunken); color: var(--muted); } .state.canon { background: var(--ok-wash); color: var(--ok); }
 .epi { font-size: 10px; border: 1px solid; border-radius: 8px; padding: 1px 7px; } .ev { text-align: center; }
 .promote { display: flex; gap: 4px; flex-wrap: wrap; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioGraph.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGraph.vue
@@ -272,7 +272,7 @@ async function loadDerived() {
                :transform="`translate(${n.x},${n.y})`" @pointerdown="onNodeDown(n, $event)"
                @pointerenter="hovered = n" @pointerleave="hovered = null" @click.stop="selected = n">
               <circle :r="n.r" :fill="color(n.epistemic_mode)"
-                      :stroke="selected?.id === n.id ? '#202124' : '#fff'" :stroke-width="selected?.id === n.id ? 2 : 1.2" />
+                      :stroke="selected?.id === n.id ? 'var(--ink)' : '#fff'" :stroke-width="selected?.id === n.id ? 2 : 1.2" />
               <text v-if="showLabels || hovered?.id === n.id || selected?.id === n.id"
                     :x="n.r + 4" y="4" class="lbl">{{ n.name }}</text>
             </g>
@@ -320,71 +320,71 @@ async function loadDerived() {
 </template>
 
 <style scoped>
-.ge { font: 14px/1.5 system-ui, sans-serif; color: #202124; position: relative; }
+.ge { font: 14px/1.5 var(--ui); color: var(--ink); position: relative; }
 .ge-head { display: flex; justify-content: space-between; align-items: flex-start; }
-.ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: #5f6368; font-weight: 400; }
-.ge-head .sub { color: #5f6368; margin: 4px 0 12px; max-width: 640px; } .ge-head .sub b { color: #202124; }
+.ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: var(--muted); font-weight: 400; }
+.ge-head .sub { color: var(--muted); margin: 4px 0 12px; max-width: 640px; } .ge-head .sub b { color: var(--ink); }
 .tools { display: flex; gap: 6px; }
-.tbtn { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
-.tbtn:hover { background: #f8f9fa; }
-.tbtn.on { background: #e8f0fe; border-color: #1a73e8; color: #1a73e8; }
-.addbox { border: 1px solid #dadce0; border-radius: 10px; background: #f8f9fa; padding: 10px 12px; margin: 0 0 12px; }
+.tbtn { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
+.tbtn:hover { background: var(--sunken); }
+.tbtn.on { background: var(--accent-wash); border-color: var(--accent); color: var(--accent); }
+.addbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin: 0 0 12px; }
 .addrow { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.addrow input, .addrow select { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; min-width: 120px; }
+.addrow input, .addrow select { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; min-width: 120px; }
 .addrow input.short { min-width: 90px; width: 110px; }
-.addrow .arr { color: #5f6368; }
-.addrow .seg { display: inline-flex; border: 1px solid #dadce0; border-radius: 8px; overflow: hidden; }
-.addrow .seg button { border: 0; background: #fff; padding: 6px 10px; font-size: 12px; cursor: pointer; color: #5f6368; }
-.addrow .seg button.on { background: #1a73e8; color: #fff; }
-.addrow button.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.addrow .arr { color: var(--muted); }
+.addrow .seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: 8px; overflow: hidden; }
+.addrow .seg button { border: 0; background: #fff; padding: 6px 10px; font-size: 12px; cursor: pointer; color: var(--muted); }
+.addrow .seg button.on { background: var(--accent); color: #fff; }
+.addrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .addrow button.primary:disabled { opacity: .6; cursor: default; }
-.addfeedback { margin: 8px 0 0; font-size: 12.5px; } .addfeedback.ok { color: #137333; } .addfeedback.err { color: #c5221f; }
-.addnote { margin: 6px 0 0; font-size: 11px; color: #5f6368; }
+.addfeedback { margin: 8px 0 0; font-size: 12.5px; } .addfeedback.ok { color: var(--ok); } .addfeedback.err { color: var(--fail); }
+.addnote { margin: 6px 0 0; font-size: 11px; color: var(--muted); }
 
 .dist { margin: 4px 0 12px; }
-.dist .bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: #eceff1; }
+.dist .bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: var(--sunken); }
 .dist .bar span { display: block; }
-.dist .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 12px; color: #5f6368; }
+.dist .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 12px; color: var(--muted); }
 .dist .lg i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 4px; vertical-align: middle; }
 
-.canvas-wrap { position: relative; border: 1px solid #e8eaed; border-radius: 12px; background:
-  radial-gradient(circle at 1px 1px, #f1f3f4 1px, transparent 0) 0 0 / 22px 22px, #fff; overflow: hidden; }
+.canvas-wrap { position: relative; border: 1px solid var(--hairline); border-radius: 12px; background:
+  radial-gradient(circle at 1px 1px, var(--sunken) 1px, transparent 0) 0 0 / 22px 22px, #fff; overflow: hidden; }
 .canvas { display: block; width: 100%; height: 560px; touch-action: none; cursor: grab; }
 .canvas:active { cursor: grabbing; }
-.edges line { stroke: #c4cad1; transition: opacity .15s; }
+.edges line { stroke: var(--hairline-strong); transition: opacity .15s; }
 .edges line.dim { opacity: .12; }
 .nodes g { cursor: pointer; transition: opacity .15s; }
 .nodes g.dim { opacity: .18; }
-.nodes .lbl { font: 500 11px/1 system-ui, sans-serif; fill: #202124; paint-order: stroke; stroke: #fff; stroke-width: 3px; stroke-linejoin: round; pointer-events: none; }
-.hint { position: absolute; bottom: 8px; left: 10px; font-size: 11px; color: #9aa0a6; pointer-events: none; }
+.nodes .lbl { font: 500 11px/1 var(--ui); fill: var(--ink); paint-order: stroke; stroke: #fff; stroke-width: 3px; stroke-linejoin: round; pointer-events: none; }
+.hint { position: absolute; bottom: 8px; left: 10px; font-size: 11px; color: var(--faint); pointer-events: none; }
 
-.note { font-size: 12px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 6px 10px; margin: 0 0 12px; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.note { font-size: 12px; color: var(--warn); background: var(--warn-wash); border-radius: 8px; padding: 6px 10px; margin: 0 0 12px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
 
-.prov { position: absolute; top: 74px; right: 8px; width: 300px; background: #fff; border: 1px solid #e8eaed; border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
-.prov .x { position: absolute; top: 10px; right: 12px; border: none; background: none; cursor: pointer; color: #5f6368; }
-.prov .pk { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: #5f6368; }
+.prov { position: absolute; top: 74px; right: 8px; width: 300px; background: #fff; border: 1px solid var(--hairline); border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
+.prov .x { position: absolute; top: 10px; right: 12px; border: none; background: none; cursor: pointer; color: var(--muted); }
+.prov .pk { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--muted); }
 .prov h3 { margin: 4px 0 12px; font-size: 17px; }
-.prov dl { margin: 0; } .prov dl > div { display: flex; gap: 10px; padding: 5px 0; border-bottom: 1px solid #f1f3f4; }
-.prov dt { color: #5f6368; min-width: 96px; font-size: 12px; } .prov dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+.prov dl { margin: 0; } .prov dl > div { display: flex; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--sunken); }
+.prov dt { color: var(--muted); min-width: 96px; font-size: 12px; } .prov dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
 .prov .mono { font-family: ui-monospace, monospace; font-size: 11px; }
 .prov .pill { border: 1.5px solid; border-radius: 8px; padding: 0 8px; font-size: 12px; font-weight: 600; }
 .prov .acts { display: flex; gap: 8px; margin-top: 14px; }
-.prov .acts button { border: 1px solid #dadce0; background: #fff; border-radius: 16px; padding: 5px 12px; font-size: 12px; cursor: pointer; }
-.prov .acts button.primary { background: #1a73e8; color: #fff; border-color: #1a73e8; }
+.prov .acts button { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 16px; padding: 5px 12px; font-size: 12px; cursor: pointer; }
+.prov .acts button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 .prov .acts button.primary:disabled { opacity: .6; cursor: default; }
-.derived { margin-top: 10px; border-top: 1px solid #e8eaed; padding-top: 10px; }
-.derived.err { color: #c5221f; font-size: 12px; }
-.derived .dsum { margin: 0 0 6px; font-size: 12.5px; color: #202124; }
+.derived { margin-top: 10px; border-top: 1px solid var(--hairline); padding-top: 10px; }
+.derived.err { color: var(--fail); font-size: 12px; }
+.derived .dsum { margin: 0 0 6px; font-size: 12.5px; color: var(--ink); }
 .derived .dmeta { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
-.derived .kko { font-size: 10px; border: 1px solid #dadce0; border-radius: 10px; padding: 1px 7px; color: #5f6368; }
-.derived .ex { font-size: 10px; color: #5f6368; }
-.derived .dlbl { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; margin-bottom: 4px; }
+.derived .kko { font-size: 10px; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 1px 7px; color: var(--muted); }
+.derived .ex { font-size: 10px; color: var(--muted); }
+.derived .dlbl { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin-bottom: 4px; }
 .derived .drow { display: flex; align-items: center; gap: 6px; padding: 3px 0; font-size: 12px; }
-.derived .rel { color: #5f6368; min-width: 92px; }
-.derived .dwith { flex: 1; color: #202124; }
+.derived .rel { color: var(--muted); min-width: 92px; }
+.derived .dwith { flex: 1; color: var(--ink); }
 .derived .dpill { font-size: 10px; border: 1px solid; border-radius: 10px; padding: 0 6px; }
-.derived .dnone { font-size: 12px; color: #5f6368; }
+.derived .dnone { font-size: 12px; color: var(--muted); }
 .slide-enter-active, .slide-leave-active { transition: transform .18s, opacity .18s; }
 .slide-enter-from, .slide-leave-to { transform: translateX(16px); opacity: 0; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioOps.vue
+++ b/socioprophet-web/app-vue/src/components/StudioOps.vue
@@ -66,7 +66,7 @@ async function submitExec() {
   finally { exBusy.value = false; }
 }
 
-function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "#c0c4c9"; }
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
 function kv(o: Record<string, number>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
 </script>
 
@@ -186,63 +186,63 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
 </template>
 
 <style scoped>
-.ops { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.ops { font: 14px/1.5 var(--ui); color: var(--ink); }
 .obar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
-.obar .cnt { color: #5f6368; font-size: 12px; } .obar .spacer { flex: 1; }
-.obar .tok { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 130px; }
-.ghost { border: 1px solid #dadce0; background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.flash { background: #eaf5ee; color: #137333; border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
-.msg { color: #5f6368; } .msg.err { color: #c5221f; }
+.obar .cnt { color: var(--muted); font-size: 12px; } .obar .spacer { flex: 1; }
+.obar .tok { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 130px; }
+.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
-.card { border: 1px solid #e8eaed; border-radius: 12px; padding: 14px 16px; background: #fff; }
+.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; }
 .card.wide { grid-column: 1 / -1; }
 .ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
-.ch .ci { color: #1a73e8; } .ch .tagline { margin-left: auto; font-size: 10.5px; color: #1a73e8; background: #e8f0fe; border-radius: 10px; padding: 2px 9px; font-weight: 500; }
-.score { margin-left: auto; font-size: 11px; color: #5f6368; background: #f1f3f4; border-radius: 10px; padding: 2px 9px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 10px; padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: 10px; padding: 2px 9px; }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
-.sub { color: #5f6368; font-size: 12px; margin: 10px 0 0; } .sub b { color: #202124; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
 
 /* compute */
 .backends { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 8px; margin-bottom: 10px; }
 .backend { display: grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto; gap: 2px 8px; align-items: center;
-  border: 1px solid #e8eaed; border-radius: 10px; padding: 8px 10px; cursor: pointer; }
-.backend.sel { border-color: #1a73e8; background: #f6f9fe; } .backend.ent { }
-.backend input { grid-row: 1 / 3; } .bn { font-weight: 600; font-size: 13px; } .bn .bk { font-style: normal; font-size: 10px; color: #5f6368; margin-left: 6px; }
-.bnote { grid-column: 2; font-size: 11px; color: #5f6368; } .bstate { grid-column: 2; font-size: 10px; color: #b06000; } .bstate.on { color: #137333; }
+  border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; cursor: pointer; }
+.backend.sel { border-color: var(--accent); background: var(--accent-wash); } .backend.ent { }
+.backend input { grid-row: 1 / 3; } .bn { font-weight: 600; font-size: 13px; } .bn .bk { font-style: normal; font-size: 10px; color: var(--muted); margin-left: 6px; }
+.bnote { grid-column: 2; font-size: 11px; color: var(--muted); } .bstate { grid-column: 2; font-size: 10px; color: var(--warn); } .bstate.on { color: var(--ok); }
 .exrow { display: flex; gap: 6px; margin-bottom: 8px; }
-.exrow .sel-k { border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.exrow .ref { flex: 1; border: 1px solid #dadce0; border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.primary { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.exrow .sel-k { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.exrow .ref { flex: 1; border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .primary:disabled { opacity: .6; }
-.exres { font-size: 12.5px; border-radius: 8px; padding: 8px 10px; background: #eaf5ee; color: #137333; }
-.exres.gated { background: #fef7e0; color: #b06000; }
+.exres { font-size: 12.5px; border-radius: 8px; padding: 8px 10px; background: var(--ok-wash); color: var(--ok); }
+.exres.gated { background: var(--warn-wash); color: var(--warn); }
 .exres .rep { margin-left: 6px; font-size: 10px; background: #fff; border-radius: 8px; padding: 1px 6px; }
 
 /* models */
 .model { margin-bottom: 8px; } .mname { font-weight: 600; margin-bottom: 3px; }
 .mver { display: flex; align-items: center; gap: 8px; font-size: 12.5px; padding: 3px 0; flex-wrap: wrap; }
-.vv { font-weight: 700; color: #1a73e8; }
-.stage { font-size: 10px; border-radius: 8px; padding: 1px 7px; background: #f1f3f4; color: #5f6368; }
-.stage.production { background: #eaf5ee; color: #137333; } .stage.staging { background: #e8f0fe; color: #1a73e8; } .stage.archived { background: #f1f3f4; color: #80868b; }
-.met { color: #137333; } .lineage { color: #5f6368; }
-.promote { margin-left: auto; border: 1px solid #dadce0; border-radius: 8px; font-size: 11.5px; padding: 2px 6px; }
+.vv { font-weight: 700; color: var(--accent); }
+.stage { font-size: 10px; border-radius: 8px; padding: 1px 7px; background: var(--sunken); color: var(--muted); }
+.stage.production { background: var(--ok-wash); color: var(--ok); } .stage.staging { background: var(--accent-wash); color: var(--accent); } .stage.archived { background: var(--sunken); color: var(--faint); }
+.met { color: var(--ok); } .lineage { color: var(--muted); }
+.promote { margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: 8px; font-size: 11.5px; padding: 2px 6px; }
 
 /* pipelines */
 .pipe { margin-bottom: 8px; } .prow { display: flex; align-items: center; gap: 8px; }
-.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid #1a73e8; background: #fff; color: #1a73e8; border-radius: 8px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
+.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid var(--accent); background: #fff; color: var(--accent); border-radius: 8px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
 .dag { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; margin-top: 5px; }
-.step { font-size: 11.5px; background: #f1f3f4; border-radius: 7px; padding: 2px 9px; } .arrow { color: #9aa0a6; }
+.step { font-size: 11.5px; background: var(--sunken); border-radius: 7px; padding: 2px 9px; } .arrow { color: var(--faint); }
 
 /* catalog */
 .cat { width: 100%; border-collapse: collapse; font-size: 12.5px; }
-.cat td { padding: 5px 8px; border-bottom: 1px solid #f1f3f4; } .cat tr:last-child td { border-bottom: 0; }
-.cat .nm { font-weight: 600; } .cat .cols { color: #5f6368; } .pill { font-size: 10px; background: #eef0f3; border-radius: 8px; padding: 1px 7px; color: #5f6368; }
+.cat td { padding: 5px 8px; border-bottom: 1px solid var(--sunken); } .cat tr:last-child td { border-bottom: 0; }
+.cat .nm { font-weight: 600; } .cat .cols { color: var(--muted); } .pill { font-size: 10px; background: var(--hairline); border-radius: 8px; padding: 1px 7px; color: var(--muted); }
 .epi { font-size: 10px; border: 1px solid; border-radius: 8px; padding: 1px 7px; }
 
 /* communities */
 .comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
-.comm { border: 1px solid #f1f3f4; border-radius: 10px; padding: 8px 10px; }
+.comm { border: 1px solid var(--sunken); border-radius: 10px; padding: 8px 10px; }
 .crow { display: flex; align-items: center; gap: 8px; font-size: 12.5px; } .crow b { font-size: 16px; }
-.mb-bar { display: flex; height: 7px; flex: 1; border-radius: 5px; overflow: hidden; background: #f1f3f4; } .mb-bar i { display: block; height: 100%; }
-.top { font-size: 11.5px; color: #5f6368; margin-top: 5px; }
+.mb-bar { display: flex; height: 7px; flex: 1; border-radius: 5px; overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
+.top { font-size: 11.5px; color: var(--muted); margin-top: 5px; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioQuery.vue
+++ b/socioprophet-web/app-vue/src/components/StudioQuery.vue
@@ -31,7 +31,7 @@ async function run() {
 }
 
 function epiOf(v: unknown): string | null { return result.value?.epistemic[String(v)] ?? null; }
-function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "#c0c4c9"; }
+function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "var(--faint)"; }
 </script>
 
 <template>
@@ -86,30 +86,30 @@ function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "#c0c4c9
 </template>
 
 <style scoped>
-.qide { font: 14px/1.5 system-ui, sans-serif; color: #202124; }
+.qide { font: 14px/1.5 var(--ui); color: var(--ink); }
 .qbar { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
 .qbar .spacer { flex: 1; }
-.seg { display: inline-flex; border: 1px solid #dadce0; border-radius: 8px; overflow: hidden; }
-.seg button { border: 0; background: #fff; padding: 6px 12px; font-size: 12px; text-transform: capitalize; cursor: pointer; color: #5f6368; }
-.seg button.on { background: #1a73e8; color: #fff; }
-.run { border: 1px solid #1a73e8; background: #1a73e8; color: #fff; border-radius: 8px; padding: 6px 16px; font-size: 13px; cursor: pointer; }
+.seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: 8px; overflow: hidden; }
+.seg button { border: 0; background: #fff; padding: 6px 12px; font-size: 12px; text-transform: capitalize; cursor: pointer; color: var(--muted); }
+.seg button.on { background: var(--accent); color: #fff; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 16px; font-size: 13px; cursor: pointer; }
 .run:disabled { opacity: .6; cursor: default; }
-.qed { width: 100%; resize: vertical; border: 1px solid #dadce0; border-radius: 10px; padding: 12px; font-size: 13px; background: #fbfcfe; box-sizing: border-box; }
+.qed { width: 100%; resize: vertical; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 12px; font-size: 13px; background: var(--surface-2); box-sizing: border-box; }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
-.qerr { color: #c5221f; font-size: 13px; margin: 10px 0 0; }
+.qerr { color: var(--fail); font-size: 13px; margin: 10px 0 0; }
 .qres { margin-top: 12px; }
-.qproof { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background: #f1f6ee; border: 1px solid #d7e8cf; border-radius: 9px; font-size: 12px; }
+.qproof { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background: var(--ok-wash); border: 1px solid var(--ok-wash); border-radius: 9px; font-size: 12px; }
 .qproof .spacer { flex: 1; }
-.pf { font-weight: 700; color: #5f6368; } .pf.ok { color: #137333; }
-.pfh { color: #137333; } .pfs { color: #5f6368; } .rc { color: #5f6368; }
-.qscroll { overflow-x: auto; margin-top: 10px; border: 1px solid #e8eaed; border-radius: 10px; }
+.pf { font-weight: 700; color: var(--muted); } .pf.ok { color: var(--ok); }
+.pfh { color: var(--ok); } .pfs { color: var(--muted); } .rc { color: var(--muted); }
+.qscroll { overflow-x: auto; margin-top: 10px; border: 1px solid var(--hairline); border-radius: 10px; }
 .qgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
-.qgrid th { text-align: left; padding: 8px 12px; background: #f8f9fa; border-bottom: 1px solid #e8eaed; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #5f6368; }
-.qgrid td { padding: 8px 12px; border-bottom: 1px solid #f1f3f4; white-space: nowrap; }
+.qgrid th { text-align: left; padding: 8px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.qgrid td { padding: 8px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; }
 .qgrid tr:last-child td { border-bottom: 0; }
 .qgrid td .epi { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 6px; vertical-align: middle; }
-.qraw { margin-top: 10px; background: #0e1116; color: #d7e0ea; padding: 12px; border-radius: 10px; overflow-x: auto; font-size: 12px; max-height: 320px; }
-.qempty, .qhint, .qnote { color: #5f6368; font-size: 12.5px; }
-.qnote { margin-top: 8px; } .qnote b { color: #202124; } .qhint b { color: #202124; }
+.qraw { margin-top: 10px; background: var(--ground); color: var(--hairline); padding: 12px; border-radius: 10px; overflow-x: auto; font-size: 12px; max-height: 320px; }
+.qempty, .qhint, .qnote { color: var(--muted); font-size: 12.5px; }
+.qnote { margin-top: 8px; } .qnote b { color: var(--ink); } .qhint b { color: var(--ink); }
 .qhint { margin-top: 12px; }
 </style>

--- a/socioprophet-web/app-vue/src/main.ts
+++ b/socioprophet-web/app-vue/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import { router } from "./router";
 import App from "./App.vue";
+import "./styles/tokens.css";
 import "./styles.css";
 
 createApp(App).use(createPinia()).use(router).mount("#app");

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -139,9 +139,23 @@ export interface GraphView {
 
 // Epistemic-mode → colour (the ladder hypothesis→…→attested). This colouring IS the feature: Bloom shows topology,
 // we show epistemic status per node.
+// Resolve from the token ramp so the graph, membrane, and chips share one ink.
+// (Falls back to literals when read outside the DOM, e.g. SSR/tests.)
+function epiVar(name: string, fallback: string): string {
+  if (typeof getComputedStyle === "function" && typeof document !== "undefined") {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    if (v) return v;
+  }
+  return fallback;
+}
 export const EPISTEMIC_COLORS: Record<string, string> = {
-  hypothesis: "#9aa0a6", observed: "#1a73e8", derived: "#8b5cf6",
-  verified: "#137333", attested: "#00897b", simulated: "#b06000", unknown: "#c0c4c9",
+  get hypothesis() { return epiVar("--epi-hypothesis", "#94a1b2"); },
+  get observed()   { return epiVar("--epi-observed",   "#4a90e2"); },
+  get derived()    { return epiVar("--epi-derived",    "#8b5cf6"); },
+  get verified()   { return epiVar("--epi-verified",   "#14b8a6"); },
+  get attested()   { return epiVar("--epi-attested",   "#059669"); },
+  get simulated()  { return epiVar("--epi-simulated",  "#d98324"); },
+  get unknown()    { return epiVar("--epi-unknown",    "#b6bec9"); },
 };
 
 const STUB_GRAPH: GraphView = {

--- a/socioprophet-web/app-vue/src/styles.css
+++ b/socioprophet-web/app-vue/src/styles.css
@@ -1,21 +1,51 @@
-:root { --brand:#3f83f8; --brand-2:#2f6fe0; --bg:#0d1117; --panel:#161b22; --border:#2a3340; --text:#e6edf3; --muted:#9aa7b4; }
-@media (prefers-color-scheme: light){ :root{ --bg:#f6f8fa; --panel:#fff; --border:#e1e6ec; --text:#1b2026; --muted:#5a6672; } }
-* { box-sizing:border-box; }
-body { margin:0; background:var(--bg); color:var(--text); font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
-a { color:var(--brand); text-decoration:none; }
-.wrap { max-width:860px; margin:0 auto; padding:24px 20px; }
-.nav { display:flex; gap:16px; align-items:center; border-bottom:1px solid var(--border); padding:12px 20px; }
-.nav .sp { flex:1; }
-.card { background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:20px; margin:14px 0; }
-label { display:block; font-size:13px; color:var(--muted); margin:12px 0 4px; }
-input,select,textarea { width:100%; padding:9px 11px; border:1px solid var(--border); border-radius:8px; background:var(--bg); color:var(--text); font-size:14px; }
-.btn { display:inline-block; background:var(--brand); color:#fff; border:0; border-radius:8px; padding:10px 16px; font-weight:600; cursor:pointer; font-size:14px; }
-.btn:hover { background:var(--brand-2); }
-.btn.alt { background:transparent; color:var(--text); border:1px solid var(--border); }
-.btn:disabled { opacity:.5; cursor:not-allowed; }
-.row { display:flex; gap:12px; }
-.row > * { flex:1; }
-.muted { color:var(--muted); font-size:13px; }
-.pill { display:inline-block; font-size:12px; padding:2px 9px; border-radius:999px; border:1px solid var(--border); color:var(--muted); }
-.status-complete { color:#3fb950; } .status-error { color:#e5534b; } .status-building,.status-dispatched,.status-queued { color:#d29922; }
-.gated { opacity:.5; }
+/* App-wide base — consumes the epistemic-Carbon token spine (styles/tokens.css).
+   Every view inherits this: search, studio, work/wiki, settings. */
+
+/* back-compat alias: older markup uses --brand/--bg/--panel/--text/--border */
+:root{
+  --brand:var(--accent); --brand-2:var(--accent-2);
+  --bg:var(--ground); --panel:var(--surface); --border:var(--hairline);
+  --text:var(--ink);
+}
+
+*{box-sizing:border-box}
+body{margin:0;background:var(--ground);color:var(--ink);
+  font:15px/1.6 var(--ui);-webkit-font-smoothing:antialiased}
+a{color:var(--accent);text-decoration:none}
+a:hover{text-decoration:underline}
+
+.wrap{max-width:920px;margin:0 auto;padding:24px 20px}
+
+.nav{display:flex;gap:16px;align-items:center;background:var(--bar);color:var(--bar-ink);
+  border-bottom:1px solid var(--bar-line);padding:10px 20px}
+.nav a{color:var(--bar-muted)} .nav a:hover{color:var(--bar-ink);text-decoration:none}
+.nav .sp{flex:1}
+
+/* Carbon cards: flat, hairline, near-square */
+.card{background:var(--surface);border:1px solid var(--hairline);border-radius:var(--r-3);
+  padding:18px 20px;margin:14px 0}
+
+label{display:block;font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.04em;
+  color:var(--muted);margin:14px 0 5px}
+input,select,textarea{width:100%;padding:9px 11px;border:1px solid var(--hairline);border-radius:var(--r-2);
+  background:var(--surface);color:var(--ink);font:inherit;font-size:14px;outline:none}
+input:focus,select:focus,textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-wash)}
+
+.btn{display:inline-block;background:var(--accent);color:#fff;border:0;border-radius:var(--r-2);
+  padding:9px 16px;font-weight:600;font-size:14px;cursor:pointer}
+.btn:hover{background:var(--accent-2)}
+.btn.alt{background:transparent;color:var(--ink);border:1px solid var(--hairline-strong)}
+.btn.alt:hover{background:var(--sunken)}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+
+.row{display:flex;gap:12px}
+.row>*{flex:1}
+.muted{color:var(--muted);font-size:13px}
+
+.pill{display:inline-flex;align-items:center;gap:6px;font-size:12px;padding:2px 9px;border-radius:var(--pill);
+  border:1px solid var(--hairline);color:var(--muted)}
+
+/* semantic status → tokens */
+.status-complete{color:var(--ok)} .status-error{color:var(--fail)}
+.status-building,.status-dispatched,.status-queued{color:var(--warn)}
+.gated{opacity:.5}

--- a/socioprophet-web/app-vue/src/styles/tokens.css
+++ b/socioprophet-web/app-vue/src/styles/tokens.css
@@ -1,0 +1,164 @@
+/* ============================================================================
+   Prophet Studio — design tokens (Layer 0)
+   The single foundation every Studio surface inherits.
+
+   Doctrine (Tufte · Bostock · Carbon):
+   - Grayscale carries ALL structure. Neutrals are chosen (biased toward our
+     brand blue), never a default mid-grey.
+   - The EPISTEMIC ramp is the one saturated dimension worth spending —
+     observed → derived → verified → attested. It is the moat, made visible.
+   - Semantic status (running/ok/warn/fail) is a SEPARATE small palette and is
+     rendered as a *filled* form, never the accent, so it can never be
+     confused with epistemic status (which is rendered as a stripe/dot).
+   - Carbon density: a 4px spacing grid, hairline borders, near-square radii.
+   - TYPE: deliberately a neutral system stack — no distinctive vendored face.
+     A single shipped webfont is a browser-fingerprint surface (kerning/metrics
+     are identifiable); until a non-fingerprintable face is chosen we ride the
+     viewer's own system font. Do NOT add a webfont here without that review.
+   ========================================================================== */
+
+:root {
+  /* — neutrals: light (default). Blue-biased, not neutral grey. — */
+  --ground:   #f4f6f9;
+  --sunken:   #eef1f5;
+  --surface:  #ffffff;
+  --surface-2:#fbfcfe;
+  --hairline: #dce1e8;
+  --hairline-strong:#c6cdd8;
+  --ink:      #141a22;
+  --ink-2:    #3a4552;
+  --muted:    #64707e;
+  --faint:    #98a3b0;
+
+  /* — app-bar is dark in both themes (Carbon app shell) — */
+  --bar:      #10151c;
+  --bar-ink:  #eef2f7;
+  --bar-muted:#8a96a4;
+  --bar-line: #232c38;
+
+  /* — brand accent (ours). Interactive + selection only, used sparingly. — */
+  --accent:    #3f83f8;
+  --accent-2:  #2f6fe0;
+  --accent-wash:#e8f0fe;
+  --accent-ink:#0b3d91;
+
+  /* — EPISTEMIC ordered ramp (grey→blue→violet→teal→emerald): the warrant ladder — */
+  --epi-hypothesis:#94a1b2;
+  --epi-observed:  #4a90e2;
+  --epi-derived:   #8b5cf6;
+  --epi-verified:  #14b8a6;
+  --epi-attested:  #059669;
+  --epi-simulated: #d98324;
+  --epi-unknown:   #b6bec9;
+  --epi-hypothesis-wash:#eef0f3;
+  --epi-observed-wash:  #e7f0fc;
+  --epi-derived-wash:   #f0ebfe;
+  --epi-verified-wash:  #e3f7f4;
+  --epi-attested-wash:  #e2f5ec;
+
+  /* — semantic status: separate palette, filled form only — */
+  --ok:      #2f9e44;
+  --warn:    #e0a800;
+  --fail:    #e5484d;
+  --run:     #4a90e2;
+  --idle:    #8a94a3;
+  --ok-wash: #e6f4ea; --warn-wash:#fbf3d9; --fail-wash:#fce9ea; --run-wash:#e7f0fc;
+
+  /* — grid, radius, elevation (Carbon: tight + flat) — */
+  --sp-1:4px; --sp-2:8px; --sp-3:12px; --sp-4:16px; --sp-5:24px; --sp-6:32px;
+  --r-1:3px; --r-2:5px; --r-3:8px;
+  --pill:999px;
+  --e-1:0 1px 2px rgba(20,26,34,.06);
+  --e-2:0 4px 14px rgba(20,26,34,.10);
+  --e-3:0 12px 40px rgba(20,26,34,.16);
+
+  /* — type: neutral system stack (see header note — no vendored face) — */
+  --ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --canvas-dot: #e7ebf1;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ground:  #0b0f15;
+    --sunken:  #080b10;
+    --surface: #141b24;
+    --surface-2:#18202a;
+    --hairline:#232c38;
+    --hairline-strong:#33404f;
+    --ink:     #e8eef5;
+    --ink-2:   #b4c0cd;
+    --muted:   #8a97a5;
+    --faint:   #5d6a78;
+
+    --bar:     #080b10;
+    --bar-ink: #e8eef5;
+    --bar-muted:#8a97a5;
+    --bar-line:#1c242f;
+
+    --accent:  #5b95f9;
+    --accent-2:#3f83f8;
+    --accent-wash:#16233b;
+    --accent-ink:#bcd4ff;
+
+    --epi-hypothesis:#8592a3;
+    --epi-observed:  #5b95f9;
+    --epi-derived:   #a082f8;
+    --epi-verified:  #2dd4bf;
+    --epi-attested:  #34d399;
+    --epi-simulated: #e0975a;
+    --epi-unknown:   #4a5568;
+    --epi-hypothesis-wash:#1a2029;
+    --epi-observed-wash:  #14243c;
+    --epi-derived-wash:   #211a3a;
+    --epi-verified-wash:  #0e2c2b;
+    --epi-attested-wash:  #0e2a22;
+
+    --ok:#3fb950; --warn:#d29922; --fail:#e5534b; --run:#5b95f9; --idle:#6b7684;
+    --ok-wash:#0f2417; --warn-wash:#241d0a; --fail-wash:#2a1315; --run-wash:#14243c;
+
+    --canvas-dot:#1a212b;
+    --e-1:0 1px 2px rgba(0,0,0,.4);--e-2:0 4px 14px rgba(0,0,0,.5);--e-3:0 12px 40px rgba(0,0,0,.6);
+  }
+}
+
+/* explicit theme override (viewer toggle stamps data-theme on <html>) — must win both ways */
+:root[data-theme="light"] {
+  --ground:#f4f6f9; --sunken:#eef1f5; --surface:#fff; --surface-2:#fbfcfe;
+  --hairline:#dce1e8; --hairline-strong:#c6cdd8;
+  --ink:#141a22; --ink-2:#3a4552; --muted:#64707e; --faint:#98a3b0;
+  --accent:#3f83f8; --accent-2:#2f6fe0; --accent-wash:#e8f0fe; --accent-ink:#0b3d91;
+  --epi-hypothesis:#94a1b2; --epi-observed:#4a90e2; --epi-derived:#8b5cf6;
+  --epi-verified:#14b8a6; --epi-attested:#059669; --epi-simulated:#d98324; --epi-unknown:#b6bec9;
+  --ok:#2f9e44; --warn:#e0a800; --fail:#e5484d; --run:#4a90e2; --idle:#8a94a3;
+  --canvas-dot:#e7ebf1;
+}
+:root[data-theme="dark"] {
+  --ground:#0b0f15; --sunken:#080b10; --surface:#141b24; --surface-2:#18202a;
+  --hairline:#232c38; --hairline-strong:#33404f;
+  --ink:#e8eef5; --ink-2:#b4c0cd; --muted:#8a97a5; --faint:#5d6a78;
+  --accent:#5b95f9; --accent-2:#3f83f8; --accent-wash:#16233b; --accent-ink:#bcd4ff;
+  --epi-hypothesis:#8592a3; --epi-observed:#5b95f9; --epi-derived:#a082f8;
+  --epi-verified:#2dd4bf; --epi-attested:#34d399; --epi-simulated:#e0975a; --epi-unknown:#4a5568;
+  --ok:#3fb950; --warn:#d29922; --fail:#e5534b; --run:#5b95f9; --idle:#6b7684;
+  --canvas-dot:#1a212b;
+}
+
+/* ---- shared primitive utilities ------------------------------------------- */
+.epi-stripe { position:relative; }
+.epi-stripe::before {
+  content:""; position:absolute; left:0; top:0; bottom:0; width:3px;
+  background:var(--epi, var(--epi-unknown)); border-radius:var(--r-1) 0 0 var(--r-1);
+}
+.epi-dot { display:inline-block; width:8px; height:8px; border-radius:var(--pill);
+  background:var(--epi, var(--epi-unknown)); flex:0 0 auto; }
+.epi-chip { display:inline-flex; align-items:center; gap:6px; font-size:11px; font-weight:600;
+  letter-spacing:.01em; padding:1px 8px 1px 7px; border-radius:var(--r-1);
+  color:var(--epi, var(--epi-unknown)); background:var(--epi-wash, transparent);
+  border:1px solid color-mix(in srgb, var(--epi, var(--epi-unknown)) 40%, transparent); }
+.stat-chip { display:inline-flex; align-items:center; gap:5px; font-size:11px; font-weight:600;
+  padding:1px 8px; border-radius:var(--pill); color:#fff; background:var(--stat, var(--idle)); }
+.stat-chip.soft { color:var(--stat, var(--idle)); background:var(--stat-wash, var(--sunken)); }
+.tnum { font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); }

--- a/socioprophet-web/app-vue/src/views/Cloud.vue
+++ b/socioprophet-web/app-vue/src/views/Cloud.vue
@@ -57,19 +57,19 @@ const fmt = (n: number) => (n === 0 ? "free" : `$${n}`);
 </template>
 
 <style scoped>
-.cloud { padding: 24px 32px; font: 14px/1.5 system-ui, sans-serif; color: #202124; overflow: auto; height: 100%; }
-h1 { font-size: 26px; margin: 0 0 4px; } .tag { font-size: 12px; background: #e8f0fe; color: #1a73e8; padding: 2px 8px; border-radius: 10px; vertical-align: middle; }
-.lede { color: #5f6368; margin: 0 0 14px; max-width: 720px; }
+.cloud { padding: 24px 32px; font: 14px/1.5 var(--ui); color: var(--ink); overflow: auto; height: 100%; }
+h1 { font-size: 26px; margin: 0 0 4px; } .tag { font-size: 12px; background: var(--accent-wash); color: var(--accent); padding: 2px 8px; border-radius: 10px; vertical-align: middle; }
+.lede { color: var(--muted); margin: 0 0 14px; max-width: 720px; }
 .controls { display: flex; gap: 24px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
-.controls select { padding: 4px 8px; border: 1px solid #dadce0; border-radius: 6px; }
-.vbtn { border: 1px solid #dadce0; background: #fff; border-radius: 14px; padding: 2px 10px; margin: 0 3px; cursor: pointer; font-size: 12px; }
-.vbtn.off { background: #fce8e6; color: #c5221f; text-decoration: line-through; }
+.controls select { padding: 4px 8px; border: 1px solid var(--hairline-strong); border-radius: 6px; }
+.vbtn { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 14px; padding: 2px 10px; margin: 0 3px; cursor: pointer; font-size: 12px; }
+.vbtn.off { background: var(--fail-wash); color: var(--fail); text-decoration: line-through; }
 .grid { width: 100%; border-collapse: collapse; }
-.grid th, .grid td { border: 1px solid #e8eaed; padding: 8px 10px; text-align: left; vertical-align: top; }
-.grid th { background: #f1f3f4; font-weight: 500; text-transform: capitalize; }
+.grid th, .grid td { border: 1px solid var(--hairline); padding: 8px 10px; text-align: left; vertical-align: top; }
+.grid th { background: var(--sunken); font-weight: 500; text-transform: capitalize; }
 .kind { font-weight: 600; text-transform: capitalize; }
-.prim { font-size: 13px; } .price { font-size: 12px; color: #5f6368; }
-.best { background: #e6f4ea; outline: 2px solid #137333; }
-.pick strong { color: #137333; text-transform: uppercase; }
-.na { color: #bdc1c6; } .foot { color: #5f6368; margin-top: 16px; font-size: 13px; }
+.prim { font-size: 13px; } .price { font-size: 12px; color: var(--muted); }
+.best { background: var(--ok-wash); outline: 2px solid var(--ok); }
+.pick strong { color: var(--ok); text-transform: uppercase; }
+.na { color: #bdc1c6; } .foot { color: var(--muted); margin-top: 16px; font-size: 13px; }
 </style>

--- a/socioprophet-web/app-vue/src/views/Code.vue
+++ b/socioprophet-web/app-vue/src/views/Code.vue
@@ -17,9 +17,9 @@ const giteaUrl = (import.meta as { env?: Record<string, string> }).env?.VITE_GIT
 
 <style scoped>
 .code { display: flex; flex-direction: column; height: 100%; }
-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 14px; border-bottom: 1px solid #e8eaed; font: 14px system-ui, sans-serif; }
-.tag { font-size: 12px; background: #e6f4ea; color: #137333; padding: 2px 8px; border-radius: 10px; }
-header a { color: #1a73e8; text-decoration: none; font-size: 13px; }
+header { display: flex; justify-content: space-between; align-items: center; padding: 8px 14px; border-bottom: 1px solid var(--hairline); font: 14px var(--ui); }
+.tag { font-size: 12px; background: var(--ok-wash); color: var(--ok); padding: 2px 8px; border-radius: 10px; }
+header a { color: var(--accent); text-decoration: none; font-size: 13px; }
 iframe { flex: 1; border: 0; width: 100%; }
-.note { font-size: 12px; color: #b06000; background: #fef7e0; padding: 4px 14px; } .note a { color: #1a73e8; }
+.note { font-size: 12px; color: var(--warn); background: var(--warn-wash); padding: 4px 14px; } .note a { color: var(--accent); }
 </style>

--- a/socioprophet-web/app-vue/src/views/Knowledge.vue
+++ b/socioprophet-web/app-vue/src/views/Knowledge.vue
@@ -141,46 +141,46 @@ function nodeTitle(n: GNode): string {
 </template>
 
 <style scoped>
-.kn { display: grid; grid-template-columns: 200px 1fr 280px; height: 100%; font: 14px/1.5 system-ui, sans-serif; color: #202124; }
-.rail, .panels { border-color: #e8eaed; background: #f8f9fa; padding: 12px; overflow: auto; }
-.rail { border-right: 1px solid #e8eaed; }
-.panels { border-left: 1px solid #e8eaed; }
+.kn { display: grid; grid-template-columns: 200px 1fr 280px; height: 100%; font: 14px/1.5 var(--ui); color: var(--ink); }
+.rail, .panels { border-color: var(--hairline); background: var(--sunken); padding: 12px; overflow: auto; }
+.rail { border-right: 1px solid var(--hairline); }
+.panels { border-left: 1px solid var(--hairline); }
 .brand { font-weight: 600; margin-bottom: 10px; }
-.tag, .auto, .from, .deg { font-size: 11px; color: #5f6368; font-weight: 400; }
-.tag { background: #e6f4ea; color: #137333; padding: 1px 6px; border-radius: 8px; }
-.page { display: block; width: 100%; text-align: left; border: 0; background: none; padding: 6px 8px; border-radius: 6px; cursor: pointer; color: #202124; }
-.page:hover { background: #eef0f2; } .page.on { background: #e8f0fe; color: #1a73e8; font-weight: 500; }
-.newp input { width: 100%; margin-top: 8px; padding: 6px 8px; border: 1px solid #dadce0; border-radius: 6px; }
+.tag, .auto, .from, .deg { font-size: 11px; color: var(--muted); font-weight: 400; }
+.tag { background: var(--ok-wash); color: var(--ok); padding: 1px 6px; border-radius: 8px; }
+.page { display: block; width: 100%; text-align: left; border: 0; background: none; padding: 6px 8px; border-radius: 6px; cursor: pointer; color: var(--ink); }
+.page:hover { background: var(--hairline); } .page.on { background: var(--accent-wash); color: var(--accent); font-weight: 500; }
+.newp input { width: 100%; margin-top: 8px; padding: 6px 8px; border: 1px solid var(--hairline-strong); border-radius: 6px; }
 .doc { padding: 28px 40px; overflow: auto; }
 .title { font-size: 30px; font-weight: 700; margin: 0 0 16px; }
 .block { margin: 2px 0; }
-.edit { width: 100%; border: 0; resize: none; font: inherit; padding: 4px 6px; background: transparent; outline: none; color: #3c4043; }
+.edit { width: 100%; border: 0; resize: none; font: inherit; padding: 4px 6px; background: transparent; outline: none; color: var(--ink-2); }
 .edit.heading { font-size: 19px; font-weight: 600; }
 .render { padding: 0 6px 4px; min-height: 2px; }
 .chip { border-radius: 6px; padding: 0 5px; font-size: 13px; cursor: pointer; }
-.chip.link { background: #e8f0fe; color: #1a73e8; } .chip.ent { background: #fef7e0; color: #b06000; }
-.chip.rel { background: #f1f3f4; color: #3c4043; display: inline-block; margin: 2px 3px 0 0; }
+.chip.link { background: var(--accent-wash); color: var(--accent); } .chip.ent { background: var(--warn-wash); color: var(--warn); }
+.chip.rel { background: var(--sunken); color: var(--ink-2); display: inline-block; margin: 2px 3px 0 0; }
 .db { width: 100%; border-collapse: collapse; margin: 4px 0 8px; }
-.db th, .db td { border: 1px solid #e8eaed; padding: 6px 10px; text-align: left; font-size: 13px; }
-.db th { background: #f1f3f4; font-weight: 500; } .dbtitle { font-weight: 600; margin-top: 8px; }
-.roll { font-weight: 700; color: #137333; }
+.db th, .db td { border: 1px solid var(--hairline); padding: 6px 10px; text-align: left; font-size: 13px; }
+.db th { background: var(--sunken); font-weight: 500; } .dbtitle { font-weight: 600; margin-top: 8px; }
+.roll { font-weight: 700; color: var(--ok); }
 .add { margin-top: 14px; display: flex; gap: 8px; }
-.add button { border: 1px solid #dadce0; background: #fff; border-radius: 16px; padding: 4px 12px; cursor: pointer; color: #1a73e8; }
-.panels section { margin-bottom: 18px; } .panels h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .4px; color: #5f6368; margin: 0 0 6px; }
-.ref { display: block; width: 100%; text-align: left; border: 0; background: #fff; border: 1px solid #e8eaed; border-radius: 6px; padding: 6px 8px; margin-bottom: 4px; cursor: pointer; }
-.empty { color: #80868b; font-size: 13px; } .bar { display: flex; justify-content: space-between; align-items: center; margin: 3px 0; }
-.todo { padding: 2px 0; color: #3c4043; }
-.connsel { display: flex; gap: 6px; } .connsel select { flex: 1; padding: 4px; border: 1px solid #dadce0; border-radius: 6px; font: inherit; }
-.path { margin-top: 6px; font-size: 13px; color: #137333; background: #e6f4ea; padding: 4px 8px; border-radius: 6px; }
-.save { width: 100%; border: 0; background: #1a73e8; color: #fff; border-radius: 8px; padding: 8px; cursor: pointer; font-weight: 500; }
+.add button { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 16px; padding: 4px 12px; cursor: pointer; color: var(--accent); }
+.panels section { margin-bottom: 18px; } .panels h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .4px; color: var(--muted); margin: 0 0 6px; }
+.ref { display: block; width: 100%; text-align: left; border: 0; background: #fff; border: 1px solid var(--hairline); border-radius: 6px; padding: 6px 8px; margin-bottom: 4px; cursor: pointer; }
+.empty { color: var(--faint); font-size: 13px; } .bar { display: flex; justify-content: space-between; align-items: center; margin: 3px 0; }
+.todo { padding: 2px 0; color: var(--ink-2); }
+.connsel { display: flex; gap: 6px; } .connsel select { flex: 1; padding: 4px; border: 1px solid var(--hairline-strong); border-radius: 6px; font: inherit; }
+.path { margin-top: 6px; font-size: 13px; color: var(--ok); background: var(--ok-wash); padding: 4px 8px; border-radius: 6px; }
+.save { width: 100%; border: 0; background: var(--accent); color: #fff; border-radius: 8px; padding: 8px; cursor: pointer; font-weight: 500; }
 .save:hover { background: #1765cc; }
 .ai { background: #faf7ff; border: 1px solid #e9ddff; border-radius: 8px; padding: 10px; }
-.ai input { width: 100%; padding: 6px 8px; border: 1px solid #dadce0; border-radius: 6px; }
+.ai input { width: 100%; padding: 6px 8px; border: 1px solid var(--hairline-strong); border-radius: 6px; }
 .aibtns { display: flex; gap: 6px; margin-top: 6px; }
 .aibtns button { flex: 1; border: 1px solid #d9c7ff; background: #fff; color: #7b3ff2; border-radius: 6px; padding: 4px; cursor: pointer; font-size: 12px; }
 .aibtns button:disabled { opacity: .5; }
 .ans { margin-top: 8px; font-size: 13px; } .ans p { margin: 0 0 6px; }
-.denied { color: #c5221f; font-size: 12px; margin-top: 6px; }
+.denied { color: var(--fail); font-size: 12px; margin-top: 6px; }
 .pill { font-size: 11px; border-radius: 10px; padding: 1px 7px; }
-.pill.ok { background: #e6f4ea; color: #137333; } .pill.bad { background: #fce8e6; color: #c5221f; }
+.pill.ok { background: var(--ok-wash); color: var(--ok); } .pill.bad { background: var(--fail-wash); color: var(--fail); }
 </style>

--- a/socioprophet-web/app-vue/src/views/Mail.vue
+++ b/socioprophet-web/app-vue/src/views/Mail.vue
@@ -170,20 +170,20 @@ onUnmounted(() => window.removeEventListener("keydown", onKey));
 
 <style scoped>
 .mail { display: grid; grid-template-columns: 200px 300px 1fr; height: calc(100vh - 56px); font-size: 14px; }
-.rail { border-right: 1px solid #e6e6e6; padding: 12px; display: flex; flex-direction: column; gap: 2px; }
-.compose { display: flex; align-items: center; gap: 8px; background: #1a73e8; color: #fff; border: 0; border-radius: 8px; padding: 9px; margin-bottom: 8px; cursor: pointer; }
+.rail { border-right: 1px solid var(--hairline); padding: 12px; display: flex; flex-direction: column; gap: 2px; }
+.compose { display: flex; align-items: center; gap: 8px; background: var(--accent); color: #fff; border: 0; border-radius: 8px; padding: 9px; margin-bottom: 8px; cursor: pointer; }
 .navitem { display: flex; align-items: center; gap: 8px; padding: 7px 10px; border: 0; background: none; border-radius: 8px; cursor: pointer; text-align: left; color: #444; }
-.navitem.on { background: #e8f0fe; color: #1a73e8; font-weight: 500; }
+.navitem.on { background: var(--accent-wash); color: var(--accent); font-weight: 500; }
 .navitem .count, .navitem .badge { margin-left: auto; font-size: 12px; }
 .navitem .badge { background: #fce8b2; color: #7a5b00; border-radius: 10px; padding: 0 7px; }
 .sep { height: 1px; background: #eee; margin: 8px 4px; }
 .railhint { font-size: 12px; color: #999; padding: 2px 10px; }
 .foot { margin-top: auto; font-size: 12px; color: #888; display: flex; gap: 6px; align-items: center; }
-.foot .ti { color: #1e8e3e; }
-.list { border-right: 1px solid #e6e6e6; overflow-y: auto; }
+.foot .ti { color: var(--ok); }
+.list { border-right: 1px solid var(--hairline); overflow-y: auto; }
 .listhead { display: flex; justify-content: space-between; padding: 10px 12px; border-bottom: 1px solid #eee; font-weight: 500; }
-.row { padding: 9px 12px; border-bottom: 1px solid #f1f1f1; cursor: pointer; }
-.row.on { background: #e8f0fe; border-left: 2px solid #1a73e8; }
+.row { padding: 9px 12px; border-bottom: 1px solid var(--sunken); cursor: pointer; }
+.row.on { background: var(--accent-wash); border-left: 2px solid var(--accent); }
 .row.unread .from, .row.unread .subj { font-weight: 600; }
 .rowtop { display: flex; justify-content: space-between; }
 .ts { font-size: 12px; color: #999; }
@@ -194,29 +194,29 @@ onUnmounted(() => window.removeEventListener("keydown", onKey));
 .readhead { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid #eee; }
 .who { flex: 1; }
 .subj.big { font-size: 16px; font-weight: 500; }
-.act { width: 34px; height: 34px; border: 1px solid #e0e0e0; background: #fff; border-radius: 8px; cursor: pointer; color: #555; }
-.act.ok { color: #1e8e3e; }
-.ai { margin: 12px 16px; padding: 8px 12px; background: #e8f0fe; color: #1a4fa0; border-radius: 8px; font-size: 13px; display: flex; gap: 8px; }
+.act { width: 34px; height: 34px; border: 1px solid var(--hairline); background: #fff; border-radius: 8px; cursor: pointer; color: #555; }
+.act.ok { color: var(--ok); }
+.ai { margin: 12px 16px; padding: 8px 12px; background: var(--accent-wash); color: #1a4fa0; border-radius: 8px; font-size: 13px; display: flex; gap: 8px; }
 .body { padding: 4px 16px; line-height: 1.7; overflow-y: auto; flex: 1; }
 .replybar { display: flex; gap: 10px; align-items: center; padding: 12px 16px; border-top: 1px solid #eee; }
-.replybar input { flex: 1; padding: 9px 12px; border: 1px solid #e0e0e0; border-radius: 8px; }
-.replybar button, .composebtns button { padding: 8px 14px; border-radius: 8px; border: 1px solid #e0e0e0; background: #fff; cursor: pointer; }
-.replybar button.send, .composebtns button.send { background: #1a73e8; color: #fff; border: 0; }
+.replybar input { flex: 1; padding: 9px 12px; border: 1px solid var(--hairline); border-radius: 8px; }
+.replybar button, .composebtns button { padding: 8px 14px; border-radius: 8px; border: 1px solid var(--hairline); background: #fff; cursor: pointer; }
+.replybar button.send, .composebtns button.send { background: var(--accent); color: #fff; border: 0; }
 .replybar button:disabled, .composebtns button:disabled { opacity: 0.5; cursor: default; }
 .compose .kbd { margin-left: auto; font-family: monospace; font-size: 11px; opacity: 0.7; }
 .compose-modal { background: #fff; width: 520px; border-radius: 12px; box-shadow: 0 12px 40px rgba(0,0,0,0.2); padding: 16px; display: flex; flex-direction: column; gap: 10px; }
-.compose-modal input, .compose-modal textarea { width: 100%; padding: 9px 12px; border: 1px solid #e0e0e0; border-radius: 8px; font: inherit; box-sizing: border-box; }
+.compose-modal input, .compose-modal textarea { width: 100%; padding: 9px 12px; border: 1px solid var(--hairline); border-radius: 8px; font: inherit; box-sizing: border-box; }
 .composebtns { display: flex; justify-content: flex-end; gap: 8px; }
-.muted { color: #999; } .small { font-size: 12px; } .pad { padding: 16px; } .err { color: #c5221f; padding: 12px; }
+.muted { color: #999; } .small { font-size: 12px; } .pad { padding: 16px; } .err { color: var(--fail); padding: 12px; }
 .overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.3); display: flex; align-items: flex-start; justify-content: center; padding-top: 12vh; }
 .palette, .screener { background: #fff; width: 520px; border-radius: 12px; box-shadow: 0 12px 40px rgba(0,0,0,0.2); padding: 12px; }
-.palette input, .screener input { width: 100%; padding: 11px 14px; border: 1px solid #e0e0e0; border-radius: 8px; font-size: 15px; }
+.palette input, .screener input { width: 100%; padding: 11px 14px; border: 1px solid var(--hairline); border-radius: 8px; font-size: 15px; }
 .palrow { display: flex; justify-content: space-between; width: 100%; padding: 9px 12px; border: 0; background: none; cursor: pointer; border-radius: 8px; }
-.palrow:hover { background: #f5f5f5; }
+.palrow:hover { background: var(--sunken); }
 .kbd { font-family: monospace; font-size: 12px; color: #999; }
-.scrow { display: flex; justify-content: space-between; align-items: center; padding: 10px 6px; border-bottom: 1px solid #f1f1f1; }
+.scrow { display: flex; justify-content: space-between; align-items: center; padding: 10px 6px; border-bottom: 1px solid var(--sunken); }
 .scbtns button { padding: 6px 16px; border-radius: 8px; border: 1px solid #ddd; cursor: pointer; margin-left: 6px; }
-.scbtns .yes { background: #e6f4ea; color: #1e8e3e; border-color: #b7e1c2; }
-.scbtns .no { background: #fce8e6; color: #c5221f; border-color: #f3c0bc; }
+.scbtns .yes { background: var(--ok-wash); color: var(--ok); border-color: #b7e1c2; }
+.scbtns .no { background: var(--fail-wash); color: var(--fail); border-color: #f3c0bc; }
 .from { color: #222; }
 </style>

--- a/socioprophet-web/app-vue/src/views/Market.vue
+++ b/socioprophet-web/app-vue/src/views/Market.vue
@@ -7,7 +7,7 @@ const kind = ref<PackageKind | "">("");
 const results = computed(() => searchApps(CATALOG, q.value, kind.value || undefined));
 function assess(m: AppManifest) { return validateManifest(m); }
 const kindLabel: Record<PackageKind, string> = { flatpak: "Flatpak", appimage: "AppImage", oci: "OCI", "mcp-plugin": "MCP" };
-const riskColor: Record<string, string> = { low: "#137333", elevated: "#b06000", high: "#c5221f" };
+const riskColor: Record<string, string> = { low: "var(--ok)", elevated: "var(--warn)", high: "var(--fail)" };
 </script>
 
 <template>
@@ -50,22 +50,22 @@ const riskColor: Record<string, string> = { low: "#137333", elevated: "#b06000",
 </template>
 
 <style scoped>
-.mkt { padding: 24px 32px; font: 14px/1.5 system-ui, sans-serif; color: #202124; overflow: auto; height: 100%; }
-h1 { font-size: 26px; margin: 0 0 4px; } .tag { font-size: 12px; background: #e8f0fe; color: #1a73e8; padding: 2px 8px; border-radius: 10px; }
-.lede { color: #5f6368; max-width: 720px; margin: 0 0 14px; }
+.mkt { padding: 24px 32px; font: 14px/1.5 var(--ui); color: var(--ink); overflow: auto; height: 100%; }
+h1 { font-size: 26px; margin: 0 0 4px; } .tag { font-size: 12px; background: var(--accent-wash); color: var(--accent); padding: 2px 8px; border-radius: 10px; }
+.lede { color: var(--muted); max-width: 720px; margin: 0 0 14px; }
 .controls { display: flex; gap: 10px; margin-bottom: 18px; }
-.controls input { flex: 1; max-width: 360px; padding: 6px 10px; border: 1px solid #dadce0; border-radius: 8px; }
-.controls select { padding: 6px 10px; border: 1px solid #dadce0; border-radius: 8px; }
+.controls input { flex: 1; max-width: 360px; padding: 6px 10px; border: 1px solid var(--hairline-strong); border-radius: 8px; }
+.controls select { padding: 6px 10px; border: 1px solid var(--hairline-strong); border-radius: 8px; }
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 14px; }
-.card { border: 1px solid #e8eaed; border-radius: 10px; padding: 14px; background: #fff; }
+.card { border: 1px solid var(--hairline); border-radius: 10px; padding: 14px; background: #fff; }
 .top { display: flex; justify-content: space-between; align-items: center; }
-.name { font-weight: 600; font-size: 16px; } .badge { font-size: 11px; background: #f1f3f4; padding: 2px 8px; border-radius: 8px; }
-.pub { color: #5f6368; font-size: 13px; } .remote { color: #1a73e8; }
+.name { font-weight: 600; font-size: 16px; } .badge { font-size: 11px; background: var(--sunken); padding: 2px 8px; border-radius: 8px; }
+.pub { color: var(--muted); font-size: 13px; } .remote { color: var(--accent); }
 .sum { font-size: 13px; margin: 8px 0; min-height: 32px; }
 .meta { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 6px; }
-.pill { font-size: 11px; border: 1px solid #dadce0; border-radius: 10px; padding: 1px 7px; }
-.pill.ok { color: #137333; border-color: #cde8d4; } .pill.warn { color: #b06000; border-color: #fde293; }
-.warns { margin: 4px 0; padding-left: 16px; font-size: 12px; color: #c5221f; }
-.install { display: block; background: #202124; color: #e8eaed; padding: 6px 8px; border-radius: 6px; font-size: 12px; overflow-x: auto; }
-.none { color: #5f6368; padding: 20px 0; }
+.pill { font-size: 11px; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 1px 7px; }
+.pill.ok { color: var(--ok); border-color: #cde8d4; } .pill.warn { color: var(--warn); border-color: #fde293; }
+.warns { margin: 4px 0; padding-left: 16px; font-size: 12px; color: var(--fail); }
+.install { display: block; background: var(--ink); color: var(--hairline); padding: 6px 8px; border-radius: 6px; font-size: 12px; overflow-x: auto; }
+.none { color: var(--muted); padding: 20px 0; }
 </style>

--- a/socioprophet-web/app-vue/src/views/Search.vue
+++ b/socioprophet-web/app-vue/src/views/Search.vue
@@ -83,37 +83,37 @@ function isExternal(url: string): boolean {
 </template>
 
 <style scoped>
-.search { padding: 24px 32px; font: 15px/1.55 system-ui, sans-serif; color: #202124; height: 100%; overflow: auto; max-width: 780px; margin: 0 auto; }
+.search { padding: 24px 32px; font: 15px/1.55 var(--ui); color: var(--ink); height: 100%; overflow: auto; max-width: 780px; margin: 0 auto; }
 .search.landing { display: flex; flex-direction: column; justify-content: center; }
 .masthead { text-align: center; margin-bottom: 20px; }
 .brand { font-size: 34px; font-weight: 700; letter-spacing: -0.5px; }
-.brand .ai { color: #1a73e8; }
-.tagline { color: #5f6368; max-width: 560px; margin: 6px auto 0; }
-.tagline em { color: #202124; font-style: normal; font-weight: 600; }
+.brand .ai { color: var(--accent); }
+.tagline { color: var(--muted); max-width: 560px; margin: 6px auto 0; }
+.tagline em { color: var(--ink); font-style: normal; font-weight: 600; }
 
 .box { display: flex; gap: 8px; margin: 8px 0 4px; }
-.box input { flex: 1; padding: 13px 16px; font-size: 16px; border: 1px solid #dadce0; border-radius: 26px; outline: none; }
-.box input:focus { border-color: #1a73e8; box-shadow: 0 1px 6px rgba(26,115,232,0.18); }
-.box button { padding: 0 22px; font-size: 15px; font-weight: 600; color: #fff; background: #1a73e8; border: none; border-radius: 26px; cursor: pointer; }
+.box input { flex: 1; padding: 13px 16px; font-size: 16px; border: 1px solid var(--hairline-strong); border-radius: 26px; outline: none; }
+.box input:focus { border-color: var(--accent); box-shadow: 0 1px 6px rgba(26,115,232,0.18); }
+.box button { padding: 0 22px; font-size: 15px; font-weight: 600; color: #fff; background: var(--accent); border: none; border-radius: 26px; cursor: pointer; }
 .box button:disabled { opacity: 0.6; cursor: default; }
 
 .note { font-size: 13px; margin: 10px 2px; padding: 8px 12px; border-radius: 8px; }
-.note.stub { background: #e8f0fe; color: #1a56c4; }
-.note.warn { background: #fef7e0; color: #b06000; }
-.note.err { background: #fce8e6; color: #c5221f; }
+.note.stub { background: var(--accent-wash); color: #1a56c4; }
+.note.warn { background: var(--warn-wash); color: var(--warn); }
+.note.err { background: var(--fail-wash); color: var(--fail); }
 
 .results { margin-top: 14px; }
 .group { margin-bottom: 26px; }
-.group h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: #5f6368; border-bottom: 1px solid #eceff1; padding-bottom: 6px; margin: 0 0 12px; }
-.group h2 .count { color: #9aa0a6; font-weight: 400; }
+.group h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); border-bottom: 1px solid var(--sunken); padding-bottom: 6px; margin: 0 0 12px; }
+.group h2 .count { color: var(--faint); font-weight: 400; }
 .hit { margin-bottom: 16px; }
 .hit .title { font-size: 18px; color: #1a0dab; text-decoration: none; }
 .hit .title:hover { text-decoration: underline; }
-.hit .title.plain { color: #202124; }
-.hit .src { font-size: 12px; color: #5f6368; margin: 2px 0 3px; }
-.hit .snippet { color: #3c4043; margin: 0; }
-.hit.commons { border-left: 3px solid #1a73e8; padding-left: 12px; }
-.badge { font-size: 11px; border: 1px solid #dadce0; border-radius: 8px; padding: 1px 6px; color: #5f6368; }
-.badge.sov { border-color: #1a73e8; color: #1a73e8; }
-.empty { color: #5f6368; }
+.hit .title.plain { color: var(--ink); }
+.hit .src { font-size: 12px; color: var(--muted); margin: 2px 0 3px; }
+.hit .snippet { color: var(--ink-2); margin: 0; }
+.hit.commons { border-left: 3px solid var(--accent); padding-left: 12px; }
+.badge { font-size: 11px; border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 1px 6px; color: var(--muted); }
+.badge.sov { border-color: var(--accent); color: var(--accent); }
+.empty { color: var(--muted); }
 </style>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -124,7 +124,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
         <span class="mb-lbl">{{ bundle.moat.fact_count }} facts</span>
         <span class="mb-bar" title="epistemic status of the project's facts">
           <i v-for="(n, mode) in bundle.moat.epistemic_distribution" :key="mode"
-             :style="{ width: (n / bundle.moat.fact_count * 100) + '%', background: EPISTEMIC_COLORS[mode] || '#c0c4c9' }" :title="mode + ': ' + n" />
+             :style="{ width: (n / bundle.moat.fact_count * 100) + '%', background: EPISTEMIC_COLORS[mode] || 'var(--faint)' }" :title="mode + ': ' + n" />
         </span>
         <span class="mb-lbl">{{ Math.round(bundle.moat.provenance_coverage * 100) }}% sourced</span>
       </div>
@@ -307,8 +307,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 </template>
 
 <style scoped>
-.studio { --line:#e8eaed; --sub:#5f6368; --ink:#202124; --accent:#1a73e8; --accent-bg:#e8f0fe; --card:#fff; --bg:#fafafa;
-  display: flex; flex-direction: column; height: 100%; font: 14px/1.5 system-ui, sans-serif; color: var(--ink); }
+.studio { --line:var(--hairline); --sub:var(--muted); --accent-bg:var(--accent-wash); --card:var(--surface); --bg:var(--ground);
+  display: flex; flex-direction: column; height: 100%; font: 14px/1.5 var(--ui); color: var(--ink); background: var(--bg); }
 
 .topbar { display: flex; align-items: center; gap: 10px; padding: 10px 16px; border-bottom: 1px solid var(--line); }
 /* WS#29 moat strip */
@@ -322,30 +322,30 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 .mb-chip { border: 1px solid var(--line); background: var(--card); color: var(--sub); border-radius: 20px;
   padding: 3px 10px; font-size: 11.5px; cursor: default; }
 button.mb-chip { cursor: pointer; }
-.mb-chip.on { color: #137333; border-color: #bfe3c9; background: #eaf5ee; }
+.mb-chip.on { color: var(--ok); border-color: #bfe3c9; background: var(--ok-wash); }
 .mb-chip b { font-weight: 700; }
-.receipts, .cite { border-bottom: 1px solid var(--line); background: #fbfcfe; padding: 10px 16px 12px; }
+.receipts, .cite { border-bottom: 1px solid var(--line); background: var(--surface-2); padding: 10px 16px 12px; }
 .cite-mint { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
 .cite-mint input { border: 1px solid var(--line); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 160px; }
 .cite-mint .primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .cite-mint .primary:disabled { opacity: .6; }
 .cite-out { margin-top: 8px; }
 .cite-ids { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; margin-bottom: 8px; }
-.cite-ids .cid b { color: var(--sub); font-weight: 600; margin-right: 4px; } .cite-ids .cid code { color: #1a73e8; }
-.cite-ids .cid.ok { color: #137333; }
+.cite-ids .cid b { color: var(--sub); font-weight: 600; margin-right: 4px; } .cite-ids .cid code { color: var(--accent); }
+.cite-ids .cid.ok { color: var(--ok); }
 .cite-block { border: 1px solid var(--line); border-radius: 8px; background: #fff; margin-top: 8px; overflow: hidden; }
-.cb-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; background: #f8f9fa; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--sub); }
+.cb-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; background: var(--sunken); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--sub); }
 .cb-head button { border: 1px solid var(--line); background: #fff; border-radius: 6px; padding: 2px 8px; font-size: 11px; cursor: pointer; }
 .cb-body { margin: 0; padding: 8px 10px; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
-.cite-note { color: var(--sub); font-size: 11.5px; margin-top: 8px; } .cite-note b { color: #137333; }
+.cite-note { color: var(--sub); font-size: 11.5px; margin-top: 8px; } .cite-note b { color: var(--ok); }
 .rc-head { display: flex; align-items: center; gap: 10px; font-size: 13px; }
 .rc-head .rc-sub { color: var(--sub); font-size: 11.5px; } .rc-head .rc-x { margin-left: auto; border: 0; background: none; cursor: pointer; color: var(--sub); font-size: 14px; }
-.rc-err { color: #c5221f; font-size: 12px; margin-top: 6px; }
+.rc-err { color: var(--fail); font-size: 12px; margin-top: 6px; }
 .rc-list { margin-top: 8px; display: flex; flex-direction: column; gap: 2px; }
 .rc-row { display: grid; grid-template-columns: 160px 1fr auto auto; gap: 10px; align-items: center; font-size: 12px; padding: 4px 8px; border-radius: 8px; }
 .rc-row:hover { background: var(--accent-bg); }
 .rc-svc { font-weight: 600; color: var(--ink); } .rc-cid { color: var(--sub); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.rc-verdict { font-size: 10.5px; font-weight: 700; color: #137333; background: #eaf5ee; border-radius: 10px; padding: 1px 8px; }
+.rc-verdict { font-size: 10.5px; font-weight: 700; color: var(--ok); background: var(--ok-wash); border-radius: 10px; padding: 1px 8px; }
 .rc-when { color: var(--sub); font-size: 11px; white-space: nowrap; }
 .rc-empty { color: var(--sub); font-size: 12px; margin-top: 6px; }
 .mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
@@ -361,51 +361,51 @@ button.mb-chip { cursor: pointer; }
 
 .body { flex: 1; display: flex; min-height: 0; }
 .rail { width: 208px; flex-shrink: 0; border-right: 1px solid var(--line); background: var(--bg); display: flex; flex-direction: column; padding: 8px; }
-.rail button { display: flex; align-items: center; gap: 10px; text-align: left; padding: 9px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: #3c4043; font-size: 14px; }
-.rail button:hover { background: #f1f3f4; }
+.rail button { display: flex; align-items: center; gap: 10px; text-align: left; padding: 9px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: var(--ink-2); font-size: 14px; }
+.rail button:hover { background: var(--sunken); }
 .rail button.on { background: var(--accent-bg); color: var(--accent); font-weight: 600; }
 .rail .ic { width: 18px; } .rail .lbl { flex: 1; } .rail .cnt { font-size: 11px; color: var(--sub); background: #fff; border: 1px solid var(--line); border-radius: 9px; padding: 0 6px; }
 .rail button.on .cnt { background: #fff; }
 .rail-foot { margin-top: auto; padding: 10px 8px; }
-.rail .stub { font-size: 11px; color: #b06000; background: #fef7e0; border-radius: 8px; padding: 3px 8px; }
+.rail .stub { font-size: 11px; color: var(--warn); background: var(--warn-wash); border-radius: 8px; padding: 3px 8px; }
 
 .panel { flex: 1; overflow: auto; padding: 20px 24px; min-width: 0; }
 .sec-head h1 { font-size: 20px; margin: 0; } .sec-head .blurb { color: var(--sub); margin: 4px 0 16px; max-width: 680px; }
 
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 12px; }
 .card { border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; background: var(--card); cursor: pointer; transition: box-shadow .12s, border-color .12s; }
-.card:hover { box-shadow: 0 1px 8px rgba(60,64,67,.12); border-color: #dadce0; }
+.card:hover { box-shadow: 0 1px 8px rgba(60,64,67,.12); border-color: var(--hairline-strong); }
 .card.sel { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-bg); }
 .card .row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .card .name { font-weight: 600; }
 .card .sub { color: var(--sub); font-size: 12px; margin-top: 4px; }
-.card .mono { display: block; font: 11px/1.4 ui-monospace, monospace; color: #3c4043; background: #f8f9fa; border-radius: 6px; padding: 5px 8px; margin: 8px 0 6px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.card .mono { display: block; font: 11px/1.4 ui-monospace, monospace; color: var(--ink-2); background: var(--sunken); border-radius: 6px; padding: 5px 8px; margin: 8px 0 6px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .chips, .metrics { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
-.chip { font-size: 11px; background: #f1f3f4; border-radius: 8px; padding: 1px 8px; color: #3c4043; }
-.metric { font-size: 12px; color: var(--sub); background: #f8f9fa; border-radius: 8px; padding: 1px 8px; } .metric b { color: var(--ink); }
+.chip { font-size: 11px; background: var(--sunken); border-radius: 8px; padding: 1px 8px; color: var(--ink-2); }
+.metric { font-size: 12px; color: var(--sub); background: var(--sunken); border-radius: 8px; padding: 1px 8px; } .metric b { color: var(--ink); }
 .lineage { font: 11px/1.4 ui-monospace, monospace; color: var(--sub); margin-top: 8px; }
 .method { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; font-weight: 600; color: var(--accent); }
-.bar { height: 5px; background: #eceff1; border-radius: 3px; margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
-.prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; } .pstep { font: 10px/1.4 ui-monospace, monospace; background: #f1f3f4; border-radius: 6px; padding: 1px 7px; color: #3c4043; }
-.dot.ok { color: #137333; font-size: 11px; }
+.bar { height: 5px; background: var(--sunken); border-radius: 3px; margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
+.prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; } .pstep { font: 10px/1.4 ui-monospace, monospace; background: var(--sunken); border-radius: 6px; padding: 1px 7px; color: var(--ink-2); }
+.dot.ok { color: var(--ok); font-size: 11px; }
 .stat { font-size: 26px; font-weight: 700; margin-top: 6px; letter-spacing: -0.5px; }
-.rail-group { font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: #9aa0a6; padding: 12px 12px 4px; }
+.rail-group { font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--faint); padding: 12px 12px 4px; }
 
 .pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid var(--line); color: var(--sub); white-space: nowrap; }
-.pill.ok, .pill.promoted, .pill.done { border-color: #137333; color: #137333; }
+.pill.ok, .pill.promoted, .pill.done { border-color: var(--ok); color: var(--ok); }
 .pill.running { border-color: var(--accent); color: var(--accent); }
-.pill.failed { border-color: #c5221f; color: #c5221f; }
-.pill.warn, .pill.staged, .pill.queued, .pill.candidate { border-color: #b06000; color: #b06000; }
+.pill.failed { border-color: var(--fail); color: var(--fail); }
+.pill.warn, .pill.staged, .pill.queued, .pill.candidate { border-color: var(--warn); color: var(--warn); }
 
-.msg { color: var(--sub); padding: 10px 2px; } .msg.err { color: #c5221f; }
-.skeleton { pointer-events: none; } .sk-line { height: 10px; background: linear-gradient(90deg,#f1f3f4,#e8eaed,#f1f3f4); background-size: 200% 100%; border-radius: 5px; margin: 6px 0; animation: sh 1.2s infinite; } .w60 { width: 60%; } .w40 { width: 40%; }
+.msg { color: var(--sub); padding: 10px 2px; } .msg.err { color: var(--fail); }
+.skeleton { pointer-events: none; } .sk-line { height: 10px; background: linear-gradient(90deg,var(--sunken),var(--hairline),var(--sunken)); background-size: 200% 100%; border-radius: 5px; margin: 6px 0; animation: sh 1.2s infinite; } .w60 { width: 60%; } .w40 { width: 40%; }
 @keyframes sh { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 
 .drawer { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); background: #fff; padding: 18px 20px; overflow: auto; position: relative; }
 .drawer .close { position: absolute; top: 12px; right: 14px; border: none; background: none; font-size: 15px; color: var(--sub); cursor: pointer; }
 .drawer .d-kind { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--sub); }
 .drawer h2 { font-size: 18px; margin: 4px 0 14px; }
-.meta { margin: 0 0 14px; } .mrow { display: flex; gap: 10px; padding: 4px 0; border-bottom: 1px solid #f1f3f4; } .mrow dt { color: var(--sub); min-width: 96px; font-size: 12px; } .mrow dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
+.meta { margin: 0 0 14px; } .mrow { display: flex; gap: 10px; padding: 4px 0; border-bottom: 1px solid var(--sunken); } .mrow dt { color: var(--sub); min-width: 96px; font-size: 12px; } .mrow dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
 .d-block { margin: 12px 0; } .d-block h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--sub); margin: 0 0 6px; }
 .d-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
 .d-actions button { border: 1px solid var(--line); background: #fff; border-radius: 16px; padding: 6px 14px; font-size: 13px; cursor: pointer; }


### PR DESCRIPTION
## What
One **token spine** (`app-vue/src/styles/tokens.css`) that the whole Vue app inherits, replacing the borrowed Google-Material palette with our epistemic-Carbon design language. Rebased onto **current master** — none of the newer Governance/Ops/Query/Commons cockpit work is touched except its colours.

**Doctrine (Tufte · Bostock · Carbon):** grayscale carries all structure; the **epistemic ordered ramp** (`hypothesis→observed→derived→verified→attested`) is the single saturated dimension; ops-status is a *separate filled* palette (never the accent); Carbon density (4px grid, hairlines, near-square radii); dual-theme + a11y-ready.

**Type:** deliberately a **neutral system stack — no vendored webface.** A distinctive shipped font is a browser-fingerprint surface (kerning/metrics are identifiable); we ride the viewer's own system font until a non-fingerprintable face is chosen. Do not add a webfont without that review.

## Changes
- **`styles/tokens.css`** (new) — neutrals (blue-biased), epistemic ramp, semantic status, density/radius scale; light+dark at token level; imported first in `main.ts`.
- **`studioApi.ts`** — `EPISTEMIC_COLORS` resolves from the token vars so graph/chips/membrane share one ink.
- **`styles.css`** — global `.card/.btn/.pill/.nav/input` reskinned Carbon-flat, wired to tokens (`--brand/--bg/--panel` back-compat aliases).
- **`Studio.vue`** root vars off `#1a73e8` onto tokens.
- **Curated Google-Material → token sweep** across every `Studio*` component (Graph/Ops/Governance/Commons/Experiments/Query) and views (Knowledge/Mail/Search/Market/Cloud/Code/AppLauncher): **441 literals**. `StudioGraph` is now **theme-aware** (was light-only). Intentional purple brand accents + `#a6ce39` left untouched.

## Safety
- **Palette / type / density only** — no behaviour/logic change.
- `vite build` green.
- No auth/config bypass files included.

## Follow-ups (not here)
Deep per-surface passes (density + epistemic stripes + inline sparklines + factsheets + wiring surfaces to the live BFF); choosing the non-fingerprintable display face; the notebook surface + governed runtime.