### PR TITLE
Inline provenance node-link strip (kill lineage.join)

### DIFF
--- a/socioprophet-web/app-vue/src/components/LineageStrip.vue
+++ b/socioprophet-web/app-vue/src/components/LineageStrip.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+// Inline provenance as a real node-link strip — not a space-joined string.
+// Accepts an array of stages; any element that itself encodes a pipeline
+// ("ingest→dbt→catalog", "a -> b", "x · y") is split into its stages.
+const props = defineProps<{ steps: (string | { label: string; hash?: string })[]; title?: string }>();
+
+const stages = computed(() => {
+  const out: { label: string; hash?: string }[] = [];
+  for (const s of props.steps ?? []) {
+    if (typeof s === "object") { out.push({ label: s.label, hash: s.hash }); continue; }
+    for (const part of String(s).split(/\s*(?:→|->|·|→)\s*/).filter(Boolean)) {
+      out.push({ label: part.trim() });
+    }
+  }
+  return out;
+});
+</script>
+
+<template>
+  <div class="lineage-strip" v-if="stages.length" :aria-label="title || 'lineage'">
+    <template v-for="(st, i) in stages" :key="i">
+      <span class="node" :class="{ last: i === stages.length - 1 }" :title="st.hash ? st.label + ' · ' + st.hash : st.label">{{ st.label }}</span>
+      <span v-if="i < stages.length - 1" class="arrow" aria-hidden="true">▸</span>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.lineage-strip { display: flex; align-items: center; gap: 5px; overflow-x: auto; padding: 2px 0;
+  font: 500 11px/1.3 var(--ui, sans-serif); scrollbar-width: thin; }
+.lineage-strip::-webkit-scrollbar { height: 4px; }
+.node { flex: 0 0 auto; white-space: nowrap; padding: 2px 8px; border: 1px solid var(--hairline);
+  border-radius: var(--r-1, 3px); background: var(--surface); color: var(--ink-2, var(--ink)); }
+.node.last { border-color: color-mix(in srgb, var(--epi-attested) 55%, var(--hairline));
+  color: var(--epi-attested); background: var(--epi-attested-wash, transparent); font-weight: 600; }
+.arrow { flex: 0 0 auto; color: var(--faint, var(--muted)); font-size: 10px; }
+</style>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -8,6 +8,7 @@ import StudioCommons from "../components/StudioCommons.vue";
 import StudioOps from "../components/StudioOps.vue";
 import StudioGovernance from "../components/StudioGovernance.vue";
 import StudioNotebooks from "../components/StudioNotebooks.vue";
+import LineageStrip from "../components/LineageStrip.vue";
 
 const bundle = ref<StudioBundle | null>(null);
 const error = ref("");
@@ -242,7 +243,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
             <template v-else-if="section === 'data'">
               <div class="row"><span class="name">{{ it.name }}</span><span v-if="it.governed" class="pill ok">governed</span><span v-else class="pill warn">ungoverned</span></div>
               <div class="sub">{{ it.kind }}<span v-if="it.rows"> · {{ it.rows.toLocaleString() }} rows</span><span v-if="it.columns"> · {{ it.columns }} cols</span></div>
-              <div v-if="it.lineage" class="lineage">{{ it.lineage.join(" ") }}</div>
+              <LineageStrip v-if="it.lineage" :steps="it.lineage" />
             </template>
             <!-- models -->
             <template v-else-if="section === 'models'">
@@ -298,8 +299,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
               <div v-if="k !== 'id' && typeof v !== 'object'" class="mrow"><dt>{{ k }}</dt><dd>{{ v }}</dd></div>
             </template>
           </dl>
-          <div v-if="selected.item.lineage" class="d-block"><h3>Lineage</h3><div class="lineage">{{ selected.item.lineage.join(" ") }}</div></div>
-          <div v-if="selected.item.steps" class="d-block"><h3>Provenance</h3><div class="prov"><span v-for="st in selected.item.steps" :key="st.label" class="pstep">{{ st.label }} · {{ st.hash }}</span></div></div>
+          <div v-if="selected.item.lineage" class="d-block"><h3>Lineage</h3><LineageStrip :steps="selected.item.lineage" title="Lineage" /></div>
+          <div v-if="selected.item.steps" class="d-block"><h3>Provenance</h3><LineageStrip :steps="selected.item.steps" title="Provenance" /></div>
           <div class="d-actions">
             <button v-for="a in actionsFor[selected.kind]" :key="a.label" :title="a.hint" :class="{ primary: a.label === actionsFor[selected.kind][0].label }">{{ a.label }}</button>
           </div>


### PR DESCRIPTION
The graph company was rendering provenance as `lineage.join(" ")` — a space-joined string. Replaced with **LineageStrip.vue**: a compact horizontal node-link strip (token-styled nodes, arrows, the terminal node emphasized as attested, overflow-scrolls, hover reveals step hashes). Splits pipeline strings like `ingest→dbt→catalog` into real stages. Wired into the data-catalog card + the drawer's Lineage and Provenance blocks. Touches only `Studio.vue` + the new component (no overlap with parallel notebook/graph work). vite build green.