### PR TITLE
feat(studio): anneal Studio surfaces to the epistemic-Carbon design system

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioCommons.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCommons.vue
@@ -60,7 +60,7 @@ function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
       <span class="cnt" v-if="commons">{{ commons.scale.facts }} facts · {{ commons.scale.preserved_versions }} versions · {{ commons.scale.endorsements }} endorsements</span>
       <div class="spacer" />
       <button class="run" @click="showEndorse = !showEndorse">＋ Endorse a fact</button>
-      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload commons">↻</button>
     </div>
 
     <div v-if="showEndorse" class="logbox">
@@ -181,60 +181,61 @@ function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
 
 <style scoped>
 .cm { font: 14px/1.5 var(--ui); color: var(--ink); }
-.cbar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.cm :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.cbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
 .cbar .cnt { color: var(--muted); font-size: 12px; } .cbar .spacer { flex: 1; }
-.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.logbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin-bottom: 14px; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: var(--r-3); background: var(--sunken); padding: 10px 12px; margin-bottom: 14px; }
 .lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-.lrow input { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
 .lrow input.j { flex: 1; min-width: 150px; } .lrow input.tok { width: 120px; }
-.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .lrow button.primary:disabled { opacity: .6; cursor: default; }
 .lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }
 
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
-.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); }
 .card.wide { grid-column: 1 / -1; }
-.ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
 .ch .ci { color: var(--accent); } .ch .plus { color: var(--accent); font-weight: 700; }
-.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: 10px; padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
 .score.hi { color: var(--ok); background: var(--ok-wash); }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.mono { font-family: var(--mono); font-size: 12px; }
 .sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
 
 .fair { display: flex; flex-wrap: wrap; gap: 6px; }
-.fq { font-size: 12px; border: 1px solid var(--hairline); color: var(--faint); border-radius: 8px; padding: 3px 9px; }
-.fq.on { color: var(--ok); border-color: var(--ok-wash); background: var(--ok-wash); }
+.fq { font-size: 12px; border: 1px solid var(--hairline); color: var(--faint); border-radius: var(--r-2); padding: 3px 9px; }
+.fq.on { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
 .plusrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
-.ptag { font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 8px; padding: 2px 8px; }
+.ptag { font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--r-2); padding: 2px 8px; }
 .ptag.sm { font-size: 9.5px; padding: 1px 6px; }
 .hint { color: var(--warn); font-size: 12px; margin: 8px 0 0; }
 .ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
-.ids code { background: var(--sunken); border: 1px solid var(--hairline); border-radius: 6px; padding: 2px 7px; }
+.ids code { background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 2px 7px; }
 
 .scale { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 10px; }
 .st { display: flex; flex-direction: column; } .st b { font-size: 20px; font-variant-numeric: tabular-nums; } .st span { font-size: 11px; color: var(--muted); }
-.mb-bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
+.mb-bar { display: flex; height: 8px; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
 
 .vlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
-.vlist li { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
-.vv { font-weight: 700; color: var(--accent); } .hash { background: var(--sunken); border-radius: 5px; padding: 1px 6px; }
+.vlist li { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; }
+.vv { font-weight: 700; color: var(--accent); font-variant-numeric: tabular-nums; } .hash { background: var(--sunken); border-radius: var(--r-1); padding: 1px 6px; }
 .when { color: var(--muted); font-size: 11px; } .vnote { color: var(--muted); font-style: italic; }
 
 .row2 { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 8px; }
 .link { color: var(--accent); text-decoration: none; } .link:hover { text-decoration: underline; }
 .orcids { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
-.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink); text-decoration: none; border: 1px solid var(--hairline); border-radius: 8px; padding: 2px 8px; }
-.orcid .oic { background: #a6ce39; color: #fff; font-size: 9px; font-weight: 700; border-radius: 3px; padding: 1px 3px; }
+.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink); text-decoration: none; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 2px 8px; }
+.orcid .oic { background: #a6ce39; color: #fff; font-size: 9px; font-weight: 700; border-radius: var(--r-1); padding: 1px 3px; }
 .manifest { border-top: 1px solid var(--sunken); padding-top: 8px; }
 .mtitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); display: flex; align-items: center; gap: 6px; }
 .verbs { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
-.verb { font-size: 11.5px; background: var(--sunken); border-radius: 7px; padding: 2px 8px; color: var(--ink); } .verb.off { color: var(--faint); }
+.verb { font-size: 11.5px; background: var(--sunken); border-radius: var(--r-2); padding: 2px 8px; color: var(--ink); } .verb.off { color: var(--faint); }
 .verb .vok { color: var(--ok); font-style: normal; margin-left: 3px; }
 
-.cscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: 10px; }
+.cscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: var(--r-3); }
 .cgrid { border-collapse: collapse; width: 100%; font-size: 12.5px; }
 .cgrid th { text-align: left; padding: 7px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
 .cgrid td { padding: 7px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; } .cgrid tr:last-child td { border-bottom: 0; }

--- a/socioprophet-web/app-vue/src/components/StudioExperiments.vue
+++ b/socioprophet-web/app-vue/src/components/StudioExperiments.vue
@@ -55,7 +55,7 @@ function kv(o: Record<string, unknown>): string { return Object.entries(o).map((
       <span class="cnt">{{ data?.count ?? 0 }} runs</span>
       <div class="spacer" />
       <button class="run" @click="showLog = !showLog">＋ Log run</button>
-      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload runs">↻</button>
     </div>
 
     <div v-if="showLog" class="logbox">
@@ -95,28 +95,29 @@ function kv(o: Record<string, unknown>): string { return Object.entries(o).map((
 
 <style scoped>
 .xp { font: 14px/1.5 var(--ui); color: var(--ink); }
-.xbar { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
-.xbar .cnt { color: var(--muted); font-size: 12px; } .xbar .spacer { flex: 1; }
-.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
-.logbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin-bottom: 12px; }
+.xp :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.xbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: 10px; }
+.xbar .cnt { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; } .xbar .spacer { flex: 1; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.mono { font-family: var(--mono); font-size: 12px; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: var(--r-3); background: var(--sunken); padding: 10px 12px; margin-bottom: 12px; }
 .lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-.lrow input { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
 .lrow input.j { flex: 1; min-width: 140px; } .lrow input.tok { width: 120px; }
-.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .lrow button.primary:disabled { opacity: .6; cursor: default; }
 .lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }
-.xscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: 10px; }
+.xscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: var(--r-3); }
 .xgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
 .xgrid th { text-align: left; padding: 8px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
 .xgrid td { padding: 8px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; }
 .xgrid tr:last-child td { border-bottom: 0; }
 .xgrid .nm { font-weight: 600; } .xgrid .met { color: var(--ok); }
-.pill { font-size: 10.5px; border-radius: 10px; padding: 1px 8px; background: var(--hairline); color: var(--muted); }
+.pill { font-size: 10.5px; border-radius: var(--pill); padding: 1px 8px; background: var(--hairline); color: var(--muted); }
 .pill.finished { background: var(--ok-wash); color: var(--ok); } .pill.running { background: var(--accent-wash); color: var(--accent); } .pill.failed { background: var(--fail-wash); color: var(--fail); }
-.epi { font-size: 10.5px; border: 1px solid; border-radius: 10px; padding: 1px 8px; }
+.epi { font-size: 10.5px; border: 1px solid; border-radius: var(--r-1); padding: 1px 8px; }
 .when { color: var(--muted); font-size: 11px; }
 .note { color: var(--muted); font-size: 12.5px; margin-top: 8px; } .note b { color: var(--ink); }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioGovernance.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGovernance.vue
@@ -91,7 +91,7 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
       <span class="cnt">Governance · real ontology · typed actions · the GAIA promotion membrane</span>
       <div class="spacer" />
       <input v-model="token" type="password" class="tok" placeholder="write token" />
-      <button class="ghost" @click="load" :disabled="loading">↻</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload governance">↻</button>
     </div>
     <p v-if="flash" class="flash">{{ flash }}</p>
     <p v-if="err" class="msg err">{{ err }}</p>
@@ -216,50 +216,51 @@ function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "ob
 
 <style scoped>
 .gov { font: 14px/1.5 var(--ui); color: var(--ink); }
-.gbar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.gov :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.gbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
 .gbar .cnt { color: var(--muted); font-size: 12px; } .gbar .spacer { flex: 1; }
-.gbar .tok { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 120px; }
-.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.flash { background: var(--ok-wash); color: var(--ok); border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.gbar .tok { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; width: 120px; background: var(--surface); color: var(--ink); }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 12px; }
-.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; } .card.wide { grid-column: 1 / -1; }
-.ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
-.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 10px; padding: 2px 9px; font-weight: 500; }
-.score { margin-left: auto; font-size: 11px; color: var(--ok); background: var(--ok-wash); border-radius: 10px; padding: 2px 9px; }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); } .card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--pill); padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--ok); background: var(--ok-wash); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); font-size: 12px; }
 .sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
-.j { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.mini { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 7px; padding: 3px 9px; font-size: 11.5px; cursor: pointer; }
+.j { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.mini { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 3px 9px; font-size: 11.5px; cursor: pointer; }
 .mini.go { border-color: var(--accent); color: var(--accent); } .mini.danger { border-color: var(--warn); color: var(--warn); }
 
 .orow { display: flex; gap: 6px; margin-bottom: 8px; } .orow .j { flex: 1; }
 .clist { list-style: none; margin: 0 0 8px; padding: 0; }
-.clist li { display: flex; align-items: center; gap: 8px; padding: 3px 6px; border-radius: 6px; cursor: pointer; }
+.clist li { display: flex; align-items: center; gap: var(--sp-2); padding: 3px 6px; border-radius: var(--r-2); cursor: pointer; }
 .clist li:hover, .clist li.sel { background: var(--accent-wash); } .clist .pc { margin-left: auto; font-size: 11px; color: var(--faint); }
 .cdetail { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; }
 .cd-h { display: flex; gap: 8px; align-items: baseline; } .cd-h .sub { font-size: 11px; color: var(--muted); }
 .props { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
-.prop { font-size: 10.5px; background: var(--sunken); border-radius: 6px; padding: 1px 6px; font-family: ui-monospace, Menlo, monospace; }
+.prop { font-size: 10.5px; background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; font-family: var(--mono); }
 .prop.object { background: var(--accent-wash); color: var(--accent); } .prop i { font-style: normal; opacity: .6; }
 
-.action { border: 1px solid var(--sunken); border-radius: 8px; padding: 6px 8px; margin-bottom: 6px; }
-.arow { display: flex; align-items: center; gap: 8px; } .arow .tt { margin-left: auto; background: var(--sunken); border-radius: 6px; padding: 1px 6px; }
-.eff { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 4px; } .eff .e { font-size: 10.5px; color: var(--muted); background: var(--sunken); border-radius: 6px; padding: 1px 6px; }
+.action { border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 6px 8px; margin-bottom: 6px; }
+.arow { display: flex; align-items: center; gap: var(--sp-2); } .arow .tt { margin-left: auto; background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; }
+.eff { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 4px; } .eff .e { font-size: 10.5px; color: var(--muted); background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; }
 .invoke { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; display: flex; flex-direction: column; gap: 6px; }
 .irow { display: flex; gap: 6px; } .irow .j { flex: 1; } .invoke .j { width: 100%; }
 
 .membrane { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
-.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid var(--hairline); border-radius: 8px; padding: 5px 9px; }
-.mstate.canon { border-color: var(--ok-wash); background: var(--ok-wash); }
+.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 5px 9px; }
+.mstate.canon { border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
 .ms-n { font-weight: 600; font-size: 12px; } .ms-epi { font-size: 10.5px; } .ms-arrow { color: var(--faint); margin: 0 2px; }
-.invariant { background: var(--warn-wash); color: var(--warn); border-radius: 8px; padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
+.invariant { background: var(--warn-wash); color: var(--warn); border-radius: var(--r-2); padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
 .submit { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
 .wgrid { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 .wgrid th { text-align: left; padding: 6px 8px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 10.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
 .wgrid td { padding: 6px 8px; border-bottom: 1px solid var(--sunken); } .wgrid .nm { font-weight: 600; }
-.state { font-size: 10.5px; border-radius: 8px; padding: 1px 8px; background: var(--sunken); color: var(--muted); } .state.canon { background: var(--ok-wash); color: var(--ok); }
-.epi { font-size: 10px; border: 1px solid; border-radius: 8px; padding: 1px 7px; } .ev { text-align: center; }
+.state { font-size: 10.5px; border-radius: var(--pill); padding: 1px 8px; background: var(--sunken); color: var(--muted); } .state.canon { background: var(--ok-wash); color: var(--ok); }
+.epi { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 1px 7px; } .ev { text-align: center; font-variant-numeric: tabular-nums; }
 .promote { display: flex; gap: 4px; flex-wrap: wrap; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioGraph.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGraph.vue
@@ -211,9 +211,9 @@ async function loadDerived() {
         <p class="sub">A force-directed explorer where every node carries its <b>epistemic status</b> and <b>provenance</b> — what a graph explorer shows that Neo4j Bloom can't.</p>
       </div>
       <div class="tools">
-        <button class="tbtn" :class="{ on: showAdd }" @click="showAdd = !showAdd" title="hand-author a node or edge (KE-1 workbench)">＋</button>
-        <button class="tbtn" @click="resetView" title="reset pan/zoom">⤢</button>
-        <button class="tbtn" @click="load" :disabled="loading" title="reload">↻</button>
+        <button class="tbtn" :class="{ on: showAdd }" @click="showAdd = !showAdd" title="hand-author a node or edge (KE-1 workbench)" aria-label="Add a node or edge">＋</button>
+        <button class="tbtn" @click="resetView" title="reset pan/zoom" aria-label="Reset pan and zoom">⤢</button>
+        <button class="tbtn" @click="load" :disabled="loading" title="reload" aria-label="Reload graph">↻</button>
       </div>
     </header>
 
@@ -272,7 +272,7 @@ async function loadDerived() {
                :transform="`translate(${n.x},${n.y})`" @pointerdown="onNodeDown(n, $event)"
                @pointerenter="hovered = n" @pointerleave="hovered = null" @click.stop="selected = n">
               <circle :r="n.r" :fill="color(n.epistemic_mode)"
-                      :stroke="selected?.id === n.id ? 'var(--ink)' : '#fff'" :stroke-width="selected?.id === n.id ? 2 : 1.2" />
+                      :stroke="selected?.id === n.id ? 'var(--ink)' : 'var(--surface)'" :stroke-width="selected?.id === n.id ? 2 : 1.2" />
               <text v-if="showLabels || hovered?.id === n.id || selected?.id === n.id"
                     :x="n.r + 4" y="4" class="lbl">{{ n.name }}</text>
             </g>
@@ -284,7 +284,7 @@ async function loadDerived() {
 
     <transition name="slide">
       <aside v-if="selected" class="prov">
-        <button class="x" @click="selected = null">✕</button>
+        <button class="x" @click="selected = null" aria-label="Close node panel">✕</button>
         <div class="pk">Node</div>
         <h3>{{ selected.name }}</h3>
         <dl>
@@ -321,70 +321,75 @@ async function loadDerived() {
 
 <style scoped>
 .ge { font: 14px/1.5 var(--ui); color: var(--ink); position: relative; }
+.ge :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
 .ge-head { display: flex; justify-content: space-between; align-items: flex-start; }
-.ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: var(--muted); font-weight: 400; }
+.ge-head h2 { font-size: 18px; margin: 0; } .ge-head .cnt { font-size: 12px; color: var(--muted); font-weight: 400; font-variant-numeric: tabular-nums; }
 .ge-head .sub { color: var(--muted); margin: 4px 0 12px; max-width: 640px; } .ge-head .sub b { color: var(--ink); }
 .tools { display: flex; gap: 6px; }
-.tbtn { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
+.tbtn { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; font-size: 14px; }
 .tbtn:hover { background: var(--sunken); }
 .tbtn.on { background: var(--accent-wash); border-color: var(--accent); color: var(--accent); }
-.addbox { border: 1px solid var(--hairline-strong); border-radius: 10px; background: var(--sunken); padding: 10px 12px; margin: 0 0 12px; }
+.addbox { border: 1px solid var(--hairline-strong); border-radius: var(--r-3); background: var(--sunken); padding: 10px 12px; margin: 0 0 12px; }
 .addrow { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.addrow input, .addrow select { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; background: #fff; min-width: 120px; }
+.addrow input, .addrow select { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); min-width: 120px; }
 .addrow input.short { min-width: 90px; width: 110px; }
 .addrow .arr { color: var(--muted); }
-.addrow .seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: 8px; overflow: hidden; }
-.addrow .seg button { border: 0; background: #fff; padding: 6px 10px; font-size: 12px; cursor: pointer; color: var(--muted); }
+.addrow .seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); overflow: hidden; }
+.addrow .seg button { border: 0; background: var(--surface); padding: 6px 10px; font-size: 12px; cursor: pointer; color: var(--muted); }
 .addrow .seg button.on { background: var(--accent); color: #fff; }
-.addrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.addrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .addrow button.primary:disabled { opacity: .6; cursor: default; }
 .addfeedback { margin: 8px 0 0; font-size: 12.5px; } .addfeedback.ok { color: var(--ok); } .addfeedback.err { color: var(--fail); }
 .addnote { margin: 6px 0 0; font-size: 11px; color: var(--muted); }
 
 .dist { margin: 4px 0 12px; }
-.dist .bar { display: flex; height: 8px; border-radius: 5px; overflow: hidden; background: var(--sunken); }
+.dist .bar { display: flex; height: 8px; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); }
 .dist .bar span { display: block; }
 .dist .legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 8px; font-size: 12px; color: var(--muted); }
-.dist .lg i { display: inline-block; width: 9px; height: 9px; border-radius: 3px; margin-right: 4px; vertical-align: middle; }
+.dist .lg i { display: inline-block; width: 9px; height: 9px; border-radius: var(--r-1); margin-right: 4px; vertical-align: middle; }
 
-.canvas-wrap { position: relative; border: 1px solid var(--hairline); border-radius: 12px; background:
-  radial-gradient(circle at 1px 1px, var(--sunken) 1px, transparent 0) 0 0 / 22px 22px, #fff; overflow: hidden; }
+.canvas-wrap { position: relative; border: 1px solid var(--hairline); border-radius: var(--r-3); background:
+  radial-gradient(circle at 1px 1px, var(--canvas-dot) 1px, transparent 0) 0 0 / 22px 22px, var(--surface); overflow: hidden; }
 .canvas { display: block; width: 100%; height: 560px; touch-action: none; cursor: grab; }
 .canvas:active { cursor: grabbing; }
 .edges line { stroke: var(--hairline-strong); transition: opacity .15s; }
 .edges line.dim { opacity: .12; }
 .nodes g { cursor: pointer; transition: opacity .15s; }
 .nodes g.dim { opacity: .18; }
-.nodes .lbl { font: 500 11px/1 var(--ui); fill: var(--ink); paint-order: stroke; stroke: #fff; stroke-width: 3px; stroke-linejoin: round; pointer-events: none; }
+.nodes .lbl { font: 500 11px/1 var(--ui); fill: var(--ink); paint-order: stroke; stroke: var(--surface); stroke-width: 3px; stroke-linejoin: round; pointer-events: none; }
 .hint { position: absolute; bottom: 8px; left: 10px; font-size: 11px; color: var(--faint); pointer-events: none; }
 
-.note { font-size: 12px; color: var(--warn); background: var(--warn-wash); border-radius: 8px; padding: 6px 10px; margin: 0 0 12px; }
+.note { font-size: 12px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 6px 10px; margin: 0 0 12px; }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }
 
-.prov { position: absolute; top: 74px; right: 8px; width: 300px; background: #fff; border: 1px solid var(--hairline); border-radius: 12px; padding: 16px 18px; box-shadow: -2px 2px 16px rgba(60,64,67,.14); }
+.prov { position: absolute; top: 74px; right: 8px; width: 300px; background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 16px 18px; box-shadow: var(--e-2); }
 .prov .x { position: absolute; top: 10px; right: 12px; border: none; background: none; cursor: pointer; color: var(--muted); }
 .prov .pk { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--muted); }
 .prov h3 { margin: 4px 0 12px; font-size: 17px; }
 .prov dl { margin: 0; } .prov dl > div { display: flex; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--sunken); }
 .prov dt { color: var(--muted); min-width: 96px; font-size: 12px; } .prov dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
-.prov .mono { font-family: ui-monospace, monospace; font-size: 11px; }
-.prov .pill { border: 1.5px solid; border-radius: 8px; padding: 0 8px; font-size: 12px; font-weight: 600; }
+.prov .mono { font-family: var(--mono); font-size: 11px; }
+.prov .pill { border: 1.5px solid; border-radius: var(--r-2); padding: 0 8px; font-size: 12px; font-weight: 600; }
 .prov .acts { display: flex; gap: 8px; margin-top: 14px; }
-.prov .acts button { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 16px; padding: 5px 12px; font-size: 12px; cursor: pointer; }
+.prov .acts button { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 5px 12px; font-size: 12px; cursor: pointer; }
 .prov .acts button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 .prov .acts button.primary:disabled { opacity: .6; cursor: default; }
 .derived { margin-top: 10px; border-top: 1px solid var(--hairline); padding-top: 10px; }
 .derived.err { color: var(--fail); font-size: 12px; }
 .derived .dsum { margin: 0 0 6px; font-size: 12.5px; color: var(--ink); }
 .derived .dmeta { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 8px; }
-.derived .kko { font-size: 10px; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 1px 7px; color: var(--muted); }
+.derived .kko { font-size: 10px; border: 1px solid var(--hairline-strong); border-radius: var(--pill); padding: 1px 7px; color: var(--muted); }
 .derived .ex { font-size: 10px; color: var(--muted); }
 .derived .dlbl { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin-bottom: 4px; }
 .derived .drow { display: flex; align-items: center; gap: 6px; padding: 3px 0; font-size: 12px; }
 .derived .rel { color: var(--muted); min-width: 92px; }
 .derived .dwith { flex: 1; color: var(--ink); }
-.derived .dpill { font-size: 10px; border: 1px solid; border-radius: 10px; padding: 0 6px; }
+.derived .dpill { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 0 6px; }
 .derived .dnone { font-size: 12px; color: var(--muted); }
 .slide-enter-active, .slide-leave-active { transition: transform .18s, opacity .18s; }
 .slide-enter-from, .slide-leave-to { transform: translateX(16px); opacity: 0; }
+@media (prefers-reduced-motion: reduce) {
+  .edges line, .nodes g { transition: none; }
+  .slide-enter-active, .slide-leave-active { transition: none; }
+}
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioOps.vue
+++ b/socioprophet-web/app-vue/src/components/StudioOps.vue
@@ -76,7 +76,7 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
       <span class="cnt">Operations · pipelines · registry · catalog · compute · communities</span>
       <div class="spacer" />
       <input v-model="token" type="password" class="tok" placeholder="write token" title="required for run / promote / execute" />
-      <button class="ghost" @click="load" :disabled="loading" title="reload">↻</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload operations">↻</button>
     </div>
     <p v-if="flash" class="flash">{{ flash }}</p>
     <p v-if="err" class="msg err">{{ err }}</p>
@@ -187,62 +187,63 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
 
 <style scoped>
 .ops { font: 14px/1.5 var(--ui); color: var(--ink); }
-.obar { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.ops :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.obar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
 .obar .cnt { color: var(--muted); font-size: 12px; } .obar .spacer { flex: 1; }
-.obar .tok { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 130px; }
-.ghost { border: 1px solid var(--hairline-strong); background: #fff; border-radius: 8px; width: 30px; height: 30px; cursor: pointer; }
-.flash { background: var(--ok-wash); color: var(--ok); border-radius: 8px; padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.obar .tok { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; width: 130px; background: var(--surface); color: var(--ink); }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
 .msg { color: var(--muted); } .msg.err { color: var(--fail); }
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; }
-.card { border: 1px solid var(--hairline); border-radius: 12px; padding: 14px 16px; background: #fff; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); }
 .card.wide { grid-column: 1 / -1; }
-.ch { display: flex; align-items: center; gap: 8px; font-weight: 600; font-size: 14px; margin-bottom: 10px; }
-.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: 10px; padding: 2px 9px; font-weight: 500; }
-.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: 10px; padding: 2px 9px; }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; font-size: 12px; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--pill); padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); font-size: 12px; }
 .sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
 
 /* compute */
-.backends { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 8px; margin-bottom: 10px; }
+.backends { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--sp-2); margin-bottom: 10px; }
 .backend { display: grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto; gap: 2px 8px; align-items: center;
-  border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; cursor: pointer; }
+  border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 8px 10px; cursor: pointer; }
 .backend.sel { border-color: var(--accent); background: var(--accent-wash); } .backend.ent { }
 .backend input { grid-row: 1 / 3; } .bn { font-weight: 600; font-size: 13px; } .bn .bk { font-style: normal; font-size: 10px; color: var(--muted); margin-left: 6px; }
 .bnote { grid-column: 2; font-size: 11px; color: var(--muted); } .bstate { grid-column: 2; font-size: 10px; color: var(--warn); } .bstate.on { color: var(--ok); }
 .exrow { display: flex; gap: 6px; margin-bottom: 8px; }
-.exrow .sel-k { border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.exrow .ref { flex: 1; border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 6px 8px; font-size: 13px; }
-.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.exrow .sel-k { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.exrow .ref { flex: 1; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .primary:disabled { opacity: .6; }
-.exres { font-size: 12.5px; border-radius: 8px; padding: 8px 10px; background: var(--ok-wash); color: var(--ok); }
+.exres { font-size: 12.5px; border-radius: var(--r-2); padding: 8px 10px; background: var(--ok-wash); color: var(--ok); }
 .exres.gated { background: var(--warn-wash); color: var(--warn); }
-.exres .rep { margin-left: 6px; font-size: 10px; background: #fff; border-radius: 8px; padding: 1px 6px; }
+.exres .rep { margin-left: 6px; font-size: 10px; background: var(--surface); border-radius: var(--r-2); padding: 1px 6px; }
 
 /* models */
 .model { margin-bottom: 8px; } .mname { font-weight: 600; margin-bottom: 3px; }
-.mver { display: flex; align-items: center; gap: 8px; font-size: 12.5px; padding: 3px 0; flex-wrap: wrap; }
-.vv { font-weight: 700; color: var(--accent); }
-.stage { font-size: 10px; border-radius: 8px; padding: 1px 7px; background: var(--sunken); color: var(--muted); }
+.mver { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; padding: 3px 0; flex-wrap: wrap; }
+.vv { font-weight: 700; color: var(--accent); font-variant-numeric: tabular-nums; }
+.stage { font-size: 10px; border-radius: var(--pill); padding: 1px 7px; background: var(--sunken); color: var(--muted); }
 .stage.production { background: var(--ok-wash); color: var(--ok); } .stage.staging { background: var(--accent-wash); color: var(--accent); } .stage.archived { background: var(--sunken); color: var(--faint); }
-.met { color: var(--ok); } .lineage { color: var(--muted); }
-.promote { margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: 8px; font-size: 11.5px; padding: 2px 6px; }
+.met { color: var(--ok); font-variant-numeric: tabular-nums; } .lineage { color: var(--muted); }
+.promote { margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); font-size: 11.5px; padding: 2px 6px; background: var(--surface); color: var(--ink); }
 
 /* pipelines */
-.pipe { margin-bottom: 8px; } .prow { display: flex; align-items: center; gap: 8px; }
-.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid var(--accent); background: #fff; color: var(--accent); border-radius: 8px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
+.pipe { margin-bottom: 8px; } .prow { display: flex; align-items: center; gap: var(--sp-2); }
+.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid var(--accent); background: var(--surface); color: var(--accent); border-radius: var(--r-2); padding: 3px 10px; font-size: 12px; cursor: pointer; }
 .dag { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; margin-top: 5px; }
-.step { font-size: 11.5px; background: var(--sunken); border-radius: 7px; padding: 2px 9px; } .arrow { color: var(--faint); }
+.step { font-size: 11.5px; background: var(--sunken); border-radius: var(--r-2); padding: 2px 9px; } .arrow { color: var(--faint); }
 
 /* catalog */
 .cat { width: 100%; border-collapse: collapse; font-size: 12.5px; }
 .cat td { padding: 5px 8px; border-bottom: 1px solid var(--sunken); } .cat tr:last-child td { border-bottom: 0; }
-.cat .nm { font-weight: 600; } .cat .cols { color: var(--muted); } .pill { font-size: 10px; background: var(--hairline); border-radius: 8px; padding: 1px 7px; color: var(--muted); }
-.epi { font-size: 10px; border: 1px solid; border-radius: 8px; padding: 1px 7px; }
+.cat .nm { font-weight: 600; } .cat .cols { color: var(--muted); } .pill { font-size: 10px; background: var(--hairline); border-radius: var(--r-2); padding: 1px 7px; color: var(--muted); }
+.epi { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 1px 7px; }
 
 /* communities */
-.comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 10px; }
-.comm { border: 1px solid var(--sunken); border-radius: 10px; padding: 8px 10px; }
-.crow { display: flex; align-items: center; gap: 8px; font-size: 12.5px; } .crow b { font-size: 16px; }
-.mb-bar { display: flex; height: 7px; flex: 1; border-radius: 5px; overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
+.comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--sp-3); }
+.comm { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 8px 10px; }
+.crow { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; } .crow b { font-size: 16px; font-variant-numeric: tabular-nums; }
+.mb-bar { display: flex; height: 7px; flex: 1; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
 .top { font-size: 11.5px; color: var(--muted); margin-top: 5px; }
 </style>

--- a/socioprophet-web/app-vue/src/components/StudioQuery.vue
+++ b/socioprophet-web/app-vue/src/components/StudioQuery.vue
@@ -87,28 +87,29 @@ function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "var(--f
 
 <style scoped>
 .qide { font: 14px/1.5 var(--ui); color: var(--ink); }
-.qbar { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.qide :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.qbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: 8px; }
 .qbar .spacer { flex: 1; }
-.seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: 8px; overflow: hidden; }
-.seg button { border: 0; background: #fff; padding: 6px 12px; font-size: 12px; text-transform: capitalize; cursor: pointer; color: var(--muted); }
+.seg { display: inline-flex; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); overflow: hidden; }
+.seg button { border: 0; background: var(--surface); padding: 6px 12px; font-size: 12px; text-transform: capitalize; cursor: pointer; color: var(--muted); }
 .seg button.on { background: var(--accent); color: #fff; }
-.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 16px; font-size: 13px; cursor: pointer; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 16px; font-size: 13px; cursor: pointer; }
 .run:disabled { opacity: .6; cursor: default; }
-.qed { width: 100%; resize: vertical; border: 1px solid var(--hairline-strong); border-radius: 10px; padding: 12px; font-size: 13px; background: var(--surface-2); box-sizing: border-box; }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+.qed { width: 100%; resize: vertical; border: 1px solid var(--hairline-strong); border-radius: var(--r-3); padding: 12px; font-size: 13px; background: var(--surface-2); color: var(--ink); box-sizing: border-box; }
+.mono { font-family: var(--mono); }
 .qerr { color: var(--fail); font-size: 13px; margin: 10px 0 0; }
 .qres { margin-top: 12px; }
-.qproof { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background: var(--ok-wash); border: 1px solid var(--ok-wash); border-radius: 9px; font-size: 12px; }
+.qproof { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background: var(--ok-wash); border: 1px solid color-mix(in srgb, var(--ok) 30%, transparent); border-radius: var(--r-3); font-size: 12px; }
 .qproof .spacer { flex: 1; }
 .pf { font-weight: 700; color: var(--muted); } .pf.ok { color: var(--ok); }
-.pfh { color: var(--ok); } .pfs { color: var(--muted); } .rc { color: var(--muted); }
-.qscroll { overflow-x: auto; margin-top: 10px; border: 1px solid var(--hairline); border-radius: 10px; }
+.pfh { color: var(--ok); } .pfs { color: var(--muted); } .rc { color: var(--muted); font-variant-numeric: tabular-nums; }
+.qscroll { overflow-x: auto; margin-top: 10px; border: 1px solid var(--hairline); border-radius: var(--r-3); }
 .qgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
 .qgrid th { text-align: left; padding: 8px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
 .qgrid td { padding: 8px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; }
 .qgrid tr:last-child td { border-bottom: 0; }
-.qgrid td .epi { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 6px; vertical-align: middle; }
-.qraw { margin-top: 10px; background: var(--ground); color: var(--hairline); padding: 12px; border-radius: 10px; overflow-x: auto; font-size: 12px; max-height: 320px; }
+.qgrid td .epi { display: inline-block; width: 8px; height: 8px; border-radius: var(--pill); margin-left: 6px; vertical-align: middle; }
+.qraw { margin-top: 10px; background: var(--sunken); color: var(--ink-2); padding: 12px; border-radius: var(--r-3); overflow-x: auto; font-size: 12px; max-height: 320px; }
 .qempty, .qhint, .qnote { color: var(--muted); font-size: 12.5px; }
 .qnote { margin-top: 8px; } .qnote b { color: var(--ink); } .qhint b { color: var(--ink); }
 .qhint { margin-top: 12px; }

--- a/socioprophet-web/app-vue/src/views/Search.vue
+++ b/socioprophet-web/app-vue/src/views/Search.vue
@@ -91,29 +91,30 @@ function isExternal(url: string): boolean {
 .tagline { color: var(--muted); max-width: 560px; margin: 6px auto 0; }
 .tagline em { color: var(--ink); font-style: normal; font-weight: 600; }
 
-.box { display: flex; gap: 8px; margin: 8px 0 4px; }
-.box input { flex: 1; padding: 13px 16px; font-size: 16px; border: 1px solid var(--hairline-strong); border-radius: 26px; outline: none; }
-.box input:focus { border-color: var(--accent); box-shadow: 0 1px 6px rgba(26,115,232,0.18); }
-.box button { padding: 0 22px; font-size: 15px; font-weight: 600; color: #fff; background: var(--accent); border: none; border-radius: 26px; cursor: pointer; }
+.search :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.box { display: flex; gap: var(--sp-2); margin: 8px 0 4px; }
+.box input { flex: 1; padding: 13px 16px; font-size: 16px; border: 1px solid var(--hairline-strong); border-radius: var(--pill); outline: none; background: var(--surface); color: var(--ink); }
+.box input:focus { border-color: var(--accent); box-shadow: 0 1px 6px color-mix(in srgb, var(--accent) 22%, transparent); }
+.box button { padding: 0 22px; font-size: 15px; font-weight: 600; color: #fff; background: var(--accent); border: none; border-radius: var(--pill); cursor: pointer; }
 .box button:disabled { opacity: 0.6; cursor: default; }
 
-.note { font-size: 13px; margin: 10px 2px; padding: 8px 12px; border-radius: 8px; }
-.note.stub { background: var(--accent-wash); color: #1a56c4; }
+.note { font-size: 13px; margin: 10px 2px; padding: 8px 12px; border-radius: var(--r-2); }
+.note.stub { background: var(--accent-wash); color: var(--accent-ink); }
 .note.warn { background: var(--warn-wash); color: var(--warn); }
 .note.err { background: var(--fail-wash); color: var(--fail); }
 
 .results { margin-top: 14px; }
 .group { margin-bottom: 26px; }
 .group h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); border-bottom: 1px solid var(--sunken); padding-bottom: 6px; margin: 0 0 12px; }
-.group h2 .count { color: var(--faint); font-weight: 400; }
+.group h2 .count { color: var(--faint); font-weight: 400; font-variant-numeric: tabular-nums; }
 .hit { margin-bottom: 16px; }
-.hit .title { font-size: 18px; color: #1a0dab; text-decoration: none; }
+.hit .title { font-size: 18px; color: var(--accent-ink); text-decoration: none; }
 .hit .title:hover { text-decoration: underline; }
 .hit .title.plain { color: var(--ink); }
 .hit .src { font-size: 12px; color: var(--muted); margin: 2px 0 3px; }
 .hit .snippet { color: var(--ink-2); margin: 0; }
 .hit.commons { border-left: 3px solid var(--accent); padding-left: 12px; }
-.badge { font-size: 11px; border: 1px solid var(--hairline-strong); border-radius: 8px; padding: 1px 6px; color: var(--muted); }
+.badge { font-size: 11px; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 1px 6px; color: var(--muted); }
 .badge.sov { border-color: var(--accent); color: var(--accent); }
 .empty { color: var(--muted); }
 </style>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -145,7 +145,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
     <!-- WS#35: cite / persistent identifier drawer -->
     <div v-if="citeOpen" class="cite">
-      <div class="rc-head"><b>Cite this knowledge graph</b><span class="rc-sub">a persistent identifier that resolves to a proof-carrying record — DataCite-compatible</span><button class="rc-x" @click="citeOpen = false">✕</button></div>
+      <div class="rc-head"><b>Cite this knowledge graph</b><span class="rc-sub">a persistent identifier that resolves to a proof-carrying record — DataCite-compatible</span><button class="rc-x" @click="citeOpen = false" aria-label="Close cite panel">✕</button></div>
       <div v-if="!citeData" class="cite-mint">
         <input v-model="citeToken" type="password" placeholder="write token" />
         <button class="primary" @click="mintCite" :disabled="minting">{{ minting ? "Minting…" : "Mint DOI" }}</button>
@@ -171,7 +171,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
     <!-- verified-compute receipts drawer -->
     <div v-if="receiptsOpen" class="receipts">
-      <div class="rc-head"><b>Verified-compute receipts</b><span class="rc-sub">replayable proof-of-work · {{ receiptsData?.services_reachable ?? 0 }} services answering</span><button class="rc-x" @click="receiptsOpen = false">✕</button></div>
+      <div class="rc-head"><b>Verified-compute receipts</b><span class="rc-sub">replayable proof-of-work · {{ receiptsData?.services_reachable ?? 0 }} services answering</span><button class="rc-x" @click="receiptsOpen = false" aria-label="Close receipts panel">✕</button></div>
       <div v-if="receiptsErr" class="rc-err">{{ receiptsErr }}</div>
       <div v-else-if="receiptsData" class="rc-list">
         <div v-for="r in receiptsData.receipts" :key="r.service + r.correlation_id" class="rc-row" :title="r.bundle_ref || ''">
@@ -319,101 +319,109 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 .moatbar { display: flex; align-items: center; gap: 12px; padding: 7px 16px; border-bottom: 1px solid var(--line);
   background: var(--card); font-size: 12px; color: var(--sub); }
 .moatbar .spacer { flex: 1; }
-.mb-epi { display: flex; align-items: center; gap: 8px; }
+.mb-epi { display: flex; align-items: center; gap: var(--sp-2); }
 .mb-lbl { white-space: nowrap; font-variant-numeric: tabular-nums; }
-.mb-bar { display: inline-flex; width: 168px; height: 8px; border-radius: 5px; overflow: hidden; background: #eceef2; }
+.mb-bar { display: inline-flex; width: 168px; height: 8px; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); }
 .mb-bar i { height: 100%; }
-.mb-chip { border: 1px solid var(--line); background: var(--card); color: var(--sub); border-radius: 20px;
+.mb-chip { border: 1px solid var(--line); background: var(--card); color: var(--sub); border-radius: var(--pill);
   padding: 3px 10px; font-size: 11.5px; cursor: default; }
 button.mb-chip { cursor: pointer; }
-.mb-chip.on { color: var(--ok); border-color: #bfe3c9; background: var(--ok-wash); }
+.mb-chip.on { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
 .mb-chip b { font-weight: 700; }
 .receipts, .cite { border-bottom: 1px solid var(--line); background: var(--surface-2); padding: 10px 16px 12px; }
-.cite-mint { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
-.cite-mint input { border: 1px solid var(--line); border-radius: 8px; padding: 6px 8px; font-size: 13px; width: 160px; }
-.cite-mint .primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 8px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.cite-mint { display: flex; align-items: center; gap: var(--sp-2); margin-top: var(--sp-2); }
+.cite-mint input { border: 1px solid var(--line); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; width: 160px; background: var(--surface); color: var(--ink); }
+.cite-mint .primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .cite-mint .primary:disabled { opacity: .6; }
-.cite-out { margin-top: 8px; }
-.cite-ids { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; margin-bottom: 8px; }
+.cite-out { margin-top: var(--sp-2); }
+.cite-ids { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; margin-bottom: var(--sp-2); }
 .cite-ids .cid b { color: var(--sub); font-weight: 600; margin-right: 4px; } .cite-ids .cid code { color: var(--accent); }
 .cite-ids .cid.ok { color: var(--ok); }
-.cite-block { border: 1px solid var(--line); border-radius: 8px; background: #fff; margin-top: 8px; overflow: hidden; }
+.cite-block { border: 1px solid var(--line); border-radius: var(--r-2); background: var(--surface); margin-top: var(--sp-2); overflow: hidden; }
 .cb-head { display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; background: var(--sunken); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--sub); }
-.cb-head button { border: 1px solid var(--line); background: #fff; border-radius: 6px; padding: 2px 8px; font-size: 11px; cursor: pointer; }
+.cb-head button { border: 1px solid var(--line); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 2px 8px; font-size: 11px; cursor: pointer; }
 .cb-body { margin: 0; padding: 8px 10px; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
 .cite-note { color: var(--sub); font-size: 11.5px; margin-top: 8px; } .cite-note b { color: var(--ok); }
 .rc-head { display: flex; align-items: center; gap: 10px; font-size: 13px; }
 .rc-head .rc-sub { color: var(--sub); font-size: 11.5px; } .rc-head .rc-x { margin-left: auto; border: 0; background: none; cursor: pointer; color: var(--sub); font-size: 14px; }
 .rc-err { color: var(--fail); font-size: 12px; margin-top: 6px; }
-.rc-list { margin-top: 8px; display: flex; flex-direction: column; gap: 2px; }
-.rc-row { display: grid; grid-template-columns: 160px 1fr auto auto; gap: 10px; align-items: center; font-size: 12px; padding: 4px 8px; border-radius: 8px; }
+.rc-list { margin-top: var(--sp-2); display: flex; flex-direction: column; gap: 2px; }
+.rc-row { display: grid; grid-template-columns: 160px 1fr auto auto; gap: 10px; align-items: center; font-size: 12px; padding: 4px 8px; border-radius: var(--r-2); }
 .rc-row:hover { background: var(--accent-bg); }
 .rc-svc { font-weight: 600; color: var(--ink); } .rc-cid { color: var(--sub); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.rc-verdict { font-size: 10.5px; font-weight: 700; color: var(--ok); background: var(--ok-wash); border-radius: 10px; padding: 1px 8px; }
+.rc-verdict { font-size: 10.5px; font-weight: 700; color: var(--ok); background: var(--ok-wash); border-radius: var(--pill); padding: 1px 8px; }
 .rc-when { color: var(--sub); font-size: 11px; white-space: nowrap; }
 .rc-empty { color: var(--sub); font-size: 12px; margin-top: 6px; }
-.mono { font-family: "SF Mono", ui-monospace, Menlo, monospace; }
+.mono { font-family: var(--mono); }
 .topbar .brand { font-size: 16px; font-weight: 700; }
-.topbar .proj { border: 1px solid var(--line); background: var(--accent-bg); color: var(--accent); border-radius: 16px; padding: 4px 12px; font-size: 13px; cursor: pointer; }
+.topbar .proj { border: 1px solid var(--line); background: var(--accent-bg); color: var(--accent); border-radius: var(--r-2); padding: 4px 12px; font-size: 13px; cursor: pointer; }
 .topbar .chev { opacity: .6; font-size: 10px; }
-.topbar .search { flex: 0 1 340px; display: flex; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: 18px; padding: 5px 12px; }
+.topbar .search { flex: 0 1 340px; display: flex; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: var(--r-2); padding: 5px 12px; background: var(--surface); }
 .topbar .search .mag { color: var(--sub); }
-.topbar .search input { border: none; outline: none; flex: 1; font-size: 14px; background: none; }
+.topbar .search input { border: none; outline: none; flex: 1; font-size: 14px; background: none; color: var(--ink); }
 .topbar .spacer { flex: 1; }
-.topbar button.ghost { border: 1px solid var(--line); background: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
-.topbar button.primary { border: none; background: var(--accent); color: #fff; border-radius: 18px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.topbar button.ghost { border: 1px solid var(--line); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.topbar button.primary { border: none; background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 
 .body { flex: 1; display: flex; min-height: 0; }
-.rail { width: 208px; flex-shrink: 0; border-right: 1px solid var(--line); background: var(--bg); display: flex; flex-direction: column; padding: 8px; }
-.rail button { display: flex; align-items: center; gap: 10px; text-align: left; padding: 9px 12px; border: none; background: none; border-radius: 8px; cursor: pointer; color: var(--ink-2); font-size: 14px; }
+.rail { width: 208px; flex-shrink: 0; border-right: 1px solid var(--line); background: var(--bg); display: flex; flex-direction: column; padding: var(--sp-2); }
+.rail button { display: flex; align-items: center; gap: 10px; text-align: left; padding: 7px 12px; border: none; background: none; border-radius: var(--r-2); cursor: pointer; color: var(--ink-2); font-size: 14px; }
 .rail button:hover { background: var(--sunken); }
 .rail button.on { background: var(--accent-bg); color: var(--accent); font-weight: 600; }
-.rail .ic { width: 18px; } .rail .lbl { flex: 1; } .rail .cnt { font-size: 11px; color: var(--sub); background: #fff; border: 1px solid var(--line); border-radius: 9px; padding: 0 6px; }
-.rail button.on .cnt { background: #fff; }
+.rail .ic { width: 18px; } .rail .lbl { flex: 1; } .rail .cnt { font-size: 11px; color: var(--sub); background: var(--surface); border: 1px solid var(--line); border-radius: var(--r-1); padding: 0 6px; font-variant-numeric: tabular-nums; }
+.rail button.on .cnt { background: var(--surface); }
 .rail-foot { margin-top: auto; padding: 10px 8px; }
-.rail .stub { font-size: 11px; color: var(--warn); background: var(--warn-wash); border-radius: 8px; padding: 3px 8px; }
+.rail .stub { font-size: 11px; color: var(--warn); background: var(--warn-wash); border-radius: var(--r-2); padding: 3px 8px; }
 
 .panel { flex: 1; overflow: auto; padding: 20px 24px; min-width: 0; }
 .sec-head h1 { font-size: 20px; margin: 0; } .sec-head .blurb { color: var(--sub); margin: 4px 0 16px; max-width: 680px; }
 
-.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 12px; }
-.card { border: 1px solid var(--line); border-radius: 12px; padding: 14px 16px; background: var(--card); cursor: pointer; transition: box-shadow .12s, border-color .12s; }
-.card:hover { box-shadow: 0 1px 8px rgba(60,64,67,.12); border-color: var(--hairline-strong); }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--line); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--card); cursor: pointer; transition: box-shadow .12s, border-color .12s; }
+.card:hover { box-shadow: var(--e-1); border-color: var(--hairline-strong); }
 .card.sel { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-bg); }
-.card .row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.card .row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); }
 .card .name { font-weight: 600; }
 .card .sub { color: var(--sub); font-size: 12px; margin-top: 4px; }
-.card .mono { display: block; font: 11px/1.4 ui-monospace, monospace; color: var(--ink-2); background: var(--sunken); border-radius: 6px; padding: 5px 8px; margin: 8px 0 6px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-.chips, .metrics { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
-.chip { font-size: 11px; background: var(--sunken); border-radius: 8px; padding: 1px 8px; color: var(--ink-2); }
-.metric { font-size: 12px; color: var(--sub); background: var(--sunken); border-radius: 8px; padding: 1px 8px; } .metric b { color: var(--ink); }
-.lineage { font: 11px/1.4 ui-monospace, monospace; color: var(--sub); margin-top: 8px; }
+.card .mono { display: block; font: 11px/1.4 var(--mono); color: var(--ink-2); background: var(--sunken); border-radius: var(--r-2); padding: 5px 8px; margin: var(--sp-2) 0 6px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.chips, .metrics { display: flex; flex-wrap: wrap; gap: 5px; margin-top: var(--sp-2); }
+.chip { font-size: 11px; background: var(--sunken); border-radius: var(--r-2); padding: 1px 8px; color: var(--ink-2); }
+.metric { font-size: 12px; color: var(--sub); background: var(--sunken); border-radius: var(--r-2); padding: 1px 8px; } .metric b { color: var(--ink); }
+.lineage { font: 11px/1.4 var(--mono); color: var(--sub); margin-top: var(--sp-2); }
 .method { text-transform: uppercase; letter-spacing: .04em; font-size: 11px; font-weight: 600; color: var(--accent); }
-.bar { height: 5px; background: var(--sunken); border-radius: 3px; margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
-.prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; } .pstep { font: 10px/1.4 ui-monospace, monospace; background: var(--sunken); border-radius: 6px; padding: 1px 7px; color: var(--ink-2); }
+.bar { height: 5px; background: var(--sunken); border-radius: var(--r-1); margin: 9px 0 5px; overflow: hidden; } .bar span { display: block; height: 100%; background: var(--accent); }
+.prov { display: flex; flex-wrap: wrap; gap: 5px; margin-top: var(--sp-2); } .pstep { font: 10px/1.4 var(--mono); background: var(--sunken); border-radius: var(--r-2); padding: 1px 7px; color: var(--ink-2); }
 .dot.ok { color: var(--ok); font-size: 11px; }
-.stat { font-size: 26px; font-weight: 700; margin-top: 6px; letter-spacing: -0.5px; }
+.stat { font-size: 26px; font-weight: 700; margin-top: 6px; letter-spacing: -0.5px; font-variant-numeric: tabular-nums; }
 .rail-group { font-size: 10px; text-transform: uppercase; letter-spacing: .1em; color: var(--faint); padding: 12px 12px 4px; }
 
-.pill { font-size: 11px; border-radius: 8px; padding: 1px 8px; border: 1px solid var(--line); color: var(--sub); white-space: nowrap; }
+.pill { font-size: 11px; border-radius: var(--r-2); padding: 1px 8px; border: 1px solid var(--line); color: var(--sub); white-space: nowrap; }
 .pill.ok, .pill.promoted, .pill.done { border-color: var(--ok); color: var(--ok); }
 .pill.running { border-color: var(--accent); color: var(--accent); }
 .pill.failed { border-color: var(--fail); color: var(--fail); }
 .pill.warn, .pill.staged, .pill.queued, .pill.candidate { border-color: var(--warn); color: var(--warn); }
 
 .msg { color: var(--sub); padding: 10px 2px; } .msg.err { color: var(--fail); }
-.skeleton { pointer-events: none; } .sk-line { height: 10px; background: linear-gradient(90deg,var(--sunken),var(--hairline),var(--sunken)); background-size: 200% 100%; border-radius: 5px; margin: 6px 0; animation: sh 1.2s infinite; } .w60 { width: 60%; } .w40 { width: 40%; }
+.skeleton { pointer-events: none; } .sk-line { height: 10px; background: linear-gradient(90deg,var(--sunken),var(--hairline),var(--sunken)); background-size: 200% 100%; border-radius: var(--r-1); margin: 6px 0; animation: sh 1.2s infinite; } .w60 { width: 60%; } .w40 { width: 40%; }
 @keyframes sh { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 
-.drawer { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); background: #fff; padding: 18px 20px; overflow: auto; position: relative; }
+.drawer { width: 340px; flex-shrink: 0; border-left: 1px solid var(--line); background: var(--surface); padding: 18px 20px; overflow: auto; position: relative; }
 .drawer .close { position: absolute; top: 12px; right: 14px; border: none; background: none; font-size: 15px; color: var(--sub); cursor: pointer; }
 .drawer .d-kind { font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--sub); }
 .drawer h2 { font-size: 18px; margin: 4px 0 14px; }
 .meta { margin: 0 0 14px; } .mrow { display: flex; gap: 10px; padding: 4px 0; border-bottom: 1px solid var(--sunken); } .mrow dt { color: var(--sub); min-width: 96px; font-size: 12px; } .mrow dd { margin: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; }
 .d-block { margin: 12px 0; } .d-block h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--sub); margin: 0 0 6px; }
-.d-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
-.d-actions button { border: 1px solid var(--line); background: #fff; border-radius: 16px; padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.d-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); margin-top: var(--sp-4); }
+.d-actions button { border: 1px solid var(--line); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
 .d-actions button.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 .drawer-enter-active, .drawer-leave-active { transition: transform .18s ease, opacity .18s ease; }
 .drawer-enter-from, .drawer-leave-to { transform: translateX(20px); opacity: 0; }
+
+/* a11y: keyboard focus is always visible; motion respects the OS preference */
+.studio :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+@media (prefers-reduced-motion: reduce) {
+  .sk-line { animation: none; }
+  .card { transition: none; }
+  .drawer-enter-active, .drawer-leave-active { transition: none; }
+}
 </style>


### PR DESCRIPTION
Multi-pass **styling + template polish** across the Studio surfaces so they faithfully embody the epistemic-Carbon design system in `app-vue/src/styles/tokens.css`. **No API/logic/behavior changes** — templates and `<style>` only. `npx vite build` passes.

## What changed, per surface

**`views/Studio.vue` (the shell)**
- Radii → tokens (`--r-2/--r-3` near-square; `--pill` reserved for status chips), spacing → `--sp-*`, mono → `var(--mono)`.
- Dark-mode correctness: every hardcoded `#fff` **background** (cards, drawers, rail counts, cite/receipt blocks, ghost/topbar buttons) → `var(--surface)`; inputs get `--ink` text.
- Shadows → elevation tokens (`--e-1`); moat-bar track `#eceef2` → `--sunken`; `#bfe3c9` border → `color-mix(... var(--ok) ...)`.
- `.tnum` on counts; global `:focus-visible`; `@media (prefers-reduced-motion: reduce)` guards on skeleton shimmer, card transition, drawer transition; `aria-label`s on the cite/receipts close buttons.

**`StudioOps.vue`**, **`StudioGovernance.vue`**, **`StudioCommons.vue`**, **`StudioExperiments.vue`**
- Cards → `--r-3`, chips/inputs → `--r-2`, status/score chips → `--pill` (kept intentionally pill so ops-status reads as the separate filled dimension). `--sp-*` rhythm.
- Inputs, ghost buttons, promote/mini controls, table surfaces → `var(--surface)`/`var(--ink-2)` so they render correctly in dark mode (were `#fff`).
- `var(--mono)` everywhere; tabular-nums on version/score/count/evidence numerics; `color-mix` hairlines for the `canon`/`fair.on` washes; per-component `:focus-visible`; `aria-label` on each reload (`↻`) button.

**`StudioQuery.vue`**
- Fixed a genuine low-contrast bug: the raw-JSON result block was `color: var(--hairline)` on `var(--ground)` → now `--ink-2` on `--sunken`.
- Proof banner border via `color-mix`; radii/mono tokens; `:focus-visible`.

**`StudioGraph.vue`**
- The force-directed canvas background and the node/label halo strokes were hardcoded `#fff` (broke in dark mode) → `var(--surface)` + `var(--canvas-dot)` for the dot grid.
- Provenance panel shadow → `--e-2`; radii/mono tokens; `aria-label`s on the icon-only tool buttons (add / reset / reload) and the node-panel close; reduced-motion guard on edge/node/slide transitions.

**`views/Search.vue`**
- Result-title and stub-note colours → `var(--accent-ink)`; focus ring shadow rebuilt with `color-mix(var(--accent))` (was `rgba(26,115,232,…)`); search field/button → `var(--pill)`; note/badge radii → `--r-2`; input gets surface/ink tokens; `:focus-visible`.

## Deliberately left as-is
- `color: #fff` on **filled accent buttons/segments** — that text is legitimately white against the saturated `--accent` in both light and dark, and there is no on-accent token in `tokens.css`.
- Brand purples (`#7b3ff2/#faf7ff/#e9ddff/#d9c7ff`) and ORCID green (`#a6ce39`) untouched, per scope.
- Out-of-scope files untouched: `StudioNotebooks.vue`, `LineageStrip.vue`, `studioApi.ts`.

## Not done / follow-ups
- Loading states in the section components remain the existing single-line "Loading…" text rather than the shell's shimmer skeletons — left as-is to avoid restructuring templates; could be unified in a later pass.
- No visual regression run beyond `vite build`; recommend an eyeball pass in both light and dark themes.