### PR TITLE
studio: Compute Console — the Universal Compute Plane surface

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioCompute.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCompute.vue
@@ -1,0 +1,404 @@
+<script setup lang="ts">
+import { ref, computed, reactive, onMounted } from "vue";
+import {
+  loadComputeRegistry, runCompute, EPISTEMIC_COLORS,
+  type ComputeKind, type ComputeResultLite,
+} from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+// ── registry (the catalog: "any compute, one door") ──
+const kinds = ref<ComputeKind[]>([]);
+const loading = ref(true);
+const regErr = ref("");
+const selectedKind = ref<string | null>(null);
+
+const selected = computed<ComputeKind | null>(() => kinds.value.find((k) => k.kind === selectedKind.value) ?? null);
+
+onMounted(async () => {
+  try {
+    const r = await loadComputeRegistry(props.project);
+    kinds.value = r.kinds;
+    // default the run panel to the first runnable (live + entitled) kind, else the first kind.
+    const runnable = r.kinds.find((k) => k.status === "live" && k.entitled);
+    pick((runnable ?? r.kinds[0])?.kind ?? null);
+  } catch (e) {
+    regErr.value = e instanceof Error ? e.message : "registry load failed";
+  } finally {
+    loading.value = false;
+  }
+});
+
+// ── epistemic-warrant chip styling — colour off the shared ramp so this reads as the same ink everywhere ──
+const EPI_WASH: Record<string, string> = {
+  hypothesis: "var(--epi-hypothesis-wash)", observed: "var(--epi-observed-wash)",
+  derived: "var(--epi-derived-wash)", verified: "var(--epi-verified-wash)", attested: "var(--epi-attested-wash)",
+};
+function epiStyle(mode: string) {
+  const c = EPISTEMIC_COLORS[mode] || EPISTEMIC_COLORS.unknown;
+  return { color: c, background: EPI_WASH[mode] || "var(--sunken)", borderColor: `color-mix(in srgb, ${c} 40%, transparent)` };
+}
+
+// ── spec editor — fields driven off the selected kind ──
+interface SpecField { key: string; label: string; type: "code" | "text" | "select"; placeholder?: string; options?: string[]; rows?: number }
+function fieldsFor(k: ComputeKind | null): SpecField[] {
+  if (!k) return [];
+  switch (k.kind) {
+    case "notebook": return [{ key: "code", label: "Cell code", type: "code", rows: 5, placeholder: "df = load('apple_2024_breach')  # governed dataset\ndf.shape" }];
+    case "spark":    return [{ key: "code", label: "Spark job", type: "code", rows: 5, placeholder: "spark.read.parquet('s3://…').groupBy('cohort').count().show()" }];
+    case "graph-query": return [
+      { key: "lang", label: "Language", type: "select", options: ["sparql", "cypher", "gremlin"] },
+      { key: "query", label: "Query", type: "code", rows: 4, placeholder: "MATCH (n) RETURN n LIMIT 10" },
+    ];
+    case "graph-stats": return [{ key: "metric", label: "Metric", type: "select", options: ["degree", "centrality", "communities"] }];
+    case "inference": return [{ key: "prompt", label: "Prompt", type: "code", rows: 4, placeholder: "Summarize the warrant distribution across the corpus…" }];
+    default: return [{ key: "input", label: "Input", type: "text", placeholder: "spec…" }];
+  }
+}
+const fields = computed(() => fieldsFor(selected.value));
+const spec = reactive<Record<string, string>>({});
+const backend = ref<string>("");
+
+function pick(kind: string | null) {
+  selectedKind.value = kind;
+  // reset the spec to this kind's field defaults
+  for (const key of Object.keys(spec)) delete spec[key];
+  for (const f of fieldsFor(selected.value)) spec[f.key] = f.type === "select" ? (f.options?.[0] ?? "") : "";
+  backend.value = selected.value?.default ?? "";
+}
+
+// ── run ──
+const running = ref(false);
+const runErr = ref("");
+const result = ref<ComputeResultLite | null>(null);
+// the receipt chain: every sealed run in this session, newest first (the tamper-evident record).
+const chain = ref<ComputeResultLite[]>([]);
+
+const canRun = computed(() => !!selected.value && !running.value && fields.value.some((f) => (spec[f.key] ?? "").trim().length > 0 || f.type === "select"));
+
+// the gateway returns the provenance subgraph itself (node/edge arrays); surface it as counts.
+const deltaCounts = computed(() => {
+  const d = result.value?.graph_delta;
+  const n = d?.nodes?.length ?? 0, e = d?.edges?.length ?? 0;
+  return (n || e) ? { n, e } : null;
+});
+
+async function run() {
+  const k = selected.value;
+  if (!k || running.value) return;
+  running.value = true; runErr.value = ""; result.value = null;
+  try {
+    const res = await runCompute({ kind: k.kind, spec: { ...spec }, project: props.project, backend: backend.value || undefined });
+    result.value = res;
+    if (res.status === "ok" || res.status === "degraded") chain.value.unshift(res);
+  } catch (e) {
+    runErr.value = e instanceof Error ? e.message : "run failed";
+  } finally {
+    running.value = false;
+  }
+}
+
+function short(id?: string | null) { return id ? String(id).replace(/^sha256:/, "").slice(0, 10) : ""; }
+// mime may be a single string or a list (the gateway's ComputeOutput.mime is a list); find an image type.
+function imageMime(mime?: string | string[]): string | null {
+  const arr = Array.isArray(mime) ? mime : mime ? [mime] : [];
+  return arr.find((m) => m.startsWith("image/")) ?? null;
+}
+function onKey(e: KeyboardEvent) { if (e.key === "Enter" && (e.shiftKey || e.ctrlKey || e.metaKey)) { e.preventDefault(); run(); } }
+</script>
+
+<template>
+  <div class="cp">
+    <!-- ─────────────── the catalog: any compute, one door (the hero) ─────────────── -->
+    <section class="reg">
+      <div class="reg-head">
+        <div>
+          <h2>Compute registry</h2>
+          <p class="sub">Every kind of compute — one governed door. Each declares its backends, capabilities, a
+            default <b>epistemic warrant</b>, whether it executes your code, and whether you're entitled. Every run
+            returns a proof-carrying receipt.</p>
+        </div>
+        <span class="door" aria-hidden="true">⛩</span>
+      </div>
+
+      <div v-if="loading" class="grid">
+        <div v-for="i in 4" :key="i" class="kcard sk"><div class="sk-line w50" /><div class="sk-line w70" /></div>
+      </div>
+      <p v-else-if="regErr" class="note err">registry: {{ regErr }}</p>
+
+      <div v-else class="grid" role="list">
+        <button v-for="k in kinds" :key="k.kind" class="kcard" role="listitem"
+                :class="{ on: selectedKind === k.kind, locked: !k.entitled }" @click="pick(k.kind)">
+          <div class="krow">
+            <span class="kname">{{ k.kind }}</span>
+            <span class="ent" :class="{ open: k.entitled }" :title="k.entitled ? 'entitled' : 'not entitled — pay-gated'">
+              {{ k.entitled ? '✓ entitled' : '🔒 locked' }}
+            </span>
+          </div>
+          <div class="kmeta">
+            <span class="epi-chip" :style="epiStyle(k.epistemic)" :title="'default epistemic warrant: ' + k.epistemic">
+              <i class="dot" :style="{ background: EPISTEMIC_COLORS[k.epistemic] }" />{{ k.epistemic }}
+            </span>
+            <span class="stat" :class="k.status">{{ k.status === 'live' ? '● live' : '○ declared' }}</span>
+            <span v-if="k.executes_user_code" class="uc" title="runs your code in a sandbox">▷ user-code</span>
+          </div>
+          <div class="kback"><span class="klbl">backends</span>
+            <span v-for="b in k.backends" :key="b" class="bk" :class="{ def: b === k.default }">{{ b }}</span>
+          </div>
+          <div class="kcaps">
+            <span v-for="c in k.capabilities" :key="c" class="cap">{{ c }}</span>
+          </div>
+        </button>
+      </div>
+    </section>
+
+    <!-- ─────────────── run panel ─────────────── -->
+    <section v-if="selected" class="run">
+      <div class="run-head">
+        <h3>Run <span class="rk">{{ selected.kind }}</span></h3>
+        <label class="bsel">backend
+          <select v-model="backend">
+            <option v-for="b in selected.backends" :key="b" :value="b">{{ b }}{{ b === selected.default ? ' · default' : '' }}</option>
+          </select>
+        </label>
+        <span class="epi-chip" :style="epiStyle(selected.epistemic)" :title="'results default to epistemic: ' + selected.epistemic">
+          <i class="dot" :style="{ background: EPISTEMIC_COLORS[selected.epistemic] }" />warrant {{ selected.epistemic }}
+        </span>
+        <div class="sp" />
+        <button class="primary" :disabled="!canRun" @click="run">
+          <span v-if="running" class="spin" />{{ running ? 'Running…' : '▸ Run' }}
+        </button>
+      </div>
+
+      <!-- spec editor — fields are driven off the selected kind -->
+      <div class="spec">
+        <div v-for="f in fields" :key="f.key" class="field" :class="{ wide: f.type === 'code' }">
+          <label :for="'f-' + f.key">{{ f.label }}</label>
+          <select v-if="f.type === 'select'" :id="'f-' + f.key" v-model="spec[f.key]">
+            <option v-for="o in f.options" :key="o" :value="o">{{ o }}</option>
+          </select>
+          <textarea v-else-if="f.type === 'code'" :id="'f-' + f.key" v-model="spec[f.key]" class="code"
+                    :rows="f.rows || 4" :placeholder="f.placeholder" spellcheck="false" @keydown="onKey" />
+          <input v-else :id="'f-' + f.key" v-model="spec[f.key]" :placeholder="f.placeholder" @keydown="onKey" />
+        </div>
+      </div>
+      <p v-if="runErr" class="note err">run: {{ runErr }}</p>
+
+      <!-- ─────────────── result ─────────────── -->
+      <div v-if="result" class="res" :class="result.status">
+        <!-- entitlement pay-gate / zero-trust grant gate (gateway returns 200 with the typed status) -->
+        <div v-if="result.status === 'entitlement_required' || result.status === 'grant_required'" class="paygate">
+          <div class="pg-head">
+            <span class="lock">🔒</span>
+            <b>{{ result.status === 'grant_required' ? 'Capability grant required' : 'Entitlement required' }}</b>
+            <span class="code402">{{ result.status === 'grant_required' ? 'zero-trust' : '402' }}</span>
+          </div>
+          <p>{{ result.message || `“${result.kind}” on ${result.backend} is a provisioned, pay-gated service — the capability is catalogued but no runtime is provisioned for you yet.` }}</p>
+          <div class="pg-foot">
+            <button class="primary">{{ result.status === 'grant_required' ? 'Request grant' : 'Provision entitlement' }}</button>
+          </div>
+        </div>
+
+        <!-- honest degraded state (e.g. plane not wired) -->
+        <div v-else-if="result.status === 'degraded'" class="degraded">
+          <span class="dwarn">⚠ degraded</span>
+          <span>{{ result.degraded || 'compute plane not wired' }}</span>
+          <span class="dhint">No result is fabricated — wire <code>VITE_STUDIO_API</code> to the Studio BFF to run live.</span>
+        </div>
+
+        <!-- ok / error: outputs + epistemic status + receipt -->
+        <template v-else>
+          <div class="res-head">
+            <span class="rstat" :class="result.status">{{ result.status === 'ok' ? '✓ ok' : '✕ error' }}</span>
+            <span class="epi-chip" :style="epiStyle(result.epistemic_status)" title="epistemic status of THIS result">
+              <i class="dot" :style="{ background: EPISTEMIC_COLORS[result.epistemic_status] }" />{{ result.epistemic_status }}
+            </span>
+            <span class="rback">{{ result.kind }} · {{ result.backend }}</span>
+            <span v-if="deltaCounts" class="gdelta" title="provenance facts written to the project graph (PROV-O)">
+              Δ {{ deltaCounts.n }} nodes · {{ deltaCounts.e }} edges</span>
+            <span v-if="result.memoized" class="memo" title="served from the content-addressed compute memo — identical inputs, identical sealed proof">⚡ memoized</span>
+            <span v-if="result.attestation?.results?.cosign_valid" class="attest"
+                  title="zero-trust AttestationBundle: Ed25519 signature over the in-toto statement verifies (cosign-class)">⛨ attested</span>
+          </div>
+
+          <div v-if="result.error" class="oerr">{{ result.error }}</div>
+          <div v-if="result.outputs.length" class="out">
+            <template v-for="(o, i) in result.outputs" :key="i">
+              <div v-if="imageMime(o.mime) && typeof o.data === 'string'" class="rich">
+                <img :src="`data:${imageMime(o.mime)};base64,${o.data}`" alt="compute output" />
+              </div>
+              <pre v-else class="stream">{{ o.text ?? (o.data != null ? JSON.stringify(o.data, null, 2) : '') }}</pre>
+            </template>
+          </div>
+          <p v-else class="empty">No outputs.</p>
+
+          <!-- receipt strip — the moat (reuses the notebook receipt-strip idea) -->
+          <div v-if="result.receipt" class="rcpt">
+            <span class="seal">⛨ receipt</span>
+            <span class="mono">{{ short(result.receipt.id) }}</span>
+            <span v-if="result.receipt.signature" class="signed" title="Ed25519-signed by the compute-gateway (in-toto statement)">signed ✓</span>
+            <span v-else class="unsigned" title="no signature on this receipt (no signing key configured)">unsigned</span>
+            <span v-if="result.receipt.inputs_sha" class="mono dim">in {{ short(result.receipt.inputs_sha) }}</span>
+            <span v-if="result.receipt.outputs_sha" class="mono dim">out {{ short(result.receipt.outputs_sha) }}</span>
+            <span v-if="result.receipt.prev" class="mono dim">↩ {{ short(result.receipt.prev) }}</span>
+            <span class="grow" />
+            <span class="replay">replayable</span>
+          </div>
+        </template>
+      </div>
+
+      <!-- session receipt chain — the tamper-evident record of every run -->
+      <div v-if="chain.length" class="chain">
+        <div class="chain-head">⛨ Session receipt chain <span class="cn">{{ chain.length }}</span></div>
+        <div class="crow" v-for="(c, i) in chain" :key="i">
+          <span class="cdot" :style="{ background: EPISTEMIC_COLORS[c.epistemic_status] || 'var(--idle)' }" />
+          <span class="mono cid">{{ c.receipt ? short(c.receipt.id) : '—' }}</span>
+          <span class="ckind">{{ c.kind }} · {{ c.backend }}</span>
+          <span class="epi-chip sm" :style="epiStyle(c.epistemic_status)">{{ c.epistemic_status }}</span>
+          <span v-if="c.receipt?.signature" class="signed sm">signed ✓</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.cp { font: 14px/1.5 var(--ui); color: var(--ink); display: flex; flex-direction: column; gap: var(--sp-5); }
+
+/* shared epistemic-warrant chip (coloured off the ramp) */
+.epi-chip { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600;
+  padding: 1px 8px 1px 7px; border-radius: var(--r-1); border: 1px solid transparent; white-space: nowrap; }
+.epi-chip .dot { width: 8px; height: 8px; border-radius: var(--pill); flex: 0 0 auto; }
+.epi-chip.sm { font-size: 10px; padding: 0 6px; }
+
+/* ── registry ── */
+.reg-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: var(--sp-4); }
+.reg-head h2 { font-size: 16px; margin: 0; }
+.reg-head .sub { color: var(--muted); font-size: 12.5px; margin: 4px 0 0; max-width: 640px; }
+.reg-head .sub b { color: var(--ink-2); }
+.reg-head .door { font-size: 30px; color: var(--accent); opacity: .8; line-height: 1; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--sp-3); }
+.kcard { text-align: left; border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface);
+  padding: var(--sp-3) var(--sp-4); cursor: pointer; display: flex; flex-direction: column; gap: 8px;
+  transition: border-color .12s, box-shadow .12s; color: inherit; font: inherit; }
+.kcard:hover { border-color: var(--hairline-strong); box-shadow: var(--e-1); }
+.kcard.on { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-wash); }
+.kcard.locked { opacity: .82; }
+.krow { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.kname { font-weight: 700; font-size: 14.5px; }
+.ent { font-size: 10.5px; font-weight: 600; border-radius: var(--pill); padding: 1px 8px; color: var(--muted);
+  border: 1px solid var(--hairline); background: var(--sunken); white-space: nowrap; }
+.ent.open { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.kmeta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.stat { font-size: 10.5px; font-weight: 600; border-radius: var(--r-1); padding: 1px 7px; border: 1px solid var(--hairline); }
+.stat.live { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.stat.declared { color: var(--muted); background: var(--sunken); }
+.uc { font-size: 10px; color: var(--epi-derived); border: 1px solid color-mix(in srgb, var(--epi-derived) 35%, transparent);
+  background: var(--epi-derived-wash); border-radius: var(--r-1); padding: 1px 6px; }
+.kback { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; font-size: 11px; }
+.kback .klbl { color: var(--faint); text-transform: uppercase; letter-spacing: .06em; font-size: 9.5px; margin-right: 2px; }
+.bk { font-family: var(--mono); font-size: 10.5px; background: var(--sunken); color: var(--ink-2); border-radius: var(--r-1); padding: 1px 7px; }
+.bk.def { color: var(--accent-ink); background: var(--accent-wash); }
+.kcaps { display: flex; flex-wrap: wrap; gap: 4px; }
+.cap { font-size: 10px; color: var(--muted); background: var(--sunken); border-radius: var(--r-1); padding: 1px 7px; }
+
+/* ── run panel ── */
+.run { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
+.run-head { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: var(--sp-3); }
+.run-head h3 { font-size: 14px; margin: 0; }
+.run-head .rk { font-family: var(--mono); color: var(--accent); font-weight: 700; }
+.bsel { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); display: inline-flex; align-items: center; gap: 6px; }
+.bsel select, .field select { padding: 4px 8px; font-size: 12px; border: 1px solid var(--hairline); border-radius: var(--r-2);
+  background: var(--surface); color: var(--ink); text-transform: none; letter-spacing: 0; }
+.run-head .sp { flex: 1; }
+.primary { border: 0; background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 7px 16px; font-size: 13px;
+  font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.primary:hover:not(:disabled) { background: var(--accent-2); }
+.primary:disabled { opacity: .5; cursor: default; }
+
+.spec { display: flex; flex-wrap: wrap; gap: var(--sp-3); }
+.field { display: flex; flex-direction: column; gap: 5px; }
+.field.wide { flex: 1 1 100%; }
+.field label { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+.field input, .field .code { border: 1px solid var(--hairline); border-radius: var(--r-2); background: var(--surface-2);
+  color: var(--ink); padding: 8px 10px; font-size: 13px; outline: none; }
+.field input:focus, .field .code:focus, .field select:focus { border-color: var(--accent); }
+.field .code { font: 13px/1.55 var(--mono); resize: vertical; width: 100%; }
+.field input::placeholder, .field .code::placeholder { color: var(--faint); }
+
+/* ── result ── */
+.res { margin-top: var(--sp-4); border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--ground); padding: var(--sp-3) var(--sp-4); }
+.res.error { border-color: color-mix(in srgb, var(--fail) 45%, var(--hairline)); }
+.res-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+.rstat { font-size: 11px; font-weight: 700; border-radius: var(--pill); padding: 1px 9px; }
+.rstat.ok { color: var(--ok); background: var(--ok-wash); }
+.rstat.error { color: var(--fail); background: var(--fail-wash); }
+.rback { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+.gdelta { font-size: 10.5px; color: var(--epi-attested); background: var(--epi-attested-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 600; }
+.memo { font-size: 10.5px; color: var(--epi-verified); background: var(--epi-verified-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 600; }
+.attest { font-size: 10.5px; color: var(--epi-attested); background: var(--epi-attested-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 700; }
+.out { display: flex; flex-direction: column; gap: 8px; }
+.out .stream { margin: 0; font: 12px/1.5 var(--mono); white-space: pre-wrap; word-break: break-word; color: var(--ink-2);
+  background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 8px 10px; }
+.rich img { max-width: 100%; border-radius: var(--r-2); }
+.oerr { color: var(--fail); background: var(--fail-wash); border-radius: var(--r-2); padding: 8px 10px; font: 12px/1.5 var(--mono); }
+.empty { color: var(--faint); font-size: 12px; margin: 0; }
+
+.rcpt { display: flex; align-items: center; gap: 10px; margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--hairline);
+  font-size: 11px; color: var(--muted); flex-wrap: wrap; }
+.rcpt .seal { color: var(--epi-attested); font-weight: 600; }
+.rcpt .mono, .mono { font-family: var(--mono); }
+.rcpt .dim { color: var(--faint); }
+.rcpt .signed, .signed { color: var(--epi-attested); background: var(--epi-attested-wash); border-radius: var(--r-1);
+  padding: 0 6px; font-weight: 600; }
+.rcpt .unsigned { color: var(--warn); background: var(--warn-wash); border-radius: var(--r-1); padding: 0 6px; }
+.rcpt .grow { flex: 1; }
+.rcpt .replay { color: var(--epi-attested); background: var(--epi-attested-wash); border-radius: var(--r-1); padding: 0 6px; font-weight: 600; }
+
+/* pay-gate 402 */
+.paygate { color: var(--ink); }
+.pg-head { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.pg-head .lock { font-size: 16px; }
+.pg-head .code402 { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--warn);
+  background: var(--warn-wash); border-radius: var(--r-1); padding: 1px 8px; font-weight: 700; }
+.paygate p { color: var(--muted); font-size: 12.5px; margin: 8px 0 12px; max-width: 560px; }
+.pg-foot { display: flex; align-items: center; gap: 12px; }
+.pg-foot .price { font-weight: 700; color: var(--ink); }
+
+/* degraded */
+.degraded { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 12px; font-size: 12.5px; color: var(--ink-2); }
+.degraded .dwarn { color: var(--warn); font-weight: 700; background: var(--warn-wash); border-radius: var(--r-1); padding: 1px 8px; }
+.degraded .dhint { color: var(--muted); font-size: 11.5px; flex: 1 1 100%; }
+.degraded code { font-family: var(--mono); font-size: 11px; }
+
+/* session chain */
+.chain { margin-top: var(--sp-4); }
+.chain-head { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.chain-head .cn { background: var(--epi-attested); color: #fff; border-radius: var(--pill); padding: 0 7px; font-size: 10px; }
+.crow { display: flex; align-items: center; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--sunken); font-size: 11.5px; }
+.crow:last-child { border-bottom: 0; }
+.crow .cdot { width: 9px; height: 9px; border-radius: var(--pill); flex: 0 0 auto; }
+.crow .cid { color: var(--ink-2); }
+.crow .ckind { color: var(--muted); font-family: var(--mono); font-size: 10.5px; }
+
+/* notes + skeletons */
+.note { font-size: 12px; border-radius: var(--r-2); padding: 8px 12px; margin: 8px 0 0; }
+.note.err { color: var(--fail); background: var(--fail-wash); border: 1px solid color-mix(in srgb, var(--fail) 30%, transparent); }
+.sk { pointer-events: none; }
+.sk-line { height: 10px; background: linear-gradient(90deg, var(--sunken), var(--hairline), var(--sunken));
+  background-size: 200% 100%; border-radius: var(--r-1); margin: 6px 0; animation: sh 1.2s infinite; }
+.w50 { width: 50%; } .w70 { width: 70%; }
+@keyframes sh { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+.spin { width: 12px; height: 12px; border: 2px solid #fff; border-top-color: transparent; border-radius: var(--pill); animation: spn .7s linear infinite; }
+@keyframes spn { to { transform: rotate(360deg); } }
+
+/* a11y */
+.cp :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+@media (prefers-reduced-motion: reduce) {
+  .sk-line { animation: none; } .spin { animation: none; } .kcard { transition: none; }
+}
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -10,7 +10,7 @@ const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_
 export type StudioSection =
   | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
   | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation" // Knowledge engineering
-  | "operations"                                                                // Operations cockpit (WS#45–48/#31)
+  | "operations" | "compute"                                                    // Operations cockpit (WS#45–48/#31) + Universal Compute Plane
   | "governance"                                                                // Governance: ontology · actions · GAIA
   | "commons";                                                                  // Commons (WS#36–39)
 
@@ -809,6 +809,99 @@ export async function promoteWorldsignal(input: { project: string; signal: strin
   }
   if (!res.ok) throw writeError("promote failed", res.status);
   return await res.json();
+}
+
+// ── Universal Compute Plane — the compute-gateway: one governed door for ALL compute ──
+// A single catalog of compute KINDS (notebook, graph-query, spark, inference, …), each declaring its
+// backends, capabilities, a DEFAULT epistemic warrant, whether it executes user code, a live/declared
+// status and whether the caller is entitled. Every run returns a proof-carrying receipt (optionally
+// signed) + an epistemic status. The Studio BFF proxies to the gateway; unset BASE → honest STUB.
+export interface ComputeKind {
+  kind: string;
+  backends: string[];
+  default: string;              // default backend
+  capabilities: string[];
+  epistemic: string;            // default epistemic warrant for this kind's results (ramp mode)
+  executes_user_code: boolean;
+  status: "live" | "declared";  // live = runnable now; declared = catalogued, not yet provisioned
+  entitled: boolean;
+}
+export interface ComputeOutput { type: string; text?: string; data?: unknown; mime?: string | string[] }
+export interface ComputeReceipt {
+  id: string; kind: string; backend: string; epistemic_status: string;
+  inputs_sha?: string; outputs_sha?: string; prev?: string | null; ts?: number;
+  signature?: string | null; public_key?: string | null;   // Ed25519 over the in-toto statement
+  [k: string]: unknown;
+}
+// Zero-trust conformance (compute-gateway ⇄ OUR mcp-a2a-zero-trust kernel).
+export interface ComputeGrantCheck { operation?: string; grant_id?: string; result?: { valid?: boolean; reason?: string } }
+export interface ComputeAttestation { results?: { tpm_valid?: boolean; cosign_valid?: boolean; fido2_valid?: boolean } }
+export interface ComputeResultLite {
+  status: "ok" | "error" | "degraded" | "entitlement_required" | "grant_required";
+  kind: string; backend: string; epistemic_status: string;
+  outputs: ComputeOutput[];
+  receipt?: ComputeReceipt | null;
+  // the gateway returns the provenance subgraph itself (arrays), not counts.
+  graph_delta?: { nodes?: unknown[]; edges?: unknown[]; written?: boolean } | null;
+  degraded?: string | null;
+  error?: string | null;
+  entitlement_required?: boolean;
+  message?: string | null;              // gateway's pay-gate / grant message (top-level)
+  grant_check?: ComputeGrantCheck | null;
+  attestation?: ComputeAttestation | null;
+  memoized?: boolean;                   // served from the content-addressed compute memo
+}
+
+// STUB catalog — MIRRORS the real compute-gateway registry (backends + warrants) so the offline preview
+// never misrepresents the live plane. notebook/graph/spark are live; inference is declared (adapter wired,
+// endpoint unverified) and left un-entitled so the pay-gate card is demonstrable standalone.
+const STUB_COMPUTE_REGISTRY: { kinds: ComputeKind[] } = {
+  kinds: [
+    { kind: "notebook", backends: ["forge"], default: "forge",
+      capabilities: ["python", "r", "julia", "stateful-kernel"], epistemic: "derived",
+      executes_user_code: true, status: "live", entitled: true },
+    { kind: "graph-query", backends: ["hellgraph"], default: "hellgraph",
+      capabilities: ["label-query", "subgraph"], epistemic: "observed",
+      executes_user_code: false, status: "live", entitled: true },
+    { kind: "graph-stats", backends: ["hellgraph"], default: "hellgraph",
+      capabilities: ["counts", "analytics"], epistemic: "observed",
+      executes_user_code: false, status: "live", entitled: true },
+    { kind: "spark", backends: ["spark-runner"], default: "spark-runner",
+      capabilities: ["sql", "dataframe"], epistemic: "derived",
+      executes_user_code: true, status: "live", entitled: true },
+    { kind: "inference", backends: ["model-server"], default: "model-server",
+      capabilities: ["chat", "embed"], epistemic: "derived",
+      executes_user_code: false, status: "declared", entitled: false },
+  ],
+};
+
+export async function loadComputeRegistry(project: string): Promise<{ kinds: ComputeKind[] }> {
+  const b = nbBase();
+  if (!b) return STUB_COMPUTE_REGISTRY;
+  const r = await fetch(`${b}/api/studio/compute/registry?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } }).catch(() => null);
+  if (!r || !r.ok) return STUB_COMPUTE_REGISTRY;
+  const d = await r.json();
+  return Array.isArray(d?.kinds) ? d : STUB_COMPUTE_REGISTRY;
+}
+
+export async function runCompute(input: { kind: string; spec: Record<string, unknown>; project: string; backend?: string }): Promise<ComputeResultLite> {
+  const b = nbBase();
+  // honest stub: no BASE → we do NOT fake a real result; the surface shows the compute plane isn't wired.
+  if (!b) return {
+    status: "degraded", kind: input.kind, backend: input.backend ?? "—",
+    epistemic_status: "hypothesis", outputs: [], receipt: null,
+    graph_delta: { nodes: [], edges: [] },
+    degraded: "compute plane not wired (dev preview)",
+  };
+  const r = await fetch(`${b}/api/studio/compute/run`, {
+    method: "POST", headers: { "Content-Type": "application/json", accept: "application/json" },
+    body: JSON.stringify(input),
+  });
+  // the gateway returns 200 with status:"entitlement_required"|"grant_required" for a soft gate; a 402 is
+  // also honoured for parity with a hard pay-gate. Either way the body carries the typed result.
+  if (r.status === 402) return (await r.json()) as ComputeResultLite;
+  if (!r.ok) throw new Error(`compute run failed (HTTP ${r.status})`);
+  return (await r.json()) as ComputeResultLite;
 }
 
 export async function loadStudio(projectId?: string): Promise<StudioBundle> {

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -6,6 +6,7 @@ import StudioQuery from "../components/StudioQuery.vue";
 import StudioExperiments from "../components/StudioExperiments.vue";
 import StudioCommons from "../components/StudioCommons.vue";
 import StudioOps from "../components/StudioOps.vue";
+import StudioCompute from "../components/StudioCompute.vue";
 import StudioGovernance from "../components/StudioGovernance.vue";
 import StudioNotebooks from "../components/StudioNotebooks.vue";
 import LineageStrip from "../components/LineageStrip.vue";
@@ -61,6 +62,7 @@ const sections: { id: StudioSection; label: string; icon: string; group: string;
   { id: "query",       label: "Query",         icon: "⌗", group: "Knowledge engineering", blurb: "SPARQL / Cypher / Gremlin over the live kernel — results you can replay (proof-carrying) and whose facts carry epistemic status." },
   { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
   { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
+  { id: "compute",     label: "Compute",       icon: "⛩", group: "Operations", blurb: "The Universal Compute Plane — every kind of compute (notebook · graph · Spark · inference) through ONE governed door. Each run is entitlement-gated, zero-trust grant-checked, sealed into a signed, replayable receipt, and typed by epistemic warrant. Databricks welded one paradigm to one surface; this is the generalization — sovereign + multi-backend + proof-carrying." },
   { id: "operations",  label: "Operations",    icon: "⚙", group: "Operations", blurb: "The operations cockpit — run pipelines, promote models, browse the data catalog, submit pay-gated compute, and inspect GraphRAG communities. Every action proof-carrying; compute entitlement-gated (sovereign + multi-backend)." },
   { id: "governance",  label: "Governance",    icon: "⬡", group: "Operations", blurb: "The governance cockpit — browse the real Ontogenesis ontology (817 classes), invoke SHACL-validated ontology actions (Foundry's crown jewel, beaten), and work the GAIA world-signal promotion membrane where a promotion state IS an epistemic status. One discipline across the knowledge, human & Earth twins." },
   { id: "commons",     label: "Commons",       icon: "◆", group: "Commons", blurb: "The proof-carrying knowledge commons — FAIR+ metadata, sovereign DOIs, immutable preservation, ORCID/OpenAIRE + agent hooks, and epistemic-weighted community curation." },
@@ -100,6 +102,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   retrieval:   [{ label: "Query", hint: "run fibered retrieval" }, { label: "Rebuild index", hint: "re-embed" }, { label: "Use in notebook", hint: "attach retriever" }],
   generation:  [{ label: "Run", hint: "New-Hope grounded synthesis" }, { label: "→ Annotation set", hint: "into the workbench" }, { label: "→ Tune", hint: "generation-tuning" }],
   commons:     [{ label: "Cite", hint: "mint a sovereign DOI" }, { label: "Preserve", hint: "seal an immutable version" }, { label: "Export FAIR", hint: "schema.org / DataCite / PROV-O" }],
+  compute:     [{ label: "Run compute", hint: "any kind, one governed door" }, { label: "Verify receipts", hint: "signed, replayable chain" }, { label: "Capability registry", hint: "the agent action space" }],
   operations:  [{ label: "Run pipeline", hint: "governed run ledger" }, { label: "Promote model", hint: "staging → production" }, { label: "Submit compute", hint: "entitlement-gated execution" }],
   governance:  [{ label: "Invoke action", hint: "SHACL-validated writeback" }, { label: "Submit signal", hint: "GAIA world-signal" }, { label: "Promote", hint: "the epistemic membrane" }],
 };
@@ -210,6 +213,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
         <!-- Notebooks = the governed notebook IDE (lattice-forge · receipt-per-cell) (#31) -->
         <StudioNotebooks v-if="section === 'notebooks'" :project="project" />
+        <!-- Compute = the Universal Compute Plane: any compute, one governed door → signed receipt + warrant (#848/#853) -->
+        <StudioCompute v-else-if="section === 'compute'" :project="project" />
         <!-- Graph section = the provenance-first explorer (KE-2) -->
         <StudioGraph v-else-if="section === 'graph'" :project="project" />
         <!-- Query section = the proof-carrying query IDE (WS#30) -->
@@ -232,15 +237,8 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
 
         <div v-else class="grid">
           <article v-for="it in items" :key="it.id" class="card" :class="{ sel: selected?.item.id === it.id }" @click="pick(it)">
-            <!-- notebooks -->
-            <template v-if="section === 'notebooks'">
-              <div class="row"><span class="name">{{ it.name }}</span><span class="pill" :class="it.status">{{ it.status }}</span></div>
-              <div class="sub">{{ it.runtime }} · {{ it.cells }} cells</div>
-              <code v-if="it.lastCell" class="mono">{{ it.lastCell }}</code>
-              <div class="chips"><span v-for="c in it.collaborators" :key="c" class="chip">{{ c }}</span></div>
-            </template>
-            <!-- data -->
-            <template v-else-if="section === 'data'">
+            <!-- data (notebooks/compute render as full-panel components above, never as grid cards) -->
+            <template v-if="section === 'data'">
               <div class="row"><span class="name">{{ it.name }}</span><span v-if="it.governed" class="pill ok">governed</span><span v-else class="pill warn">ungoverned</span></div>
               <div class="sub">{{ it.kind }}<span v-if="it.rows"> · {{ it.rows.toLocaleString() }} rows</span><span v-if="it.columns"> · {{ it.columns }} cols</span></div>
               <LineageStrip v-if="it.lineage" :steps="it.lineage" />


### PR DESCRIPTION
Surfaces the **Universal Compute Plane** (gateway #848/#853) intuitively in Studio — the missing front for "any compute, one governed door." Pairs with prophet-platform #853 (signed receipts + zero-trust).

## What
New Studio section **⛩ Compute** (Operations group):
- **Registry catalog** — every compute kind as a card: backends · capabilities · **default epistemic warrant** · user-code flag · live/declared · entitlement. This is the hero: *heterogeneous compute, one door.*
- **Run panel** — fields driven off the selected kind (notebook cell, Spark SQL, graph query, inference prompt), backend selector, ⇧⏎ to run.
- **Result surface** — outputs (text/JSON/image), epistemic status chip, **PROV-O graph-delta** counts, and the **receipt strip**: `signed ✓` · `in`/`out` sha · `↩ prev`-link. Now also surfaces the zero-trust proof from #853 — **⚡ memoized** (content-addressed) and **⛨ attested** (cosign-valid AttestationBundle).
- **Honest states** — pay-gate (`entitlement_required`), zero-trust grant gate (`grant_required`), and `degraded` (**never a fabricated result** — wire `VITE_STUDIO_API` to go live).
- **Session receipt chain** — the tamper-evident record of every run this session.

## Correctness
- Types + offline stub **mirror the real gateway**: real backends (`forge`/`hellgraph`/`spark-runner`/`model-server`), correct warrants, `graph_delta` as node/edge **arrays**, and the new `grant_check`/`attestation`/`memoized` fields. Live data flows via the BFF proxy (lattice-studio #851); the stub is offline-only.
- Fixes a **pre-existing latent typecheck error** (dead notebooks grid-card template, unreachable since notebooks renders as a full-panel component — no one had run `vue-tsc`).

## Proof
`npm run typecheck` clean · `vite build` green.