### PR TITLE
vue-chat parity 1/N: real Stop + composer controls

### DIFF
--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -32,10 +32,21 @@ export interface ChatTurn {
 
 const TRACE_EVENTS = new Set(['intent', 'plan', 'step', 'narration', 'grounding', 'retrieval', 'deliberation', 'action', 'effort', 'decidable', 'discipline', 'safety', 'escalation']);
 
+export type AgentMode = 'auto' | 'plan' | 'ask';
+export type ReplyLength = 'short' | 'medium' | 'long';
+
 export function createNoeticaChat() {
   const sessionId = (globalThis.crypto?.randomUUID?.() ?? `sess-${Date.now()}`);
   const turns = ref<ChatTurn[]>(loadPersisted());
   const busy = ref(false);
+  // composer request-shaping — all map to fields the agent-machine /api/chat already reads.
+  const agentMode = ref<AgentMode>('auto');
+  const replyLength = ref<ReplyLength>('medium');
+  const webMode = ref(false);
+  const systemPrompt = ref('');
+  // the in-flight request, so Stop can abort it.
+  let controller: AbortController | null = null;
+  function stop() { controller?.abort(); }
 
   // Persist finalized history so a reload keeps the conversation.
   watch(turns, (t) => {
@@ -74,11 +85,17 @@ export function createNoeticaChat() {
       return;
     }
 
+    controller = new AbortController();
     try {
       const res = await fetch(`${AM_BASE}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: sessionId, messages: history, reply_length: 'medium', agent_mode: 'auto' }),
+        signal: controller.signal,
+        body: JSON.stringify({
+          session_id: sessionId, messages: history,
+          reply_length: replyLength.value, agent_mode: agentMode.value,
+          web: webMode.value, ...(systemPrompt.value.trim() ? { system_prompt: systemPrompt.value.trim() } : {}),
+        }),
       });
       if (!res.ok || !res.body) throw new Error(res.status === 423 ? 'agent halted (kill-switch armed)' : `chat unavailable (${res.status})`);
       const reader = res.body.getReader();
@@ -120,15 +137,21 @@ export function createNoeticaChat() {
         }
       }
     } catch (e) {
-      assistant.content = assistant.content || `⚠ ${e instanceof Error ? e.message : 'chat failed'} — start the Agent Machine (dev:app) with a model available.`;
-      assistant.error = true;
+      // an abort is a user Stop, not a failure — keep whatever streamed so far.
+      if (e instanceof DOMException && e.name === 'AbortError') {
+        if (!assistant.content) assistant.content = '⏹ stopped';
+      } else {
+        assistant.content = assistant.content || `⚠ ${e instanceof Error ? e.message : 'chat failed'} — start the Agent Machine (dev:app) with a model available.`;
+        assistant.error = true;
+      }
     } finally {
+      controller = null;
       assistant.streaming = false;
       busy.value = false;
     }
   }
 
-  return { sessionId, turns, busy, send, reset };
+  return { sessionId, turns, busy, send, stop, reset, agentMode, replyLength, webMode, systemPrompt };
 }
 
 export type NoeticaChat = ReturnType<typeof createNoeticaChat>;

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -99,18 +99,28 @@
           @keydown="onKey"
         />
         <div class="nx-toolbar">
+          <!-- composer controls — all just shape the /api/chat request -->
+          <div class="nx-seg" role="group" aria-label="Agent mode">
+            <button v-for="m in agentModes" :key="m" type="button" :class="{ on: chat.agentMode.value === m }"
+              @click="chat.agentMode.value = m" :title="'Agent mode: ' + m">{{ m }}</button>
+          </div>
+          <div class="nx-seg" role="group" aria-label="Reply length">
+            <button v-for="l in replyLengths" :key="l" type="button" :class="{ on: chat.replyLength.value === l }"
+              @click="chat.replyLength.value = l" :title="'Reply length: ' + l">{{ l[0].toUpperCase() }}</button>
+          </div>
+          <button type="button" class="nx-toggle" :class="{ on: chat.webMode.value }"
+            @click="chat.webMode.value = !chat.webMode.value" :aria-pressed="chat.webMode.value" title="Search the web">web</button>
+
+          <span class="nx-spacer" />
           <span class="nx-toolbar-hint">⏎ send</span>
-          <button
-            type="submit"
-            class="nx-send"
-            :disabled="chat.busy.value || !draft.trim()"
-            :aria-label="chat.busy.value ? 'Working' : 'Send'"
-          >
-            <svg v-if="!chat.busy.value" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
+          <button v-if="chat.busy.value" type="button" class="nx-send nx-stopbtn" @click="chat.stop()" aria-label="Stop">
+            <span class="nx-stop" aria-hidden="true" />
+          </button>
+          <button v-else type="submit" class="nx-send" :disabled="!draft.trim()" aria-label="Send">
+            <svg viewBox="0 0 24 24" width="15" height="15" aria-hidden="true">
               <path d="M12 19V5M12 5l-6 6M12 5l6 6" fill="none" stroke="currentColor" stroke-width="2"
                 stroke-linecap="round" stroke-linejoin="round" />
             </svg>
-            <span v-else class="nx-stop" aria-hidden="true" />
           </button>
         </div>
       </form>
@@ -124,6 +134,8 @@ import { useNoeticaChat } from '../composables/useNoeticaChat';
 import NoeticaMark from '../components/NoeticaMark.vue';
 
 const chat = useNoeticaChat();
+const agentModes = ['auto', 'plan', 'ask'] as const;
+const replyLengths = ['short', 'medium', 'long'] as const;
 const draft = ref('');
 const expanded = ref<Set<number>>(new Set());
 function toggleTrace(i: number) { if (expanded.value.has(i)) expanded.value.delete(i); else expanded.value.add(i); }
@@ -310,8 +322,17 @@ onMounted(() => inputEl.value?.focus());
   padding: 12px; outline: none;
 }
 .nx-input textarea::placeholder { color: var(--ntext3); }
-.nx-toolbar { display: flex; align-items: center; justify-content: flex-end; gap: 10px; border-top: 1px solid var(--nline-weak); padding: 6px 8px; }
-.nx-toolbar-hint { font-size: 10px; color: var(--ntext3); margin-right: auto; padding-left: 4px; }
+.nx-toolbar { display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--nline-weak); padding: 6px 8px; flex-wrap: wrap; }
+.nx-toolbar-hint { font-size: 10px; color: var(--ntext3); padding-left: 4px; }
+.nx-spacer { flex: 1 1 auto; }
+.nx-seg { display: inline-flex; border: 1px solid var(--nline-weak); border-radius: 7px; overflow: hidden; }
+.nx-seg button { border: 0; background: transparent; color: var(--ntext3); font: inherit; font-size: 10.5px; font-weight: 600;
+  padding: 3px 8px; cursor: pointer; text-transform: capitalize; }
+.nx-seg button.on { background: var(--nblue); color: #fff; }
+.nx-toggle { border: 1px solid var(--nline-weak); background: transparent; color: var(--ntext3); font: inherit; font-size: 10.5px;
+  font-weight: 600; padding: 3px 9px; border-radius: 7px; cursor: pointer; }
+.nx-toggle.on { background: var(--nblue); color: #fff; border-color: var(--nblue); }
+.nx-stopbtn { background: var(--nsurface, transparent); color: #dc2626; }
 .nx-send {
   display: inline-flex; align-items: center; justify-content: center;
   width: 28px; height: 28px; border: none; border-radius: 8px; cursor: pointer;


### PR DESCRIPTION
First slice of the **Noetica React → Vue chat port**, per the parity audit. Extends client-vue's existing live `NoeticaChat` surface — **no backend changes** (every field is one the agent-machine `/api/chat` already reads). Smallest-first.

## What
- **Stop actually works** — an `AbortController` on the in-flight `/api/chat` request; the previously-inert stop button now aborts it. An abort keeps whatever streamed and is treated as a user stop, not an error.
- **Composer controls** that shape the request: **agent mode** (Auto/Plan/Ask), **reply length** (S/M/L), and a **web-search** toggle — replacing the hardcoded `auto`/`medium`.

## Proof
`typecheck` + `vite build` green.

## Next slices (ordered, from the audit)
markdown/code/citation rendering + live thinking stream → message actions (copy/regenerate/edit/feedback/speak/fork) → structured trace (plan checklist, retrieval, grounding) → plan approve/reject gate → **projects + scope picker + attachments** (the big one) → fan-out/MCP.