### PR TITLE
vue-chat parity 4/N: structured reasoning trace

### DIFF
--- a/socioprophet-web/client-vue/src/components/NoeticaTrace.vue
+++ b/socioprophet-web/client-vue/src/components/NoeticaTrace.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+// Structured reasoning trace — the moat made legible. Renders the agent's plan as a
+// checklist, its retrieval provenance, grounding, and value-judgment verdict, falling
+// back to text chips for the remaining trace kinds.
+import type { ChatTurn } from '../composables/useNoeticaChat';
+
+defineProps<{ turn: ChatTurn }>();
+
+const STEP_GLYPH: Record<string, string> = {
+  done: '✓', complete: '✓', completed: '✓', success: '✓',
+  running: '◔', active: '◔', in_progress: '◔',
+  failed: '✕', error: '✕', blocked: '✕', pending: '○', queued: '○',
+};
+const VERDICT_COLOR: Record<string, string> = {
+  grounded: '#22c55e', speculative: '#d9a63a', contradiction: '#ef4444',
+};
+function pct(n?: number): string { return n == null ? '' : `${Math.round(n * 100)}%`; }
+</script>
+
+<template>
+  <div class="tv">
+    <div v-if="turn.intentName" class="tv-line"><span class="tv-k">intent</span><b>{{ turn.intentName }}</b></div>
+
+    <!-- plan checklist -->
+    <div v-if="turn.plan?.steps?.length" class="tv-sec">
+      <div class="tv-k">plan<span v-if="turn.plan.capability"> · {{ turn.plan.capability }}</span></div>
+      <ol class="tv-plan">
+        <li v-for="s in turn.plan.steps" :key="s.id" :class="s.status">
+          <span class="tv-glyph">{{ STEP_GLYPH[s.status] ?? '○' }}</span>
+          <span class="tv-step-label">{{ s.label }}</span>
+          <span v-if="s.detail" class="tv-step-detail">{{ s.detail }}</span>
+        </li>
+      </ol>
+    </div>
+
+    <!-- retrieval provenance -->
+    <div v-if="turn.retrieval" class="tv-sec">
+      <div class="tv-k">retrieval
+        <span class="tv-dim">
+          {{ (turn.retrieval.sources?.length ?? 0) + (turn.retrieval.document_sources?.length ?? 0) }} sources
+          <template v-if="turn.retrieval.beliefs_injected"> · {{ turn.retrieval.beliefs_injected }} beliefs</template>
+          <template v-if="turn.retrieval.token_estimate"> · ~{{ turn.retrieval.token_estimate }} tok</template>
+        </span>
+      </div>
+      <div class="tv-chips">
+        <span v-for="src in (turn.retrieval.document_sources ?? turn.retrieval.sources ?? []).slice(0, 6)" :key="src.id" class="tv-chip"
+          :title="'score ' + src.score.toFixed(2)">{{ src.label }}</span>
+      </div>
+    </div>
+
+    <!-- grounding -->
+    <div v-if="turn.grounding && (turn.grounding.terms?.length || turn.grounding.domain)" class="tv-sec">
+      <div class="tv-k">grounding<span v-if="turn.grounding.domain" class="tv-dim"> · {{ turn.grounding.domain }}</span></div>
+      <div class="tv-chips">
+        <span v-for="t in (turn.grounding.terms ?? []).slice(0, 10)" :key="t" class="tv-chip">{{ t }}</span>
+      </div>
+    </div>
+
+    <!-- value judgment -->
+    <div v-if="turn.judgment?.verdict" class="tv-sec">
+      <div class="tv-k">judgment</div>
+      <div class="tv-verdict">
+        <span class="tv-badge" :style="{ color: VERDICT_COLOR[turn.judgment.verdict] }">● {{ turn.judgment.verdict }}</span>
+        <span v-if="turn.judgment.worth != null" class="tv-dim">worth {{ pct(turn.judgment.worth) }}</span>
+        <span v-if="turn.judgment.grounding != null" class="tv-dim">grounding {{ pct(turn.judgment.grounding) }}</span>
+      </div>
+      <div v-for="(c, i) in (turn.judgment.contradictions ?? [])" :key="i" class="tv-contra">⚠ {{ c.statement }}</div>
+    </div>
+
+    <!-- remaining trace kinds as text chips -->
+    <div v-if="turn.trace?.length" class="tv-chips tv-rest">
+      <span v-for="(tr, i) in turn.trace" :key="i" class="tv-chip tv-kindchip">
+        <span class="tv-kindname">{{ tr.kind }}</span>{{ tr.text }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tv { display: flex; flex-direction: column; gap: 8px; font-size: 11.5px; }
+.tv-line { display: flex; align-items: center; gap: 6px; }
+.tv-line b { color: var(--ntext); font-weight: 600; }
+.tv-k { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--ntext3); margin-bottom: 3px; }
+.tv-dim { font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--ntext3); }
+.tv-plan { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+.tv-plan li { display: flex; align-items: baseline; gap: 7px; color: var(--ntext); }
+.tv-plan li.done, .tv-plan li.complete, .tv-plan li.completed, .tv-plan li.success { color: var(--ntext3); }
+.tv-glyph { color: var(--nblue); width: 12px; flex: 0 0 auto; }
+.tv-plan li.done .tv-glyph, .tv-plan li.complete .tv-glyph { color: #22c55e; }
+.tv-plan li.failed .tv-glyph, .tv-plan li.error .tv-glyph { color: #ef4444; }
+.tv-step-detail { color: var(--ntext3); font-size: 10.5px; }
+.tv-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.tv-chip { background: var(--nline-weak); color: var(--ntext); border-radius: 5px; padding: 1px 7px; font-size: 10.5px; }
+.tv-verdict { display: flex; align-items: center; gap: 10px; }
+.tv-badge { font-weight: 700; }
+.tv-contra { color: #f59e0b; margin-top: 3px; }
+.tv-rest { margin-top: 2px; }
+.tv-kindchip { display: inline-flex; align-items: center; gap: 5px; }
+.tv-kindname { font-size: 8.5px; font-weight: 700; text-transform: uppercase; color: var(--nblue); }
+</style>

--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -20,12 +20,31 @@ function loadPersisted(): ChatTurn[] {
 
 export type Role = 'user' | 'assistant';
 export interface TraceItem { kind: string; text: string }
+// Structured trace payloads (mirrors Noetica's message types; the agent-machine emits
+// each under an event-specific key: plan→plan, retrieval→trace, grounding→grounding…).
+export interface PlanStepT { id: string; label: string; status: string; detail?: string }
+export interface PlanT { capability?: string; skill?: string; steps: PlanStepT[] }
+export interface RetrievalT {
+  patterns?: string[]; token_estimate?: number; beliefs_injected?: number;
+  sources?: Array<{ id: string; label: string; score: number }>;
+  document_sources?: Array<{ id: string; label: string; score: number }>;
+}
+export interface GroundingT { domain?: string; topics?: string[]; terms?: string[] }
+export interface JudgmentT {
+  verdict?: 'grounded' | 'speculative' | 'contradiction'; worth?: number; grounding?: number;
+  notes?: string[]; contradictions?: Array<{ statement: string; detail?: string }>;
+}
 export interface ChatTurn {
   role: Role;
   content: string;
   streaming?: boolean;
   thinking?: string;   // streamed reasoning (thinking_delta), if the model emits it
-  trace?: TraceItem[];
+  trace?: TraceItem[]; // remaining trace kinds (narration/discipline/…) as text chips
+  intentName?: string;
+  plan?: PlanT;
+  retrieval?: RetrievalT;
+  grounding?: GroundingT;
+  judgment?: JudgmentT;
   error?: boolean;
   model?: string;   // model_routed from the done event
   badge?: string;   // verification badge (e.g. "Generated · best-effort · attested")
@@ -140,6 +159,20 @@ export function createNoeticaChat() {
               assistant.content = assistant.content || `⚠ ${(d.error as string) ?? 'chat error'}`;
               assistant.error = true;
               assistant.streaming = false;
+            } else if (event === 'plan' && d.plan) {
+              assistant.plan = d.plan as PlanT;
+            } else if (event === 'step' && d.step) {
+              const su = d.step as { id: string; status: string; detail?: string };
+              const step = assistant.plan?.steps.find((x) => x.id === su.id);
+              if (step) { step.status = su.status; if (su.detail) step.detail = su.detail; }
+            } else if (event === 'retrieval' && d.trace) {
+              assistant.retrieval = d.trace as RetrievalT;
+            } else if (event === 'grounding' && d.grounding) {
+              assistant.grounding = d.grounding as GroundingT;
+            } else if (event === 'value_judgment' && d.value_judgment) {
+              assistant.judgment = d.value_judgment as JudgmentT;
+            } else if (event === 'intent' && d.intent) {
+              assistant.intentName = (d.intent as { name?: string }).name;
             } else if (TRACE_EVENTS.has(event)) {
               const t = (d.label ?? d.text ?? d.name ?? d.message ?? d.status ?? '') as string;
               if (t) assistant.trace!.push({ kind: event, text: String(t) });

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -46,18 +46,15 @@
             <div class="nx-a-col">
               <div class="nx-a-label">Noetica</div>
 
-              <!-- Reasoning trace disclosure (the moat, made visible) -->
-              <details v-if="t.trace && t.trace.length" class="nx-trace" :open="t.streaming || expanded.has(i)">
+              <!-- Reasoning trace disclosure (the moat, made visible) — structured -->
+              <details v-if="hasTrace(t)" class="nx-trace" :open="t.streaming || expanded.has(i)">
                 <summary class="nx-trace-summary" @click.prevent="toggleTrace(i)">
                   <span class="nx-trace-caret" :class="{ open: t.streaming || expanded.has(i) }">▶</span>
-                  <span class="nx-trace-title">Trace</span>
-                  <span class="nx-trace-count">{{ t.trace.length }}</span>
+                  <span class="nx-trace-title">Reasoning</span>
+                  <span v-if="traceCount(t)" class="nx-trace-count">{{ traceCount(t) }}</span>
                 </summary>
                 <div class="nx-trace-body">
-                  <div v-for="(tr, j) in t.trace" :key="j" class="nx-tr">
-                    <span class="nx-tr-kind">{{ tr.kind }}</span>
-                    <span class="nx-tr-text">{{ tr.text }}</span>
-                  </div>
+                  <NoeticaTrace :turn="t" />
                 </div>
               </details>
 
@@ -142,6 +139,14 @@ import { ref, watch, nextTick, onMounted, computed } from 'vue';
 import { useNoeticaChat, type ChatTurn } from '../composables/useNoeticaChat';
 import { renderMarkdown } from '../utils/markdown';
 import NoeticaMark from '../components/NoeticaMark.vue';
+import NoeticaTrace from '../components/NoeticaTrace.vue';
+
+function hasTrace(t: ChatTurn): boolean {
+  return !!(t.trace?.length || t.plan?.steps?.length || t.retrieval || t.grounding || t.judgment?.verdict || t.intentName);
+}
+function traceCount(t: ChatTurn): number {
+  return (t.trace?.length ?? 0) + (t.plan?.steps?.length ?? 0);
+}
 
 const chat = useNoeticaChat();
 const agentModes = ['auto', 'plan', 'ask'] as const;


### PR DESCRIPTION
Fourth slice of the Noetica → Vue chat port. The trace was flat kind/text chips (and mostly **empty** — plan/retrieval/grounding payloads live under event-specific keys, not `label`/`text`). Now captured and rendered **structured**, matching Noetica React.

## What
- **Composable** captures typed payloads under the correct keys the agent-machine emits: `plan` (steps), `step` (status updates), `retrieval` (`trace`), `grounding`, `value_judgment`, `intent`.
- **`NoeticaTrace.vue`** renders: intent · a **plan checklist** (per-step status glyph) · **retrieval provenance** (source count + beliefs + tokens + top source chips) · **grounding** (domain + term chips) · the **value-judgment verdict** (grounded/speculative/contradiction, coloured, with worth/grounding % + contradictions). Remaining kinds (narration/discipline/deliberation) stay as text chips.

## Proof
`typecheck` + `vite build` green.

## Next
Plan approve/reject gate, then projects + scope + attachments.