### PR TITLE
vue-chat parity 5/N: plan approve/reject gate

### DIFF
--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -49,6 +49,7 @@ export interface ChatTurn {
   model?: string;   // model_routed from the done event
   badge?: string;   // verification badge (e.g. "Generated · best-effort · attested")
   rating?: 'up' | 'down';   // user feedback on an assistant turn
+  awaitingApproval?: boolean;   // plan-mode: produced a plan, waiting for approve/reject
 }
 
 const TRACE_EVENTS = new Set(['intent', 'plan', 'step', 'narration', 'grounding', 'retrieval', 'deliberation', 'action', 'effort', 'decidable', 'discipline', 'safety', 'escalation']);
@@ -87,6 +88,7 @@ export function createNoeticaChat() {
   // Shared by send() and regenerate().
   async function stream() {
     if (busy.value) return;
+    const modeAtSend = agentMode.value;   // plan-mode turns gate on approval when done
     const assistant: ChatTurn = { role: 'assistant', content: '', streaming: true, trace: [] };
     turns.value.push(assistant);
     busy.value = true;
@@ -154,6 +156,7 @@ export function createNoeticaChat() {
               assistant.content = assistant.content.replace(/\n?<!--\s*c2pa:[^>]*-->\s*$/i, '').trimEnd();
               if (result?.model_routed) assistant.model = result.model_routed;
               if (result?.verification?.badge) assistant.badge = result.verification.badge;
+              if (modeAtSend === 'plan') assistant.awaitingApproval = true;
               assistant.streaming = false;
             } else if (event === 'error') {
               assistant.content = assistant.content || `⚠ ${(d.error as string) ?? 'chat error'}`;
@@ -215,7 +218,22 @@ export function createNoeticaChat() {
     } catch { /* best-effort — the rating still shows locally */ }
   }
 
-  return { sessionId, turns, busy, send, stop, reset, regenerate, feedback,
+  // Plan-mode gate: approve → execute the plan in auto mode; reject → discard.
+  async function approvePlan(index: number) {
+    const t = turns.value[index];
+    if (!t || !t.awaitingApproval) return;
+    t.awaitingApproval = false;
+    const prev = agentMode.value;
+    agentMode.value = 'auto';
+    try { await send('Approved. Execute the plan exactly as outlined, step by step.'); }
+    finally { agentMode.value = prev; }
+  }
+  function rejectPlan(index: number) {
+    const t = turns.value[index];
+    if (t) t.awaitingApproval = false;
+  }
+
+  return { sessionId, turns, busy, send, stop, reset, regenerate, feedback, approvePlan, rejectPlan,
     agentMode, replyLength, webMode, systemPrompt };
 }
 

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -73,6 +73,13 @@
                 </span>
               </div>
 
+              <!-- Plan-mode approval gate -->
+              <div v-if="t.awaitingApproval && !t.streaming" class="nx-gate">
+                <span class="nx-gate-txt">Ready to execute — approve to run this plan, or reject to revise.</span>
+                <button class="nx-gate-reject" @click="chat.rejectPlan(i)">Reject</button>
+                <button class="nx-gate-approve" :disabled="chat.busy.value" @click="chat.approvePlan(i)">Approve &amp; Execute</button>
+              </div>
+
               <!-- Governance / model footer -->
               <div v-if="t.model || t.badge" class="nx-meta">
                 <span v-if="t.badge" class="nx-badge">◆ {{ t.badge }}</span>
@@ -369,6 +376,15 @@ onMounted(() => inputEl.value?.focus());
 .nx-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-top: 6px; font-size: 10px; color: var(--ntext3); }
 .nx-model { font-family: ui-monospace, 'SF Mono', monospace; }
 .nx-badge { display: inline-flex; align-items: center; gap: 4px; color: #22c55e; }
+.nx-gate { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 8px; padding: 8px 12px;
+  border: 1px solid var(--nline-weak); border-radius: 8px; background: var(--nline-weak); }
+.nx-gate-txt { flex: 1 1 auto; font-size: 11px; color: var(--ntext3); }
+.nx-gate-reject, .nx-gate-approve { border: 1px solid transparent; border-radius: 6px; padding: 4px 10px;
+  font-size: 11px; font-weight: 600; cursor: pointer; }
+.nx-gate-reject { background: transparent; border-color: var(--nline-strong, var(--nline-weak)); color: var(--ntext3); }
+.nx-gate-reject:hover { color: var(--ntext); }
+.nx-gate-approve { background: var(--nblue); color: #fff; }
+.nx-gate-approve:disabled { opacity: .5; cursor: default; }
 .nx-actions { display: flex; gap: 4px; margin-top: 6px; opacity: 0; transition: opacity .12s; }
 .nx-turn:hover .nx-actions, .nx-actions:focus-within { opacity: 1; }
 .nx-act { display: inline-flex; align-items: center; justify-content: center; width: 24px; height: 24px;


### PR DESCRIPTION
Fifth slice of the Noetica → Vue chat port. When **agent mode = Plan**, the model produces a plan and waits for approval before executing.

- A turn sent in plan mode is marked `awaitingApproval` on `done`.
- The message shows an approval gate: **Approve & Execute** (runs the plan in auto mode via the same execute instruction Noetica React uses) or **Reject** (discard).
- Mirrors React's `handlePlanApprove`/`handlePlanReject`.

`typecheck` + `vite build` green. Next: projects + scope + attachments.