### PR TITLE
vue-chat parity 6a/N: projects + knowledge-scope picker

### DIFF
--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -6,6 +6,7 @@
 import { ref, watch } from 'vue';
 import { AM_BASE } from '../services/agentMachineApi';
 import { useSettings } from '../stores/settings';
+import { useProjects, projectCollectionId } from '../stores/projects';
 import { meshChatStream } from '../config/mesh';
 
 const STORE_KEY = 'noetica-chat-v1';
@@ -66,6 +67,7 @@ export function createNoeticaChat() {
   const replyLength = ref<ReplyLength>('medium');
   const webMode = ref(false);
   const systemPrompt = ref('');
+  const retrievalScope = ref<'chat' | 'project' | 'everything'>('chat');   // knowledge scope
   // the in-flight request, so Stop can abort it.
   let controller: AbortController | null = null;
   function stop() { controller?.abort(); }
@@ -89,6 +91,7 @@ export function createNoeticaChat() {
   async function stream() {
     if (busy.value) return;
     const modeAtSend = agentMode.value;   // plan-mode turns gate on approval when done
+    const activeProject = retrievalScope.value === 'project' ? useProjects().active : null;
     const assistant: ChatTurn = { role: 'assistant', content: '', streaming: true, trace: [] };
     turns.value.push(assistant);
     busy.value = true;
@@ -125,6 +128,8 @@ export function createNoeticaChat() {
           session_id: sessionId, messages: history,
           reply_length: replyLength.value, agent_mode: agentMode.value,
           web: webMode.value, ...(systemPrompt.value.trim() ? { system_prompt: systemPrompt.value.trim() } : {}),
+          retrieval_scope: retrievalScope.value,
+          ...(activeProject ? { collection_id: projectCollectionId(activeProject.id) } : {}),
         }),
       });
       if (!res.ok || !res.body) throw new Error(res.status === 423 ? 'agent halted (kill-switch armed)' : `chat unavailable (${res.status})`);
@@ -234,7 +239,7 @@ export function createNoeticaChat() {
   }
 
   return { sessionId, turns, busy, send, stop, reset, regenerate, feedback, approvePlan, rejectPlan,
-    agentMode, replyLength, webMode, systemPrompt };
+    agentMode, replyLength, webMode, systemPrompt, retrievalScope };
 }
 
 export type NoeticaChat = ReturnType<typeof createNoeticaChat>;

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -112,6 +112,21 @@
           @keydown="onKey"
         />
         <div class="nx-toolbar">
+          <!-- knowledge scope -->
+          <div class="nx-scope">
+            <button type="button" class="nx-scope-btn" @click="showScope = !showScope" :title="'Knowledge scope'">
+              ⌾ <span class="nx-scope-label">{{ scopeLabel }}</span> ▾
+            </button>
+            <div v-if="showScope" class="nx-scope-menu">
+              <button type="button" :class="{ on: chat.retrievalScope.value === 'chat' }" @click="pickScope('chat')">This chat only</button>
+              <div v-if="projects.projects.length" class="nx-scope-sec">Projects</div>
+              <button v-for="p in projects.projects" :key="p.id"
+                :class="{ on: chat.retrievalScope.value === 'project' && projects.activeId === p.id }" @click="pickProject(p.id)">{{ p.title }}</button>
+              <button type="button" :class="{ on: chat.retrievalScope.value === 'everything' }" @click="pickScope('everything')">Everything</button>
+              <button type="button" class="nx-scope-new" @click="newProject">+ New project</button>
+            </div>
+          </div>
+
           <!-- composer controls — all just shape the /api/chat request -->
           <div class="nx-seg" role="group" aria-label="Agent mode">
             <button v-for="m in agentModes" :key="m" type="button" :class="{ on: chat.agentMode.value === m }"
@@ -144,6 +159,7 @@
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, computed } from 'vue';
 import { useNoeticaChat, type ChatTurn } from '../composables/useNoeticaChat';
+import { useProjects } from '../stores/projects';
 import { renderMarkdown } from '../utils/markdown';
 import NoeticaMark from '../components/NoeticaMark.vue';
 import NoeticaTrace from '../components/NoeticaTrace.vue';
@@ -156,9 +172,25 @@ function traceCount(t: ChatTurn): number {
 }
 
 const chat = useNoeticaChat();
+const projects = useProjects();
 const agentModes = ['auto', 'plan', 'ask'] as const;
 const replyLengths = ['short', 'medium', 'long'] as const;
 const draft = ref('');
+
+// ── knowledge-scope picker ──
+const showScope = ref(false);
+const scopeLabel = computed(() => {
+  if (chat.retrievalScope.value === 'everything') return 'Everything';
+  if (chat.retrievalScope.value === 'project') return projects.active?.title ?? 'This chat';
+  return 'This chat';
+});
+function pickScope(s: 'chat' | 'project' | 'everything') { chat.retrievalScope.value = s; showScope.value = false; }
+function pickProject(id: string) { projects.setActive(id); chat.retrievalScope.value = 'project'; showScope.value = false; }
+function newProject() {
+  const name = window.prompt('New project name');
+  if (name && name.trim()) { const p = projects.create(name); chat.retrievalScope.value = 'project'; void p; }
+  showScope.value = false;
+}
 const expanded = ref<Set<number>>(new Set());
 function toggleTrace(i: number) { if (expanded.value.has(i)) expanded.value.delete(i); else expanded.value.add(i); }
 const scrollEl = ref<HTMLElement | null>(null);
@@ -411,6 +443,18 @@ onMounted(() => inputEl.value?.focus());
 .nx-toolbar { display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--nline-weak); padding: 6px 8px; flex-wrap: wrap; }
 .nx-toolbar-hint { font-size: 10px; color: var(--ntext3); padding-left: 4px; }
 .nx-spacer { flex: 1 1 auto; }
+.nx-scope { position: relative; }
+.nx-scope-btn { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--nline-weak); background: transparent;
+  color: var(--ntext3); font: inherit; font-size: 10.5px; font-weight: 600; padding: 3px 8px; border-radius: 7px; cursor: pointer; }
+.nx-scope-label { max-width: 110px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nx-scope-menu { position: absolute; bottom: calc(100% + 6px); left: 0; z-index: 20; min-width: 180px; max-height: 260px; overflow-y: auto;
+  background: var(--nsurface, #14161c); border: 1px solid var(--nline-weak); border-radius: 10px; padding: 4px; box-shadow: 0 8px 24px rgba(0,0,0,.4); }
+.nx-scope-menu button { display: block; width: 100%; text-align: left; border: 0; background: transparent; color: var(--ntext2, var(--ntext));
+  font: inherit; font-size: 12px; padding: 6px 10px; border-radius: 6px; cursor: pointer; }
+.nx-scope-menu button:hover { background: var(--nline-weak); }
+.nx-scope-menu button.on { color: var(--nblue); }
+.nx-scope-sec { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--ntext3); padding: 5px 10px 2px; }
+.nx-scope-new { color: var(--nblue) !important; border-top: 1px solid var(--nline-weak); margin-top: 3px; }
 .nx-seg { display: inline-flex; border: 1px solid var(--nline-weak); border-radius: 7px; overflow: hidden; }
 .nx-seg button { border: 0; background: transparent; color: var(--ntext3); font: inherit; font-size: 10.5px; font-weight: 600;
   padding: 3px 8px; cursor: pointer; text-transform: capitalize; }

--- a/socioprophet-web/client-vue/src/stores/projects.ts
+++ b/socioprophet-web/client-vue/src/stores/projects.ts
@@ -1,0 +1,57 @@
+import { defineStore } from 'pinia';
+import { computed, ref, watch } from 'vue';
+
+// Chat projects — a client-side store (localStorage), matching Noetica's model. A project
+// groups a knowledge base; the chat scopes retrieval to the active project's collection.
+// The collection id is a DERIVED string both this Vue app and Noetica compute identically,
+// so uploads/retrieval bind to the same agent-machine collection with no shared store.
+export interface Project { id: string; title: string; createdAt: number }
+
+const LS_KEY = 'noetica-projects-v1';
+
+// mirrors Noetica's projectCollectionId(): proj-<id, dashes stripped, 12 chars>
+export function projectCollectionId(id: string): string {
+  return `proj-${id.replace(/-/g, '').slice(0, 12)}`;
+}
+
+function load(): { projects: Project[]; activeId: string | null } {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch { /* private mode / bad json */ }
+  return { projects: [], activeId: null };
+}
+
+export const useProjects = defineStore('projects', () => {
+  const persisted = load();
+  const projects = ref<Project[]>(persisted.projects);
+  const activeId = ref<string | null>(persisted.activeId);
+
+  watch([projects, activeId], () => {
+    try { localStorage.setItem(LS_KEY, JSON.stringify({ projects: projects.value, activeId: activeId.value })); }
+    catch { /* quota / private mode */ }
+  }, { deep: true });
+
+  const active = computed<Project | null>(() => projects.value.find((p) => p.id === activeId.value) ?? null);
+
+  function create(title: string): Project {
+    const p: Project = {
+      id: globalThis.crypto?.randomUUID?.() ?? `proj-${Date.now()}`,
+      title: title.trim() || 'Untitled project', createdAt: Date.now(),
+    };
+    projects.value.push(p);
+    activeId.value = p.id;
+    return p;
+  }
+  function rename(id: string, title: string) {
+    const p = projects.value.find((x) => x.id === id);
+    if (p) p.title = title.trim() || p.title;
+  }
+  function remove(id: string) {
+    projects.value = projects.value.filter((p) => p.id !== id);
+    if (activeId.value === id) activeId.value = null;
+  }
+  function setActive(id: string | null) { activeId.value = id; }
+
+  return { projects, activeId, active, create, rename, remove, setActive };
+});


### PR DESCRIPTION
Slice 6 part **a** of the Noetica → Vue chat port — projects and scoping (attachments follow in 6b).

## What
- **`stores/projects.ts`** — a Pinia project store (localStorage): create / rename / remove / setActive. `projectCollectionId()` mirrors Noetica's derivation (`proj-<id, 12 chars>`) so uploads and retrieval bind to the **same agent-machine collection** with no shared backend store.
- **Knowledge-scope picker** in the composer: *This chat* / a project / *Everything*, with inline **+ New project**. Selecting a project makes it active and scopes the conversation to it.
- The chat request now carries **`retrieval_scope` + `collection_id`** (the active project's), exactly as Noetica React sends them. **No backend changes.**

## Proof
`typecheck` + `vite build` green.

## Next
6b: file attachments → `/api/ingest/queue` (bound to the active project's collection).