### PR TITLE
vue-chat parity 7/N: fan-out (compare N models)

### DIFF
--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -51,6 +51,7 @@ export interface ChatTurn {
   badge?: string;   // verification badge (e.g. "Generated · best-effort · attested")
   rating?: 'up' | 'down';   // user feedback on an assistant turn
   awaitingApproval?: boolean;   // plan-mode: produced a plan, waiting for approve/reject
+  fanoutModel?: string;   // when set, this turn is one column of a multi-model compare
 }
 
 const TRACE_EVENTS = new Set(['intent', 'plan', 'step', 'narration', 'grounding', 'retrieval', 'deliberation', 'action', 'effort', 'decidable', 'discipline', 'safety', 'escalation']);
@@ -70,7 +71,7 @@ export function createNoeticaChat() {
   const retrievalScope = ref<'chat' | 'project' | 'everything'>('chat');   // knowledge scope
   // the in-flight request, so Stop can abort it.
   let controller: AbortController | null = null;
-  function stop() { controller?.abort(); }
+  function stop() { controller?.abort(); stopFanout(); }
 
   // Persist finalized history so a reload keeps the conversation.
   watch(turns, (t) => {
@@ -223,6 +224,72 @@ export function createNoeticaChat() {
     } catch { /* best-effort — the rating still shows locally */ }
   }
 
+  // ── fan-out: one prompt → several models, side by side ──
+  // Self-contained (does NOT touch stream()): a minimal SSE consumer per compare slot,
+  // reading just the text + model so the single-chat path carries zero regression risk.
+  let fanControllers: AbortController[] = [];
+  function stopFanout() { fanControllers.forEach((c) => c.abort()); fanControllers = []; }
+
+  async function fanoutSlot(history: Array<{ role: Role; content: string }>, modelId: string, assistant: ChatTurn) {
+    const ctrl = new AbortController();
+    fanControllers.push(ctrl);
+    try {
+      const res = await fetch(`${AM_BASE}/api/chat`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, signal: ctrl.signal,
+        body: JSON.stringify({ session_id: sessionId, messages: history, reply_length: replyLength.value,
+          agent_mode: 'auto', model_id: modelId }),
+      });
+      if (!res.ok || !res.body) throw new Error(`model unavailable (${res.status})`);
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = '', event = 'message';
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const lines = buf.split('\n');
+        buf = lines.pop() ?? '';
+        for (const line of lines) {
+          if (line.startsWith('event:')) { event = line.slice(6).trim(); continue; }
+          if (!line.startsWith('data:')) { if (line.trim() === '') event = 'message'; continue; }
+          const payload = line.slice(5).trim();
+          if (!payload) continue;
+          try {
+            const d = JSON.parse(payload) as Record<string, unknown>;
+            if (event === 'delta' && typeof d.delta === 'string') assistant.content += d.delta;
+            else if (event === 'done') {
+              const r = d.result as { content?: string; model_routed?: string } | undefined;
+              if (r?.content && !assistant.content) assistant.content = r.content;
+              assistant.content = assistant.content.replace(/\n?<!--\s*c2pa:[^>]*-->\s*$/i, '').trimEnd();
+              if (r?.model_routed) assistant.model = r.model_routed;
+            } else if (event === 'error') { assistant.error = true; assistant.content ||= `⚠ ${(d.error as string) ?? 'error'}`; }
+          } catch { /* skip */ }
+        }
+      }
+    } catch (e) {
+      if (!(e instanceof DOMException && e.name === 'AbortError')) {
+        assistant.error = true; assistant.content ||= `⚠ ${e instanceof Error ? e.message : 'failed'}`;
+      }
+    } finally {
+      assistant.streaming = false;
+    }
+  }
+
+  async function fanout(text: string, modelIds: string[]) {
+    const msg = text.trim();
+    if (!msg || busy.value || modelIds.length === 0) return;
+    turns.value.push({ role: 'user', content: msg });
+    const history = turns.value.filter((t) => t.role === 'user').map((t) => ({ role: t.role, content: t.content }));
+    const slots = modelIds.map((mid) => {
+      const a: ChatTurn = { role: 'assistant', content: '', streaming: true, fanoutModel: mid };
+      turns.value.push(a);
+      return { mid, a };
+    });
+    busy.value = true;
+    try { await Promise.all(slots.map(({ mid, a }) => fanoutSlot(history, mid, a))); }
+    finally { fanControllers = []; busy.value = false; }
+  }
+
   // Plan-mode gate: approve → execute the plan in auto mode; reject → discard.
   async function approvePlan(index: number) {
     const t = turns.value[index];
@@ -238,7 +305,7 @@ export function createNoeticaChat() {
     if (t) t.awaitingApproval = false;
   }
 
-  return { sessionId, turns, busy, send, stop, reset, regenerate, feedback, approvePlan, rejectPlan,
+  return { sessionId, turns, busy, send, stop, reset, regenerate, feedback, approvePlan, rejectPlan, fanout,
     agentMode, replyLength, webMode, systemPrompt, retrievalScope };
 }
 

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -44,7 +44,7 @@
           <article v-else class="nx-turn nx-turn--assistant">
             <div class="nx-avatar"><NoeticaMark /></div>
             <div class="nx-a-col">
-              <div class="nx-a-label">Noetica</div>
+              <div class="nx-a-label">{{ t.fanoutModel ? '⧉ ' + t.fanoutModel : 'Noetica' }}</div>
 
               <!-- Reasoning trace disclosure (the moat, made visible) — structured -->
               <details v-if="hasTrace(t)" class="nx-trace" :open="t.streaming || expanded.has(i)">
@@ -146,6 +146,20 @@
           <span v-if="ingesting" class="nx-ingest">ingesting…</span>
           <span v-else-if="ingestedCount" class="nx-ingest" :title="ingestedCount + ' files ingested this session'">✓ {{ ingestedCount }}</span>
 
+          <!-- fan-out: compare multiple models -->
+          <div v-if="models.length" class="nx-scope">
+            <button type="button" class="nx-toggle" :class="{ on: compareMode }"
+              @click="compareMode = !compareMode; showModels = compareMode" title="Compare several models">
+              ⧉ compare<span v-if="compareMode && selectedModels.size"> ({{ selectedModels.size }})</span>
+            </button>
+            <div v-if="compareMode && showModels" class="nx-scope-menu">
+              <div class="nx-scope-sec">Compare models — {{ selectedModels.size }}/4</div>
+              <button v-for="m in models" :key="m.id" type="button" :class="{ on: selectedModels.has(m.id) }" @click="toggleModel(m.id)">
+                {{ selectedModels.has(m.id) ? '✓ ' : '' }}{{ m.id }}
+              </button>
+            </div>
+          </div>
+
           <span class="nx-spacer" />
           <span class="nx-toolbar-hint">⏎ send</span>
           <button v-if="chat.busy.value" type="button" class="nx-send nx-stopbtn" @click="chat.stop()" aria-label="Stop">
@@ -167,7 +181,7 @@
 import { ref, watch, nextTick, onMounted, computed } from 'vue';
 import { useNoeticaChat, type ChatTurn } from '../composables/useNoeticaChat';
 import { useProjects, projectCollectionId } from '../stores/projects';
-import { AM_BASE } from '../services/agentMachineApi';
+import { AM_BASE, labsCatalog, type ModelEntry } from '../services/agentMachineApi';
 import { renderMarkdown } from '../utils/markdown';
 import NoeticaMark from '../components/NoeticaMark.vue';
 import NoeticaTrace from '../components/NoeticaTrace.vue';
@@ -278,6 +292,20 @@ const lastAsstIdx = computed(() => {
   return -1;
 });
 function copyTurn(t: ChatTurn) { void navigator.clipboard?.writeText(mparts(t).answer || t.content); }
+
+// ── fan-out (compare N models) ──
+const compareMode = ref(false);
+const showModels = ref(false);
+const models = ref<ModelEntry[]>([]);
+const selectedModels = ref<Set<string>>(new Set());
+onMounted(async () => {
+  try { models.value = (await labsCatalog()).models.filter((m) => m.kind === 'base'); } catch { /* AM offline */ }
+});
+function toggleModel(id: string) {
+  const s = new Set(selectedModels.value);
+  if (s.has(id)) s.delete(id); else if (s.size < 4) s.add(id);   // cap at 4 columns
+  selectedModels.value = s;
+}
 const speakingIdx = ref<number | null>(null);
 function speakTurn(i: number, t: ChatTurn) {
   const synth = window.speechSynthesis;
@@ -299,7 +327,8 @@ async function submit() {
   if (!text || chat.busy.value) return;
   draft.value = '';
   nextTick(autoGrow);
-  await chat.send(text);
+  if (compareMode.value && selectedModels.value.size) await chat.fanout(text, [...selectedModels.value]);
+  else await chat.send(text);
 }
 function fillAndSend(s: string) { draft.value = s; submit(); }
 function onKey(e: KeyboardEvent) {


### PR DESCRIPTION
Slice 7 (fan-out half) of the Noetica → Vue chat port. One prompt → several models, answers side by side.

## What
- **Composable**: a **self-contained** `fanout(text, modelIds)` — a minimal SSE consumer per compare slot (delta + done: text & model only), per-slot `AbortController`s, `Promise.all`. **Deliberately does not touch `stream()`** so the single-chat path carries **zero regression risk**. Stop cancels all fan-out slots.
- **Composer**: a **Compare** toggle + model multi-select (from `/api/labs/catalog` base models, capped at 4); submit routes to `fanout` when Compare is on. Each fan-out turn is labelled with its model.

## Proof
`typecheck` + `vite build` green.

## Note
MCP tool-picker is the remaining half of slice 7 — it needs the browser MCP client subsystem (or a tool-catalog endpoint), a separate lift.