### PR TITLE
vue-chat parity 7b-2/N: MCP tool use — closes the port

### DIFF
--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -7,6 +7,7 @@ import { ref, watch } from 'vue';
 import { AM_BASE } from '../services/agentMachineApi';
 import { useSettings } from '../stores/settings';
 import { useProjects, projectCollectionId } from '../stores/projects';
+import { useMcp } from '../stores/mcp';
 import { meshChatStream } from '../config/mesh';
 
 const STORE_KEY = 'noetica-chat-v1';
@@ -52,6 +53,7 @@ export interface ChatTurn {
   rating?: 'up' | 'down';   // user feedback on an assistant turn
   awaitingApproval?: boolean;   // plan-mode: produced a plan, waiting for approve/reject
   fanoutModel?: string;   // when set, this turn is one column of a multi-model compare
+  toolCalls?: Array<{ name: string; input?: unknown }>;   // MCP tool calls the agent made
 }
 
 const TRACE_EVENTS = new Set(['intent', 'plan', 'step', 'narration', 'grounding', 'retrieval', 'deliberation', 'action', 'effort', 'decidable', 'discipline', 'safety', 'escalation']);
@@ -93,6 +95,7 @@ export function createNoeticaChat() {
     if (busy.value) return;
     const modeAtSend = agentMode.value;   // plan-mode turns gate on approval when done
     const activeProject = retrievalScope.value === 'project' ? useProjects().active : null;
+    const toolDefs = useMcp().selectedDefs();   // MCP tools the agent may call this turn
     const assistant: ChatTurn = { role: 'assistant', content: '', streaming: true, trace: [] };
     turns.value.push(assistant);
     busy.value = true;
@@ -131,6 +134,7 @@ export function createNoeticaChat() {
           web: webMode.value, ...(systemPrompt.value.trim() ? { system_prompt: systemPrompt.value.trim() } : {}),
           retrieval_scope: retrievalScope.value,
           ...(activeProject ? { collection_id: projectCollectionId(activeProject.id) } : {}),
+          ...(toolDefs.length ? { tools: toolDefs } : {}),
         }),
       });
       if (!res.ok || !res.body) throw new Error(res.status === 423 ? 'agent halted (kill-switch armed)' : `chat unavailable (${res.status})`);
@@ -182,6 +186,10 @@ export function createNoeticaChat() {
               assistant.judgment = d.value_judgment as JudgmentT;
             } else if (event === 'intent' && d.intent) {
               assistant.intentName = (d.intent as { name?: string }).name;
+            } else if (event === 'tool_calls' && Array.isArray(d.tool_calls)) {
+              // informational when the AM drives the loop server-side: show what it called
+              assistant.toolCalls = (d.tool_calls as Array<{ name?: string; input?: unknown }>)
+                .map((c) => ({ name: c.name ?? 'tool', input: c.input }));
             } else if (TRACE_EVENTS.has(event)) {
               const t = (d.label ?? d.text ?? d.name ?? d.message ?? d.status ?? '') as string;
               if (t) assistant.trace!.push({ kind: event, text: String(t) });

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -73,6 +73,11 @@
                 </span>
               </div>
 
+              <!-- MCP tool calls the agent made -->
+              <div v-if="t.toolCalls?.length" class="nx-tools-used">
+                🔧 <span v-for="(tc, k) in t.toolCalls" :key="k" class="nx-tool-chip">{{ tc.name }}</span>
+              </div>
+
               <!-- Plan-mode approval gate -->
               <div v-if="t.awaitingApproval && !t.streaming" class="nx-gate">
                 <span class="nx-gate-txt">Ready to execute — approve to run this plan, or reject to revise.</span>
@@ -175,10 +180,11 @@
               <div v-if="!mcp.servers.length" class="nx-mcp-empty">No MCP servers configured.</div>
               <button type="button" class="nx-scope-new" @click="addMcpServer">+ Add MCP server</button>
               <template v-if="mcp.tools.length">
-                <div class="nx-scope-sec">Discovered tools</div>
-                <div v-for="t in mcp.tools" :key="t.serverId + t.name" class="nx-mcp-tool" :title="t.description">
-                  <b>{{ t.name }}</b> <span class="nx-dim">· {{ t.serverName }}</span>
-                </div>
+                <div class="nx-scope-sec">Tools — tick to let the agent use them</div>
+                <button v-for="t in mcp.tools" :key="t.serverId + t.name" type="button"
+                  :class="{ on: mcp.enabled.has(toolKey(t)) }" @click="mcp.toggleTool(toolKey(t))" :title="t.description">
+                  {{ mcp.enabled.has(toolKey(t)) ? '☑' : '☐' }} <b>{{ t.name }}</b> <span class="nx-dim">· {{ t.serverName }}</span>
+                </button>
               </template>
             </div>
           </div>
@@ -204,7 +210,7 @@
 import { ref, watch, nextTick, onMounted, computed } from 'vue';
 import { useNoeticaChat, type ChatTurn } from '../composables/useNoeticaChat';
 import { useProjects, projectCollectionId } from '../stores/projects';
-import { useMcp } from '../stores/mcp';
+import { useMcp, toolKey } from '../stores/mcp';
 import { AM_BASE, labsCatalog, type ModelEntry } from '../services/agentMachineApi';
 import { renderMarkdown } from '../utils/markdown';
 import NoeticaMark from '../components/NoeticaMark.vue';
@@ -573,6 +579,8 @@ onMounted(() => inputEl.value?.focus());
 .nx-mcp-empty { padding: 4px 10px; font-size: 11px; color: var(--ntext3); }
 .nx-mcp-tool { padding: 3px 10px; font-size: 11px; color: var(--ntext2, var(--ntext)); }
 .nx-mcp-tool .nx-dim { color: var(--ntext3); }
+.nx-tools-used { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; margin-top: 6px; font-size: 11px; color: var(--ntext3); }
+.nx-tool-chip { font-family: ui-monospace, Menlo, monospace; font-size: 10.5px; background: var(--nline-weak); color: var(--ntext); border-radius: 5px; padding: 1px 7px; }
 .nx-seg { display: inline-flex; border: 1px solid var(--nline-weak); border-radius: 7px; overflow: hidden; }
 .nx-seg button { border: 0; background: transparent; color: var(--ntext3); font: inherit; font-size: 10.5px; font-weight: 600;
   padding: 3px 8px; cursor: pointer; text-transform: capitalize; }

--- a/socioprophet-web/client-vue/src/stores/mcp.ts
+++ b/socioprophet-web/client-vue/src/stores/mcp.ts
@@ -19,12 +19,27 @@ function load(): McpServerConfig[] {
   return [];
 }
 
+export function toolKey(t: { serverId: string; name: string }): string { return `${t.serverId}:${t.name}`; }
+
 export const useMcp = defineStore('mcp', () => {
   const servers = ref<McpServerConfig[]>(load());
   const status = ref<Record<string, McpStatus>>({});
   const errors = ref<Record<string, string>>({});
   const tools = ref<McpToolInfo[]>([]);
+  const enabled = ref<Set<string>>(new Set());   // tool keys the model may call this session
   const clients = new Map<string, Client>();   // non-reactive live connections
+
+  function toggleTool(key: string) {
+    const s = new Set(enabled.value);
+    if (s.has(key)) s.delete(key); else s.add(key);
+    enabled.value = s;
+  }
+  // the selected tools as definitions passed into /api/chat. When the agent-machine is
+  // driving the loop it executes them server-side and emits tool_calls for display.
+  function selectedDefs(): Array<{ name: string; description?: string; inputSchema?: unknown; serverId: string }> {
+    return tools.value.filter((t) => enabled.value.has(toolKey(t)))
+      .map((t) => ({ name: t.name, description: t.description, inputSchema: t.inputSchema, serverId: t.serverId }));
+  }
 
   function persist() {
     try { localStorage.setItem(LS_KEY, JSON.stringify(servers.value)); } catch { /* */ }
@@ -78,5 +93,6 @@ export const useMcp = defineStore('mcp', () => {
   }
   function connectAll() { servers.value.forEach((s) => void connect(s)); }
 
-  return { servers, status, errors, tools, addServer, removeServer, connect, disconnect, connectAll };
+  return { servers, status, errors, tools, enabled, toggleTool, selectedDefs,
+    addServer, removeServer, connect, disconnect, connectAll };
 });


### PR DESCRIPTION
Completes MCP — and the **entire Noetica → Vue chat port** (full functional parity).

## Key architectural fact
On the **agent-machine path (client-vue's)** the AM drives the tool loop **server-side** (`AppShell.tsx:1310` — `agentMachineEndpoint` short-circuits the browser loop); `tool_calls` events are **informational**. So the browser only **passes tool definitions** and **displays what was called** — no browser execution loop.

## What
- **`mcp` store**: per-tool enable set + `selectedDefs()` (the definitions to pass).
- **Composer 🔧 popover**: tick tools to let the agent use them.
- **Composable**: passes selected tool defs as `/api/chat` `tools`; consumes `tool_calls` events into the turn.
- Each turn shows a **🔧 chip row** of the tools the agent called.

## Proof
`typecheck` + `vite build` green.

## 🎉 The port
Full parity: stop · markdown · thinking · message actions · structured trace · plan gate · projects · scope · attachments · fan-out · MCP — ~11 slice-PRs, **zero backend changes**. Deferred (need multi-session first, not parity-critical): edit-user, fork, conversation list.