### PR TITLE
Unified cockpit: Studio migration + Algo-Trading / NLP-IE / Discovery made real

### DIFF
--- a/socioprophet-web/client-vue/pnpm-lock.yaml
+++ b/socioprophet-web/client-vue/pnpm-lock.yaml
@@ -1,0 +1,4587 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@carbon/styles':
+        specifier: ^1.89.0
+        version: 1.110.1(sass@1.101.0)
+      '@carbon/vue':
+        specifier: ^3.0.27
+        version: 3.0.31(vue@3.5.39(typescript@5.9.3))
+      '@deck.gl/core':
+        specifier: 9.3.6
+        version: 9.3.6
+      '@deck.gl/geo-layers':
+        specifier: 9.3.6
+        version: 9.3.6(@deck.gl/core@9.3.6)(@deck.gl/extensions@9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))))(@deck.gl/layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))))(@deck.gl/mesh-layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/gltf@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))
+      '@deck.gl/layers':
+        specifier: 9.3.6
+        version: 9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))
+      '@deck.gl/mapbox':
+        specifier: 9.3.6
+        version: 9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@math.gl/web-mercator@4.1.0)
+      d3:
+        specifier: ^7.9.0
+        version: 7.9.0
+      firebase:
+        specifier: 10.14.1
+        version: 10.14.1
+      h3-js:
+        specifier: 4.5.0
+        version: 4.5.0
+      maplibre-gl:
+        specifier: ^5.7.1
+        version: 5.24.0
+      pinia:
+        specifier: 2.3.1
+        version: 2.3.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3))
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
+      vue:
+        specifier: ^3.4.0
+        version: 3.5.39(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.3.0
+        version: 4.6.4(vue@3.5.39(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^5.0.0
+        version: 5.2.4(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0))(vue@3.5.39(typescript@5.9.3))
+      '@vue/test-utils':
+        specifier: ^2.4.9
+        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.10.6
+      sass:
+        specifier: ^1.77.0
+        version: 1.101.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21(@types/node@26.1.1)(sass@1.101.0)
+      vitest:
+        specifier: ^4.0.16
+        version: 4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0))
+      vue-tsc:
+        specifier: ^3.2.1
+        version: 3.3.7(typescript@5.9.3)
+
+packages:
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@carbon/colors@11.53.0':
+    resolution: {integrity: sha512-PvvBsNFng3IRoBp1f7SsHewmuxMTIsCoyl09ksjrQw5iwNSwScKJ3gcSVVLr1rhjQ0p/DakVANupnAaKp03ReA==}
+
+  '@carbon/feature-flags@1.4.0':
+    resolution: {integrity: sha512-ENWuo49HTT4pgWL3TgY+EIMQQyFwTykWnmfCfaXvRzc2mQQ3d22sV0chTJsMiZwclHiRASeb/q5FIZquZb7iFw==}
+
+  '@carbon/grid@11.57.0':
+    resolution: {integrity: sha512-VqRy0gxb+jOzu9c2IiDsCt8m6S08/AEv35M6ehCi1zI8ANVKGG8mLQJvpnYUY80ZtsuCDEmVkcNrcRfz2nkbeg==}
+
+  '@carbon/icon-helpers@10.77.0':
+    resolution: {integrity: sha512-furqJbaATl7PTn9ZKpaDHwQsNhOBcuFMspRJR0CyErAxxuioMPopnCiYcwG38yXiC1G7FqTMf3l0mErTZuc7Gw==}
+
+  '@carbon/icons-vue@10.130.0':
+    resolution: {integrity: sha512-GRo6tthRp3itB0bm5unG2i1tpWH+hlmFA1Sbu9k0GP1oYro58TGboYQbQEopLaADKaPewDLhbjG2I4ejWbRZBw==}
+
+  '@carbon/layout@11.54.0':
+    resolution: {integrity: sha512-Jz+kBUKnjx83qHRQI3stz1dhX1JLITdUGxpf0R2YvsghBpT4DQpx1BmHH2zWOFx/Oh/rJijMOCFTSkLizSbySg==}
+
+  '@carbon/motion@11.47.0':
+    resolution: {integrity: sha512-EhMVu6YFak+DzaYv5VPReRhmT8NT9RWMIpN6pWTByseATszOn+gvPu27ggiXMiOxOzTuqgUTKpp+n6jvNyBeZw==}
+
+  '@carbon/styles@1.110.1':
+    resolution: {integrity: sha512-UrWTQmM7Da6uN7rPzRaM/KEJ8S4AKgOCETdwZ1OTmGKls28j78CzVE7fD9yWkgOWsboglbnWLXCTADkaDZFfgg==}
+    peerDependencies:
+      sass: ^1.33.0
+    peerDependenciesMeta:
+      sass:
+        optional: true
+
+  '@carbon/telemetry@0.1.0':
+    resolution: {integrity: sha512-kNWt0bkgPwGW0i5h7HFuljbKRXPvIhsKbB+1tEURAYLXoJg9iJLF1eGvWN5iVoFCS2zje4GR3OGOsvvKVe7Hlg==}
+    hasBin: true
+
+  '@carbon/themes@11.76.1':
+    resolution: {integrity: sha512-Oml4pqSoJrTb9hU4uCCIqMKLLV8Ej7zoen7j3fOQoL9rPOBia91/oz73dY1neqpZc6hPbtzbERLKIM5YCHFzLA==}
+
+  '@carbon/type@11.62.0':
+    resolution: {integrity: sha512-qSNCK8AUGGAumGz43ZDFwTEW19xTsE9cfYPstxIHYkIobflOiqynwyMj00r2w1oRpPx7YhXIBI9AAJYJL2qjhQ==}
+
+  '@carbon/vue@3.0.31':
+    resolution: {integrity: sha512-9Bumsz39eTCS0WQ5aodhPIn+d+Al3YE6qNko3kncUfwgFoEoyPN6LfPsik2cjWY0WoAorkQunRY8GkzoL/u+5Q==}
+
+  '@deck.gl/core@9.3.6':
+    resolution: {integrity: sha512-dCwF+ATE382DdbIqbaoHYCTAW7vutkVlQvWlmMebTDW1j7rPnKrT6ZPa0Y996U/8ZL5NNWc2/wWWY9LYhZVm2Q==}
+
+  '@deck.gl/extensions@9.3.6':
+    resolution: {integrity: sha512-zWAyeyFlbryrjvlQYYUn+0g7u7LUtS4J6WDWMjrJOP89WCiYitWPz+aqL+0x6iNTZk5xz0YK5FxSarDRCWxZCQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/geo-layers@9.3.6':
+    resolution: {integrity: sha512-qhRrbVQ05nuxM4H8DnA6kuikTFDZWXVvOMDFBeOHF5k4rsjiyIg5ahIJG0AYuYKMzAeYMNyPDR+diFH1JV0yLg==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@deck.gl/extensions': ~9.3.0
+      '@deck.gl/layers': ~9.3.0
+      '@deck.gl/mesh-layers': ~9.3.0
+      '@loaders.gl/core': ^4.4.3
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/layers@9.3.6':
+    resolution: {integrity: sha512-Ex3Lh4AIQ4zi8iojyWr/kpjwdY9HFKkR0iLeNt0hgz3fOmgL8++5jwUuzt+VOQnjE+x7TsNlM1B1fLciHnH4Xg==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@loaders.gl/core': ^4.4.3
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+
+  '@deck.gl/mapbox@9.3.6':
+    resolution: {integrity: sha512-EtjN/Dea7Z6w4gb4c5EE2AEUpKAxrwD5wfZQUFu3+In3wXP1cyfbkJwEqwozRHXo06F6sCknXc9zvmgOXyt0uA==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@math.gl/web-mercator': ^4.1.0
+
+  '@deck.gl/mesh-layers@9.3.6':
+    resolution: {integrity: sha512-tKG+gqwSfVQTocH2XlV5o3otUQ/DARJ5vj/JpRv6FTWhUkHo5Acp9BDkvv3Lb5KYx0MkLZyjSKsvai1oAxVAIQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.3.0
+      '@luma.gl/core': ~9.3.3
+      '@luma.gl/engine': ~9.3.3
+      '@luma.gl/gltf': ~9.3.3
+      '@luma.gl/shadertools': ~9.3.3
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@firebase/analytics-compat@0.2.14':
+    resolution: {integrity: sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.2':
+    resolution: {integrity: sha512-EnzNNLh+9/sJsimsA/FGqzakmrAUKLeJvjRHlg8df1f97NLUlFidk9600y0ZgWOp3CAxn6Hjtk+08tixlUOWyw==}
+
+  '@firebase/analytics@0.10.8':
+    resolution: {integrity: sha512-CVnHcS4iRJPqtIDc411+UmFldk0ShSK3OB+D0bKD8Ck5Vro6dbK5+APZpkuWpbfdL359DIQUnAaMLE+zs/PVyA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.3.15':
+    resolution: {integrity: sha512-zFIvIFFNqDXpOT2huorz9cwf56VT3oJYRFjSFYdSbGYEJYEaXjLJbfC79lx/zjx4Fh+yuN8pry3TtvwaevrGbg==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/app-check-interop-types@0.3.2':
+    resolution: {integrity: sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==}
+
+  '@firebase/app-check-types@0.5.2':
+    resolution: {integrity: sha512-FSOEzTzL5bLUbD2co3Zut46iyPWML6xc4x+78TeaXMSuJap5QObfb+rVvZJtla3asN4RwU7elaQaduP+HFizDA==}
+
+  '@firebase/app-check@0.8.8':
+    resolution: {integrity: sha512-O49RGF1xj7k6BuhxGpHmqOW5hqBIAEbt2q6POW0lIywx7emYtzPDeQI+ryQpC4zbKX646SoVZ711TN1DBLNSOQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.2.43':
+    resolution: {integrity: sha512-HM96ZyIblXjAC7TzE8wIk2QhHlSvksYkQ4Ukh1GmEenzkucSNUmUX4QvoKrqeWsLEQ8hdcojABeCV8ybVyZmeg==}
+
+  '@firebase/app-types@0.9.2':
+    resolution: {integrity: sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==}
+
+  '@firebase/app@0.10.13':
+    resolution: {integrity: sha512-OZiDAEK/lDB6xy/XzYAyJJkaDqmQ+BCtOEPLqFvxWKUz5JbBmej7IiiRHdtiIOD/twW7O5AxVsfaaGA/V1bNsA==}
+
+  '@firebase/auth-compat@0.5.14':
+    resolution: {integrity: sha512-2eczCSqBl1KUPJacZlFpQayvpilg3dxXLy9cSMTKtQMTQSmondUtPI47P3ikH3bQAXhzKLOE+qVxJ3/IRtu9pw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/auth-interop-types@0.2.3':
+    resolution: {integrity: sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==}
+
+  '@firebase/auth-types@0.12.2':
+    resolution: {integrity: sha512-qsEBaRMoGvHO10unlDJhaKSuPn4pyoTtlQuP1ghZfzB6rNQPuhp/N/DcFZxm9i4v0SogjCbf9reWupwIvfmH6w==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.7.9':
+    resolution: {integrity: sha512-yLD5095kVgDw965jepMyUrIgDklD6qH/BZNHeKOgvu7pchOKNjVM+zQoOVYJIKWMWOWBq8IRNVU6NXzBbozaJg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^1.18.1
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.6.9':
+    resolution: {integrity: sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==}
+
+  '@firebase/data-connect@0.1.0':
+    resolution: {integrity: sha512-vSe5s8dY13ilhLnfY0eYRmQsdTbH7PUFZtBbqU6JVX/j8Qp9A6G5gG6//ulbX9/1JFOF1IWNOne9c8S/DOCJaQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/database-compat@1.0.8':
+    resolution: {integrity: sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==}
+
+  '@firebase/database-types@1.0.5':
+    resolution: {integrity: sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==}
+
+  '@firebase/database@1.0.8':
+    resolution: {integrity: sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==}
+
+  '@firebase/firestore-compat@0.3.38':
+    resolution: {integrity: sha512-GoS0bIMMkjpLni6StSwRJarpu2+S5m346Na7gr9YZ/BZ/W3/8iHGNr9PxC+f0rNZXqS4fGRn88pICjrZEgbkqQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.2':
+    resolution: {integrity: sha512-wp1A+t5rI2Qc/2q7r2ZpjUXkRVPtGMd6zCLsiWurjsQpqPgFin3AhNibKcIzoF2rnToNa/XYtyWXuifjOOwDgg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.7.3':
+    resolution: {integrity: sha512-NwVU+JPZ/3bhvNSJMCSzfcBZZg8SUGyzZ2T0EW3/bkUeefCyzMISSt/TTIfEHc8cdyXGlMqfGe3/62u9s74UEg==}
+    engines: {node: '>=10.10.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.3.14':
+    resolution: {integrity: sha512-dZ0PKOKQFnOlMfcim39XzaXonSuPPAVuzpqA4ONTIdyaJK/OnBaIEVs/+BH4faa1a2tLeR+Jy15PKqDRQoNIJw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.2':
+    resolution: {integrity: sha512-0KiJ9lZ28nS2iJJvimpY4nNccV21rkQyor5Iheu/nq8aKXJqtJdeSlZDspjPSBBiHRzo7/GMUttegnsEITqR+w==}
+
+  '@firebase/functions@0.11.8':
+    resolution: {integrity: sha512-Lo2rTPDn96naFIlSZKVd1yvRRqqqwiJk7cf9TZhUerwnPKgBzXy+aHE22ry+6EjCaQusUoNai6mU6p+G8QZT1g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.9':
+    resolution: {integrity: sha512-2lfdc6kPXR7WaL4FCQSQUhXcPbI7ol3wF+vkgtU25r77OxPf8F/VmswQ7sgIkBBWtymn5ZF20TIKtnOj9rjb6w==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.2':
+    resolution: {integrity: sha512-que84TqGRZJpJKHBlF2pkvc1YcXrtEDOVGiDjovP/a3s6W4nlbohGXEsBJo0JCeeg/UG9A+DEZVDUV9GpklUzA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.9':
+    resolution: {integrity: sha512-hlT7AwCiKghOX3XizLxXOsTFiFCQnp/oj86zp1UxwDGmyzsyoxtX+UIZyVyH/oBF5+XtblFG9KZzZQ/h+dpy+Q==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.4.2':
+    resolution: {integrity: sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==}
+
+  '@firebase/messaging-compat@0.2.12':
+    resolution: {integrity: sha512-pKsiUVZrbmRgdImYqhBNZlkKJbqjlPkVdQRZGRbkTyX4OSGKR0F/oJeCt1a8jEg5UnBp4fdVwSWSp4DuCovvEQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.2':
+    resolution: {integrity: sha512-l68HXbuD2PPzDUOFb3aG+nZj5KA3INcPwlocwLZOzPp9rFM9yeuI9YLl6DQfguTX5eAGxO0doTR+rDLDvQb5tA==}
+
+  '@firebase/messaging@0.12.12':
+    resolution: {integrity: sha512-6q0pbzYBJhZEtUoQx7hnPhZvAbuMNuBXKQXOx2YlWhSrlv9N1m0ZzlNpBbu/ItTzrwNKTibdYzUyaaxdWLg+4w==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.9':
+    resolution: {integrity: sha512-dNl95IUnpsu3fAfYBZDCVhXNkASE0uo4HYaEPd2/PKscfTvsgqFAOxfAXzBEDOnynDWiaGUnb5M1O00JQ+3FXA==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.2':
+    resolution: {integrity: sha512-gVq0/lAClVH5STrIdKnHnCo2UcPLjJlDUoEB/tB4KM+hAeHUxWKnpT0nemUPvxZ5nbdY/pybeyMe8Cs29gEcHA==}
+
+  '@firebase/performance@0.6.9':
+    resolution: {integrity: sha512-PnVaak5sqfz5ivhua+HserxTJHtCar/7zM0flCX6NkzBNzJzyzlH4Hs94h2Il0LQB99roBqoE5QT1JqWqcLJHQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.9':
+    resolution: {integrity: sha512-AxzGpWfWFYejH2twxfdOJt5Cfh/ATHONegTd/a0p5flEzsD5JsxXgfkFToop+mypEL3gNwawxrxlZddmDoNxyA==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.3.2':
+    resolution: {integrity: sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==}
+
+  '@firebase/remote-config@0.4.9':
+    resolution: {integrity: sha512-EO1NLCWSPMHdDSRGwZ73kxEEcTopAxX1naqLJFNApp4hO8WfKfmEpmjxmP5TrrnypjIf2tUkYaKsfbEA7+AMmA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.3.12':
+    resolution: {integrity: sha512-hA4VWKyGU5bWOll+uwzzhEMMYGu9PlKQc1w4DWxB3aIErWYzonrZjF0icqNQZbwKNIdh8SHjZlFeB2w6OSsjfg==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.2':
+    resolution: {integrity: sha512-0vWu99rdey0g53lA7IShoA2Lol1jfnPovzLDUBuon65K7uKG9G+L5uO05brD9pMw+l4HRFw23ah3GwTGpEav6g==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.13.2':
+    resolution: {integrity: sha512-fxuJnHshbhVwuJ4FuISLu+/76Aby2sh+44ztjF2ppoe0TELIDxPW6/r1KGlWYt//AD0IodDYYA8ZTN89q8YqUw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.10.0':
+    resolution: {integrity: sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==}
+
+  '@firebase/vertexai-preview@0.0.4':
+    resolution: {integrity: sha512-EBSqyu9eg8frQlVU9/HjKtHN7odqbh9MtAcVz3WwHj4gLCLOoN9F/o+oxlq3CxvFrd3CNTZwu6d2mZtVlEInng==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
+
+  '@firebase/webchannel-wrapper@1.0.1':
+    resolution: {integrity: sha512-jmEnr/pk0yVkA7mIlHNnxCi+wWzOFUg0WyIotgkKAb2u1J7fAeDBcVNSTjTihbAYNusCLQdW5s9IJ5qwnEufcQ==}
+
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@ibm/plex-mono@1.1.0':
+    resolution: {integrity: sha512-hpsdRxR3BRJkC6wGM4MZcUFD6C8M+mmK76RtAy/hlsfPro9FzpXVdIWC+G3jeQOXof109dxlUvmeKxpeKUG68A==}
+
+  '@ibm/plex-sans-arabic@1.1.0':
+    resolution: {integrity: sha512-u8wIS6szLAOFvlBjCFZmtpKIqbhuIuniG2N0J+sio8vV6INH58hP0t0QNYrSl9SZtCv2Fwb4oQGuZJY3kJ4+QA==}
+
+  '@ibm/plex-sans-devanagari@1.1.0':
+    resolution: {integrity: sha512-IVNV9NxXZDzcGZRao/xj+kiFwkdLkcw5vNiKwY8wEzzkpjApXJnPhJ0a7mIKNAh8oIadTIF68+iGtzRKK3nXAQ==}
+
+  '@ibm/plex-sans-hebrew@1.1.0':
+    resolution: {integrity: sha512-iix0rLpUD0E8dE8q+/t3B7u1or7h6gEzoy6TK9NwP41AN31WE55f2cFwQAXomBDwr0Ozc9sHYy97NutEukZXzQ==}
+
+  '@ibm/plex-sans-thai-looped@1.1.0':
+    resolution: {integrity: sha512-9zbDGzmtscHgBRTF88y3/92zQx6lmKjz5ZxhgcljilwOpj08BAytDc3mzUl9XGUh+DmOMl0Ql1lk6ecsEYYg2w==}
+
+  '@ibm/plex-sans-thai@1.1.0':
+    resolution: {integrity: sha512-vk7IrjdO69eEElJpFBppCha/wvU48DFyVuDewcfIf5L6Z11s0vbROANCvKipVPRUz1LE4ron8KoitWGcl3AlfA==}
+
+  '@ibm/plex-sans@1.1.0':
+    resolution: {integrity: sha512-WPgvO6Yfj2w5YbhyAr1tv95RUz4LRJlqN+CmYvBglabXteufP1D1E9BABMde+ZIKdRbFJDoKF5eQzfhpnbgZcQ==}
+
+  '@ibm/plex-serif@2.0.0':
+    resolution: {integrity: sha512-xVu9JsC18tBoQF2M6fofpsWrHj5a94saxlOZbYmXoC0E3UfjgS1JlibgrnaUJjnkLlEyCpMgI2PdhkDxijw0gA==}
+
+  '@ibm/plex@6.4.1':
+    resolution: {integrity: sha512-fnsipQywHt3zWvsnlyYKMikcVI7E2fEwpiPnIHFqlbByXVfQfANAAeJk1IV4mNnxhppUIDlhU0TzwYwL++Rn2g==}
+
+  '@ibm/telemetry-js@1.11.0':
+    resolution: {integrity: sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==}
+    hasBin: true
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@loaders.gl/3d-tiles@4.4.3':
+    resolution: {integrity: sha512-trKDXRYE7xIyH0g2tvDG0SHo/J5sCUhOec70Ne1a5t64/yY+yifQ4B67n4AnSOnZ+l4sxjUypjxhHUqoAeWieQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/compression@4.4.3':
+    resolution: {integrity: sha512-v3feEE48FblxBPaILwejV48plcLmjvOh2yBQrgvKvLCaQdQ9bVz7PzhrUdLW0VDVlGnoR1NUJtI833627U8Heg==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/core@4.4.3':
+    resolution: {integrity: sha512-D6kXFdpUtYwoqS5OQLLaLELkHlS3qIdcSgzVvsh/MinRteeVIITJojqEc/lmDx1zVR3j6WND7yPGF4i4aOwiOg==}
+
+  '@loaders.gl/crypto@4.4.3':
+    resolution: {integrity: sha512-zratEvtj/Mdbu0NwwwzdbP1oyY4FNxLcOY2JRcYqe3wzw+0kyeK7THdaVPcduZAnQ06HtpwHls61ONZunjMtXA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/draco@4.4.3':
+    resolution: {integrity: sha512-YNI1MUDDIbrJBamgU1emLBC2kQUbESNIOZv9bcS8xwxr9SNMfnAMZWgdUJkYcC5xzV2q6ty2I/b2eGhXQkd9EQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/geoarrow@4.4.3':
+    resolution: {integrity: sha512-P0TSbtsw1UI1rZnp1tGHuqPVHcH7Yc14q9jZLIcrjhQOzol55YDI0/hYSXpA73794nR6o8ALxNwiy7/4HlBlcA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/gis@4.4.3':
+    resolution: {integrity: sha512-2dhhzfCT1cXQQLZ1lMtb2Y+pX414qaeLL8Wpx7FJu/ar1HJfKL6Fb3juTR+2WzMybkAOX5zLxYh6+y7LqiPjgA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/gltf@4.4.3':
+    resolution: {integrity: sha512-OYE/0nGLYm3weiCb78+ROwdNVyuLS8IZwN8NvGqctqt0HS4ZD40biu7b9L8xkFbVTZQkQZXDpyZ61n5PSQeU1A==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/images@4.4.3':
+    resolution: {integrity: sha512-a4C6x+4GZUchf+IwpdBOvyGeLGSbGOVob+WSWfGUezEQ4gqu1zS1pn3lCX3ZTL5P+Ch3v6KKwPGdO5YdTd52Ew==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/loader-utils@4.4.3':
+    resolution: {integrity: sha512-5yt1OqZPYR3d+xFAqtzSKO24Hd7019KqN+iOWp7XBKPQBS+sAEhAnmSTnO1axo45IEi14J3FhMDk+ndqBoSKEQ==}
+
+  '@loaders.gl/math@4.4.3':
+    resolution: {integrity: sha512-EdEsZGqo1AX3sqgXt8bSBmdo+8ncURXjWucyQ8eeIJ2h0VIqM3bLkOGKk/D1ngeqK4hJXcjiturYHBW1B286lw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/mvt@4.4.3':
+    resolution: {integrity: sha512-s2R8GRlaWDfZ7oKDFiY0c5EJ8elkf2VbPvdC0eoh69DN71y+AKngDSB+7h4veH/oueLEjmV7tNlF0+Snv58CPw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/schema-utils@4.4.3':
+    resolution: {integrity: sha512-TggzQWkzf9pIYbj8I9RlTk33kwXslvDkY1nnw/OL/hika6qTls1G127qK5m9skiAjElk5ZkvQLQcwhOboZXZeA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/schema@4.4.3':
+    resolution: {integrity: sha512-tDb/rOn44nHWvMFSOaAk1/pQcQcusxirGCM1O5BMJR0PQ71UrCHey56rsbcf7/wGhvyRwPtX+oiMzlJ9TmN8vQ==}
+
+  '@loaders.gl/terrain@4.4.3':
+    resolution: {integrity: sha512-wu7O3FVXE6D1kSm5inRu8M8V1Vv5AYlnlNB0EJIOSSXBLhfNbPL5oHjlD2wIlag0gSxOVlhWjCUcWS3/Nb0P8Q==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/textures@4.4.3':
+    resolution: {integrity: sha512-QNC+anwJJcHsLsaAzXozJ+IUNxBnqWsZLUMkUZIorVey+XQcp2hcYng5iOmUQnCZdIR9gYe53VJa0j1C0JXRSg==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/tiles@4.4.3':
+    resolution: {integrity: sha512-8ZkPMe+daMV5mHKTEU591mJSp6pswdWliI+PcNhSOkpeuvyjecaYKSzuzMFMmaywfgOLpYl+lpfzKUEmCcE5vQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/wms@4.4.3':
+    resolution: {integrity: sha512-fKYCdIp6xQcucbm42bztprlfMJ5SZKx5f2ZwWLcj+kwv53U7hjcbIl04uMAk/i/7Xw/I4QEyA/XnPnxquuIFHQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/worker-utils@4.4.3':
+    resolution: {integrity: sha512-RZt/NwFXm6Kx3Fn/rqiW3Alse9Z0XtBktH/EFAp8W6LvsKuxpRMjULqGfybTu2waRXRYUNYZ6zGs9aOWbtDRLw==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/xml@4.4.3':
+    resolution: {integrity: sha512-/CtpIWaPKBs/AaX7MqUGSSE1OAhq78nDrJ5xPExYdIQAw5gl5OSmLZobUSSxV5FGaqkJRVbtC/sj5sUpci7doA==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@loaders.gl/zip@4.4.3':
+    resolution: {integrity: sha512-HH/JLulJJVyqmbQYp4e/9MPjaTnUFnWfhgza8sMGIBYZ/YuZXOc6Ad2vvmyFQHvNbVr+NLrRZODASEjNZQ5rfQ==}
+    peerDependencies:
+      '@loaders.gl/core': ~4.4.0
+
+  '@luma.gl/core@9.3.6':
+    resolution: {integrity: sha512-eqHnCPh2xHYkdd9rEkiIIkGMixNiJkq1ROrnTob6npvmZNVHXL0ubIw5KueL7rqW0+J1tm+p2+TXZaCmn0sP7Q==}
+
+  '@luma.gl/engine@9.3.6':
+    resolution: {integrity: sha512-NYTdhn2NaH/MjN8qXCl2ukrT1Ac9iTKu1mgN0wz11XRd1QYnlMNBXswRROD7IZ2PUsBWdmYHc9qE8wKBQqMuIA==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+      '@luma.gl/shadertools': ~9.3.0
+
+  '@luma.gl/gltf@9.3.6':
+    resolution: {integrity: sha512-9R27aYwvu6KBJzd9Kxs4cqIJpgJsI1AyL6Pn6+5CrmGbaCqMtgWi7Sf9Wo+bqv0PRxwzH0j1oAv7qRk0hGbstw==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+      '@luma.gl/engine': ~9.3.0
+      '@luma.gl/shadertools': ~9.3.0
+
+  '@luma.gl/shadertools@9.3.6':
+    resolution: {integrity: sha512-dDuD8lCOkAE1L7hJGZEyZAi7upR1HG3wEEIQ1gCLaTTbJWC7tNtnVz853lqUA+VXgjgS9NiQFFRcosiIZmW4Vg==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+
+  '@luma.gl/webgl@9.3.6':
+    resolution: {integrity: sha512-tGm7FGWPmJKxGZMvkRPRi219x3tKmBxR7Uke09nTp2ujNak/O5V9xPIQ9lUBGTxqAb8U2yjKkXG8j+f/4b2+sw==}
+    peerDependencies:
+      '@luma.gl/core': ~9.3.0
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/martini@0.2.0':
+    resolution: {integrity: sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==}
+
+  '@mapbox/point-geometry@0.1.0':
+    resolution: {integrity: sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@1.3.1':
+    resolution: {integrity: sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==}
+
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
+
+  '@math.gl/core@4.1.0':
+    resolution: {integrity: sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==}
+
+  '@math.gl/culling@4.1.0':
+    resolution: {integrity: sha512-jFmjFEACnP9kVl8qhZxFNhCyd47qPfSVmSvvjR0/dIL6R9oD5zhR1ub2gN16eKDO/UM7JF9OHKU3EBIfeR7gtg==}
+
+  '@math.gl/geospatial@4.1.0':
+    resolution: {integrity: sha512-BzsUhpVvnmleyYF6qdqJIip6FtIzJmnWuPTGhlBuPzh7VBHLonCFSPtQpbkRuoyAlbSyaGXcVt6p6lm9eK2vtg==}
+
+  '@math.gl/polygon@4.1.0':
+    resolution: {integrity: sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==}
+
+  '@math.gl/sun@4.1.0':
+    resolution: {integrity: sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA==}
+
+  '@math.gl/types@4.1.0':
+    resolution: {integrity: sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==}
+
+  '@math.gl/web-mercator@4.1.0':
+    resolution: {integrity: sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==}
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@probe.gl/env@4.1.1':
+    resolution: {integrity: sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==}
+
+  '@probe.gl/log@4.1.1':
+    resolution: {integrity: sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==}
+
+  '@probe.gl/stats@4.1.1':
+    resolution: {integrity: sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@turf/boolean-clockwise@5.1.5':
+    resolution: {integrity: sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==}
+
+  '@turf/clone@5.1.5':
+    resolution: {integrity: sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==}
+
+  '@turf/helpers@5.1.5':
+    resolution: {integrity: sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==}
+
+  '@turf/invariant@5.2.0':
+    resolution: {integrity: sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==}
+
+  '@turf/meta@5.2.0':
+    resolution: {integrity: sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==}
+
+  '@turf/rewind@5.1.5':
+    resolution: {integrity: sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==}
+
+  '@types/brotli@1.3.5':
+    resolution: {integrity: sha512-9xoNr+bcxT236/7ZgcWw/6Pb2RRetE13p4bFy1xYSckKwyOiRfmInay8baUWZgH7/284Wl6IPe7+nOI9+OQg/A==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
+
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
+  '@types/pako@1.0.7':
+    resolution: {integrity: sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue/compiler-core@3.5.39':
+    resolution: {integrity: sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==}
+
+  '@vue/compiler-dom@3.5.39':
+    resolution: {integrity: sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==}
+
+  '@vue/compiler-sfc@3.5.39':
+    resolution: {integrity: sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==}
+
+  '@vue/compiler-ssr@3.5.39':
+    resolution: {integrity: sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
+  '@vue/language-core@3.3.7':
+    resolution: {integrity: sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==}
+
+  '@vue/reactivity@3.5.39':
+    resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
+
+  '@vue/runtime-core@3.5.39':
+    resolution: {integrity: sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==}
+
+  '@vue/runtime-dom@3.5.39':
+    resolution: {integrity: sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==}
+
+  '@vue/server-renderer@3.5.39':
+    resolution: {integrity: sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==}
+    peerDependencies:
+      vue: 3.5.39
+
+  '@vue/shared@3.5.39':
+    resolution: {integrity: sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==}
+
+  '@vue/test-utils@2.4.11':
+    resolution: {integrity: sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
+  '@vueuse/core@4.11.2':
+    resolution: {integrity: sha512-4A17XvKXpMR6829EVWvrdSKEeAjTWaiC3+xh51KEtlyCwvWQwZ0xwKDrbMj+e15ANxjHrTw/0bJVaWDfPQt/Pw==}
+
+  '@vueuse/shared@4.11.2':
+    resolution: {integrity: sha512-vTbTi6ou7ljH3CkKVoaIaCAoWB5T1ewSogpL6VnO1duMPNuiv7x8K/LunMbnTg4tVyt6QwaiCuEq/kyS6AUBRg==}
+
+  a5-js@0.7.3:
+    resolution: {integrity: sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q==}
+
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  alien-signals@3.2.1:
+    resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
+  apache-arrow@21.1.0:
+    resolution: {integrity: sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==}
+    hasBin: true
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-back@6.2.3:
+    resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
+    engines: {node: '>=12.17'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  buf-compare@1.0.1:
+    resolution: {integrity: sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==}
+    engines: {node: '>=0.10.0'}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
+  carbon-components@10.58.15:
+    resolution: {integrity: sha512-w1ubGzeH+HdJotD+B2UgW8hUeTtp1CcXDcki20Il3er6BfLjEhQL5/XlXnJiDzRmB6NgozxOQEbjLPXbZSfiqA==}
+    deprecated: This package is no longer supported. More info at https://carbondesignsystem.com/deprecations/
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
+  command-line-args@6.0.2:
+    resolution: {integrity: sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==}
+    engines: {node: '>=12.20'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-assert@0.2.1:
+    resolution: {integrity: sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==}
+    engines: {node: '>=0.10.0'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  deep-strict-equal@0.2.0:
+    resolution: {integrity: sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==}
+    engines: {node: '>=0.10.0'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  draco3d@1.5.7:
+    resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
+
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eslint-plugin-prettier-vue@4.2.0:
+    resolution: {integrity: sha512-DA2oNRx+pZ6RM/EIHIPME4FQZifnkEROa55OWtTTUFGHpj53tcHomuxVP/kS/2MM+ul46GEK+jymK69STWDWoA==}
+    engines: {node: '>=14'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.0:
+    resolution: {integrity: sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==}
+    hasBin: true
+
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fflate@0.7.4:
+    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+
+  find-replace@5.0.2:
+    resolution: {integrity: sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@75lb/nature': latest
+    peerDependenciesMeta:
+      '@75lb/nature':
+        optional: true
+
+  firebase@10.14.1:
+    resolution: {integrity: sha512-0KZxU+Ela9rUCULqFsUUOYYkjh7OM1EWdIfG6///MtXd0t2/uUIf0iNV5i0KariMhRQ5jve/OY985nrAXFaZeQ==}
+
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
+  flatpickr@4.6.1:
+    resolution: {integrity: sha512-3ULSxbXmcMIRzer/2jLNweoqHpwDvsjEawO2FUd9UFR8uPwLM+LruZcPDpuZStcEgbQKhuFOfXo4nYdGladSNw==}
+
+  flatpickr@4.6.13:
+    resolution: {integrity: sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  h3-js@4.5.0:
+    resolution: {integrity: sha512-uKmdPc+DuarnR+XqZxEuWOMw7KzzKROrx3MLeJpFnMOs78S9M5eZ+X5RieS9UcSFQqbeXzbfWuX/W9Pyajinqw==}
+    engines: {node: '>=4', npm: '>=3', yarn: '>=1.3.0'}
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  image-size@0.7.5:
+    resolution: {integrity: sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==}
+    engines: {node: '>=6.9.0'}
+    hasBin: true
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-error@2.2.2:
+    resolution: {integrity: sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.8:
+    resolution: {integrity: sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
+
+  ktx-parse@0.7.1:
+    resolution: {integrity: sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
+  long@3.2.0:
+    resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}
+    engines: {node: '>=0.6'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz4js@0.2.0:
+    resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mjolnir.js@3.0.1:
+    resolution: {integrity: sha512-/RMi8Jm3NKleOkVI8D2ai+1OVwtfRJsSVBVjbTXNm83nfsN4uORYaN3u1/hsg5CqVI+di8enTkvgDNDOywn6cQ==}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pbf@3.3.0:
+    resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
+    hasBin: true
+
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pinia@2.3.1:
+    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
+    peerDependencies:
+      typescript: '>=4.4.4'
+      vue: ^2.7.0 || ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  postcss@8.5.19:
+    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sass@1.101.0:
+    resolution: {integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
+
+  snappyjs@0.6.1:
+    resolution: {integrity: sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
+
+  texture-compressor@1.0.2:
+    resolution: {integrity: sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==}
+    hasBin: true
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@6.19.7:
+    resolution: {integrity: sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==}
+    engines: {node: '>=18.17'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue-tsc@3.3.7:
+    resolution: {integrity: sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.39:
+    resolution: {integrity: sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  warning@3.0.0:
+    resolution: {integrity: sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==}
+
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  zstd-codec@0.1.5:
+    resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
+
+snapshots:
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@carbon/colors@11.53.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/feature-flags@1.4.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/grid@11.57.0':
+    dependencies:
+      '@carbon/layout': 11.54.0
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/icon-helpers@10.77.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/icons-vue@10.130.0':
+    dependencies:
+      '@carbon/icon-helpers': 10.77.0
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/layout@11.54.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/motion@11.47.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/styles@1.110.1(sass@1.101.0)':
+    dependencies:
+      '@carbon/colors': 11.53.0
+      '@carbon/feature-flags': 1.4.0
+      '@carbon/grid': 11.57.0
+      '@carbon/layout': 11.54.0
+      '@carbon/motion': 11.47.0
+      '@carbon/themes': 11.76.1
+      '@carbon/type': 11.62.0
+      '@ibm/plex': 6.4.1
+      '@ibm/plex-mono': 1.1.0
+      '@ibm/plex-sans': 1.1.0
+      '@ibm/plex-sans-arabic': 1.1.0
+      '@ibm/plex-sans-devanagari': 1.1.0
+      '@ibm/plex-sans-hebrew': 1.1.0
+      '@ibm/plex-sans-thai': 1.1.0
+      '@ibm/plex-sans-thai-looped': 1.1.0
+      '@ibm/plex-serif': 2.0.0
+      '@ibm/telemetry-js': 1.11.0
+    optionalDependencies:
+      sass: 1.101.0
+
+  '@carbon/telemetry@0.1.0': {}
+
+  '@carbon/themes@11.76.1':
+    dependencies:
+      '@carbon/colors': 11.53.0
+      '@carbon/layout': 11.54.0
+      '@carbon/type': 11.62.0
+      '@ibm/telemetry-js': 1.11.0
+      color: 4.2.3
+
+  '@carbon/type@11.62.0':
+    dependencies:
+      '@carbon/grid': 11.57.0
+      '@carbon/layout': 11.54.0
+      '@ibm/telemetry-js': 1.11.0
+
+  '@carbon/vue@3.0.31(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@carbon/icons-vue': 10.130.0
+      '@ibm/telemetry-js': 1.11.0
+      '@vueuse/core': 4.11.2(vue@3.5.39(typescript@5.9.3))
+      carbon-components: 10.58.15
+      eslint-plugin-prettier-vue: 4.2.0
+      flatpickr: 4.6.13
+      mitt: 3.0.1
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@deck.gl/core@9.3.6':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@luma.gl/webgl': 9.3.6(@luma.gl/core@9.3.6)
+      '@math.gl/core': 4.1.0
+      '@math.gl/sun': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+      gl-matrix: 3.4.4
+      mjolnir.js: 3.0.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/extensions@9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))':
+    dependencies:
+      '@deck.gl/core': 9.3.6
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@luma.gl/webgl': 9.3.6(@luma.gl/core@9.3.6)
+      '@math.gl/core': 4.1.0
+
+  '@deck.gl/geo-layers@9.3.6(@deck.gl/core@9.3.6)(@deck.gl/extensions@9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))))(@deck.gl/layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))))(@deck.gl/mesh-layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/gltf@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))':
+    dependencies:
+      '@deck.gl/core': 9.3.6
+      '@deck.gl/extensions': 9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))
+      '@deck.gl/layers': 9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))
+      '@deck.gl/mesh-layers': 9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/gltf@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@loaders.gl/3d-tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gis': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/mvt': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/terrain': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/wms': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/gltf': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@types/geojson': 7946.0.16
+      a5-js: 0.7.3
+      h3-js: 4.5.0
+      long: 3.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))':
+    dependencies:
+      '@deck.gl/core': 9.3.6
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@mapbox/tiny-sdf': 2.2.0
+      '@math.gl/core': 4.1.0
+      '@math.gl/polygon': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@types/geojson': 7946.0.16
+      earcut: 2.2.4
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@deck.gl/mapbox@9.3.6(@deck.gl/core@9.3.6)(@luma.gl/core@9.3.6)(@math.gl/web-mercator@4.1.0)':
+    dependencies:
+      '@deck.gl/core': 9.3.6
+      '@luma.gl/core': 9.3.6
+      '@math.gl/web-mercator': 4.1.0
+
+  '@deck.gl/mesh-layers@9.3.6(@deck.gl/core@9.3.6)(@loaders.gl/core@4.4.3)(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/gltf@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))':
+    dependencies:
+      '@deck.gl/core': 9.3.6
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/gltf': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@loaders.gl/core'
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@firebase/analytics-compat@0.2.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/analytics': 0.10.8(@firebase/app@0.10.13)
+      '@firebase/analytics-types': 0.8.2
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/analytics-types@0.8.2': {}
+
+  '@firebase/analytics@0.10.8(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/app-check-compat@0.3.15(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-check': 0.8.8(@firebase/app@0.10.13)
+      '@firebase/app-check-types': 0.5.2
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/app-check-interop-types@0.3.2': {}
+
+  '@firebase/app-check-types@0.5.2': {}
+
+  '@firebase/app-check@0.8.8(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/app-compat@0.2.43':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/app-types@0.9.2': {}
+
+  '@firebase/app@0.10.13':
+    dependencies:
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/auth-compat@0.5.14(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/auth': 1.7.9(@firebase/app@0.10.13)
+      '@firebase/auth-types': 0.12.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
+      '@firebase/component': 0.6.9
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+      undici: 6.19.7
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
+  '@firebase/auth-interop-types@0.2.3': {}
+
+  '@firebase/auth-types@0.12.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.2
+      '@firebase/util': 1.10.0
+
+  '@firebase/auth@1.7.9(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+      undici: 6.19.7
+
+  '@firebase/component@0.6.9':
+    dependencies:
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/data-connect@0.1.0(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/auth-interop-types': 0.2.3
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/database-compat@1.0.8':
+    dependencies:
+      '@firebase/component': 0.6.9
+      '@firebase/database': 1.0.8
+      '@firebase/database-types': 1.0.5
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/database-types@1.0.5':
+    dependencies:
+      '@firebase/app-types': 0.9.2
+      '@firebase/util': 1.10.0
+
+  '@firebase/database@1.0.8':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.2
+      '@firebase/auth-interop-types': 0.2.3
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/firestore-compat@0.3.38(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/firestore': 4.7.3(@firebase/app@0.10.13)
+      '@firebase/firestore-types': 3.0.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.2
+      '@firebase/util': 1.10.0
+
+  '@firebase/firestore@4.7.3(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      '@firebase/webchannel-wrapper': 1.0.1
+      '@grpc/grpc-js': 1.9.16
+      '@grpc/proto-loader': 0.7.15
+      tslib: 2.8.1
+      undici: 6.19.7
+
+  '@firebase/functions-compat@0.3.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/functions': 0.11.8(@firebase/app@0.10.13)
+      '@firebase/functions-types': 0.6.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/functions-types@0.6.2': {}
+
+  '@firebase/functions@0.11.8(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/app-check-interop-types': 0.3.2
+      '@firebase/auth-interop-types': 0.2.3
+      '@firebase/component': 0.6.9
+      '@firebase/messaging-interop-types': 0.2.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+      undici: 6.19.7
+
+  '@firebase/installations-compat@0.2.9(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/installations-types': 0.5.2(@firebase/app-types@0.9.2)
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.2(@firebase/app-types@0.9.2)':
+    dependencies:
+      '@firebase/app-types': 0.9.2
+
+  '@firebase/installations@0.6.9(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/util': 1.10.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/logger@0.4.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/messaging-compat@0.2.12(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/messaging': 0.12.12(@firebase/app@0.10.13)
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/messaging-interop-types@0.2.2': {}
+
+  '@firebase/messaging@0.12.12(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/messaging-interop-types': 0.2.2
+      '@firebase/util': 1.10.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/performance-compat@0.2.9(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/performance': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/performance-types': 0.2.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/performance-types@0.2.2': {}
+
+  '@firebase/performance@0.6.9(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/remote-config-compat@0.2.9(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/remote-config': 0.4.9(@firebase/app@0.10.13)
+      '@firebase/remote-config-types': 0.3.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/remote-config-types@0.3.2': {}
+
+  '@firebase/remote-config@0.4.9(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/storage-compat@0.3.12(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app-compat': 0.2.43
+      '@firebase/component': 0.6.9
+      '@firebase/storage': 0.13.2(@firebase/app@0.10.13)
+      '@firebase/storage-types': 0.8.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.2(@firebase/app-types@0.9.2)(@firebase/util@1.10.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.2
+      '@firebase/util': 1.10.0
+
+  '@firebase/storage@0.13.2(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/component': 0.6.9
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+      undici: 6.19.7
+
+  '@firebase/util@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/vertexai-preview@0.0.4(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)':
+    dependencies:
+      '@firebase/app': 0.10.13
+      '@firebase/app-check-interop-types': 0.3.2
+      '@firebase/app-types': 0.9.2
+      '@firebase/component': 0.6.9
+      '@firebase/logger': 0.4.2
+      '@firebase/util': 1.10.0
+      tslib: 2.8.1
+
+  '@firebase/webchannel-wrapper@1.0.1': {}
+
+  '@grpc/grpc-js@1.9.16':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 26.1.1
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
+  '@ibm/plex-mono@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans-arabic@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans-devanagari@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans-hebrew@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans-thai-looped@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans-thai@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-sans@1.1.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex-serif@2.0.0':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/plex@6.4.1':
+    dependencies:
+      '@ibm/telemetry-js': 1.11.0
+
+  '@ibm/telemetry-js@1.11.0': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@loaders.gl/3d-tiles@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/compression': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/crypto': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/draco': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/math': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/tiles': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/zip': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/geospatial': 4.1.0
+      '@probe.gl/log': 4.1.1
+      long: 5.3.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/compression@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@types/pako': 1.0.7
+      fflate: 0.7.4
+      pako: 1.0.11
+      snappyjs: 0.6.1
+    optionalDependencies:
+      '@types/brotli': 1.3.5
+      brotli: 1.3.3
+      lz4js: 0.2.0
+      zstd-codec: 0.1.5
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/core@4.4.3':
+    dependencies:
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@probe.gl/log': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/crypto@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@types/crypto-js': 4.2.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/draco@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      draco3d: 1.5.7
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/geoarrow@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@math.gl/polygon': 4.1.0
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/gis@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/geoarrow': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/schema-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@mapbox/vector-tile': 1.3.1
+      '@math.gl/polygon': 4.1.0
+      pbf: 3.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/gltf@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/draco': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/textures': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/images@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/loader-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+      - '@loaders.gl/core'
+
+  '@loaders.gl/math@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@math.gl/core': 4.1.0
+
+  '@loaders.gl/mvt@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gis': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@math.gl/polygon': 4.1.0
+      '@probe.gl/stats': 4.1.1
+      pbf: 3.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/schema-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/schema': 4.4.3
+      '@types/geojson': 7946.0.16
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/schema@4.4.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      apache-arrow: 21.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/terrain@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@mapbox/martini': 0.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/textures@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/worker-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/types': 4.1.0
+      ktx-parse: 0.7.1
+      texture-compressor: 1.0.2
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/tiles@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/math': 4.4.3(@loaders.gl/core@4.4.3)
+      '@math.gl/core': 4.1.0
+      '@math.gl/culling': 4.1.0
+      '@math.gl/geospatial': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@probe.gl/stats': 4.1.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/wms@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/images': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      '@loaders.gl/xml': 4.4.3(@loaders.gl/core@4.4.3)
+      '@turf/rewind': 5.1.5
+      deep-strict-equal: 0.2.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/worker-utils@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+
+  '@loaders.gl/xml@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/schema': 4.4.3
+      fast-xml-parser: 5.10.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@loaders.gl/zip@4.4.3(@loaders.gl/core@4.4.3)':
+    dependencies:
+      '@loaders.gl/compression': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/crypto': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/loader-utils': 4.4.3(@loaders.gl/core@4.4.3)
+      jszip: 3.10.1
+      md5: 2.3.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@luma.gl/core@9.3.6':
+    dependencies:
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+
+  '@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))':
+    dependencies:
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+
+  '@luma.gl/gltf@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/engine@9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)))(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))':
+    dependencies:
+      '@loaders.gl/core': 4.4.3
+      '@loaders.gl/gltf': 4.4.3(@loaders.gl/core@4.4.3)
+      '@loaders.gl/textures': 4.4.3(@loaders.gl/core@4.4.3)
+      '@luma.gl/core': 9.3.6
+      '@luma.gl/engine': 9.3.6(@luma.gl/core@9.3.6)(@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6))
+      '@luma.gl/shadertools': 9.3.6(@luma.gl/core@9.3.6)
+      '@math.gl/core': 4.1.0
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  '@luma.gl/shadertools@9.3.6(@luma.gl/core@9.3.6)':
+    dependencies:
+      '@luma.gl/core': 9.3.6
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@luma.gl/webgl@9.3.6(@luma.gl/core@9.3.6)':
+    dependencies:
+      '@luma.gl/core': 9.3.6
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/martini@0.2.0': {}
+
+  '@mapbox/point-geometry@0.1.0': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@1.3.1':
+    dependencies:
+      '@mapbox/point-geometry': 0.1.0
+
+  '@mapbox/vector-tile@2.0.5':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
+  '@math.gl/core@4.1.0':
+    dependencies:
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/culling@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/geospatial@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/polygon@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+
+  '@math.gl/sun@4.1.0': {}
+
+  '@math.gl/types@4.1.0': {}
+
+  '@math.gl/web-mercator@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+
+  '@nodable/entities@2.2.0': {}
+
+  '@one-ini/wasm@0.1.1': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.5
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@probe.gl/env@4.1.1': {}
+
+  '@probe.gl/log@4.1.1':
+    dependencies:
+      '@probe.gl/env': 4.1.1
+
+  '@probe.gl/stats@4.1.1': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@turf/boolean-clockwise@5.1.5':
+    dependencies:
+      '@turf/helpers': 5.1.5
+      '@turf/invariant': 5.2.0
+
+  '@turf/clone@5.1.5':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/helpers@5.1.5': {}
+
+  '@turf/invariant@5.2.0':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/meta@5.2.0':
+    dependencies:
+      '@turf/helpers': 5.1.5
+
+  '@turf/rewind@5.1.5':
+    dependencies:
+      '@turf/boolean-clockwise': 5.1.5
+      '@turf/clone': 5.1.5
+      '@turf/helpers': 5.1.5
+      '@turf/invariant': 5.2.0
+      '@turf/meta': 5.2.0
+
+  '@types/brotli@1.3.5':
+    dependencies:
+      '@types/node': 26.1.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
+
+  '@types/crypto-js@4.2.2': {}
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
+  '@types/offscreencanvas@2019.7.3': {}
+
+  '@types/pako@1.0.7': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.1
+
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0))(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.21(@types/node@26.1.1)(sass@1.101.0)
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@26.1.1)(sass@1.101.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.39':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.39
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.39':
+    dependencies:
+      '@vue/compiler-core': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/compiler-sfc@3.5.39':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.39
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.19
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.39':
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/devtools-api@6.6.4': {}
+
+  '@vue/language-core@3.3.7':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.39
+      '@vue/shared': 3.5.39
+      alien-signals: 3.2.1
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.5
+
+  '@vue/reactivity@3.5.39':
+    dependencies:
+      '@vue/shared': 3.5.39
+
+  '@vue/runtime-core@3.5.39':
+    dependencies:
+      '@vue/reactivity': 3.5.39
+      '@vue/shared': 3.5.39
+
+  '@vue/runtime-dom@3.5.39':
+    dependencies:
+      '@vue/reactivity': 3.5.39
+      '@vue/runtime-core': 3.5.39
+      '@vue/shared': 3.5.39
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.39
+      '@vue/shared': 3.5.39
+      vue: 3.5.39(typescript@5.9.3)
+
+  '@vue/shared@3.5.39': {}
+
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      js-beautify: 1.15.4
+      vue: 3.5.39(typescript@5.9.3)
+      vue-component-type-helpers: 3.3.7
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+
+  '@vueuse/core@4.11.2(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      '@vueuse/shared': 4.11.2(vue@3.5.39(typescript@5.9.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/shared@4.11.2(vue@3.5.39(typescript@5.9.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  a5-js@0.7.3:
+    dependencies:
+      gl-matrix: 3.4.4
+
+  abbrev@2.0.0: {}
+
+  alien-signals@3.2.1: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  anynum@1.0.1: {}
+
+  apache-arrow@21.1.0:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 24.13.3
+      command-line-args: 6.0.2
+      command-line-usage: 7.0.4
+      flatbuffers: 25.9.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@75lb/nature'
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  array-back@6.2.3: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1:
+    optional: true
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+    optional: true
+
+  buf-compare@1.0.1: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 26.1.1
+
+  carbon-components@10.58.15:
+    dependencies:
+      '@carbon/telemetry': 0.1.0
+      flatpickr: 4.6.1
+      lodash.debounce: 4.0.8
+      warning: 3.0.0
+
+  chai@6.2.2: {}
+
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  charenc@0.0.2: {}
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
+  command-line-args@6.0.2:
+    dependencies:
+      array-back: 6.2.3
+      find-replace: 5.0.2
+      lodash.camelcase: 4.3.0
+      typical: 7.3.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.3
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
+
+  commander@10.0.1: {}
+
+  commander@7.2.0: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  convert-source-map@2.0.0: {}
+
+  core-assert@0.2.1:
+    dependencies:
+      buf-compare: 1.0.1
+      is-error: 2.2.2
+
+  core-util-is@1.0.3: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  crypt@0.0.2: {}
+
+  csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  deep-strict-equal@0.2.0:
+    dependencies:
+      core-assert: 0.2.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
+  detect-libc@2.1.2:
+    optional: true
+
+  draco3d@1.5.7: {}
+
+  earcut@2.2.4: {}
+
+  earcut@3.2.3: {}
+
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.5
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  entities@7.0.1: {}
+
+  es-module-lexer@2.3.1: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  eslint-plugin-prettier-vue@4.2.0:
+    dependencies:
+      '@vue/compiler-sfc': 3.5.39
+      chalk: 4.1.2
+      prettier: 2.8.8
+      prettier-linter-helpers: 1.0.1
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-diff@1.3.0: {}
+
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.0:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.5
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fflate@0.7.4: {}
+
+  find-replace@5.0.2: {}
+
+  firebase@10.14.1:
+    dependencies:
+      '@firebase/analytics': 0.10.8(@firebase/app@0.10.13)
+      '@firebase/analytics-compat': 0.2.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/app': 0.10.13
+      '@firebase/app-check': 0.8.8(@firebase/app@0.10.13)
+      '@firebase/app-check-compat': 0.3.15(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/app-compat': 0.2.43
+      '@firebase/app-types': 0.9.2
+      '@firebase/auth': 1.7.9(@firebase/app@0.10.13)
+      '@firebase/auth-compat': 0.5.14(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)
+      '@firebase/data-connect': 0.1.0(@firebase/app@0.10.13)
+      '@firebase/database': 1.0.8
+      '@firebase/database-compat': 1.0.8
+      '@firebase/firestore': 4.7.3(@firebase/app@0.10.13)
+      '@firebase/firestore-compat': 0.3.38(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)
+      '@firebase/functions': 0.11.8(@firebase/app@0.10.13)
+      '@firebase/functions-compat': 0.3.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/installations': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/installations-compat': 0.2.9(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)
+      '@firebase/messaging': 0.12.12(@firebase/app@0.10.13)
+      '@firebase/messaging-compat': 0.2.12(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/performance': 0.6.9(@firebase/app@0.10.13)
+      '@firebase/performance-compat': 0.2.9(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/remote-config': 0.4.9(@firebase/app@0.10.13)
+      '@firebase/remote-config-compat': 0.2.9(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)
+      '@firebase/storage': 0.13.2(@firebase/app@0.10.13)
+      '@firebase/storage-compat': 0.3.12(@firebase/app-compat@0.2.43)(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)
+      '@firebase/util': 1.10.0
+      '@firebase/vertexai-preview': 0.0.4(@firebase/app-types@0.9.2)(@firebase/app@0.10.13)
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+
+  flatbuffers@25.9.23: {}
+
+  flatpickr@4.6.1: {}
+
+  flatpickr@4.6.13: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  gl-matrix@3.4.4: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  h3-js@4.5.0: {}
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 26.1.1
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  has-flag@4.0.0: {}
+
+  http-parser-js@0.5.10: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  idb@7.1.1: {}
+
+  ieee754@1.2.1: {}
+
+  image-size@0.7.5: {}
+
+  immediate@3.0.6: {}
+
+  immutable@5.1.9: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
+
+  internmap@2.0.3: {}
+
+  is-arrayish@0.3.4: {}
+
+  is-buffer@1.1.6: {}
+
+  is-error@2.2.2: {}
+
+  is-extglob@2.1.1:
+    optional: true
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+    optional: true
+
+  is-unsafe@2.0.0: {}
+
+  isarray@1.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.8
+      nopt: 7.2.1
+
+  js-cookie@3.0.8: {}
+
+  js-tokens@4.0.0: {}
+
+  json-bignum@0.0.3: {}
+
+  json-stringify-pretty-compact@4.0.0: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  kdbush@4.1.0: {}
+
+  ktx-parse@0.7.1: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash.debounce@4.0.8: {}
+
+  long@3.2.0: {}
+
+  long@5.3.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@10.4.3: {}
+
+  lz4js@0.2.0:
+    optional: true
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  mitt@3.0.1: {}
+
+  mjolnir.js@3.0.1: {}
+
+  muggle-string@0.4.1: {}
+
+  murmurhash-js@1.0.0: {}
+
+  nanoid@3.3.16: {}
+
+  node-addon-api@7.1.1:
+    optional: true
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
+  obug@2.1.3: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  pako@1.0.11: {}
+
+  path-browserify@1.0.1: {}
+
+  path-expression-matcher@1.6.2: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  pbf@3.3.0:
+    dependencies:
+      ieee754: 1.2.1
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  pinia@2.3.1(typescript@5.9.3)(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.39(typescript@5.9.3)
+      vue-demi: 0.14.10(vue@3.5.39(typescript@5.9.3))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  postcss@8.5.19:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  potpack@2.1.0: {}
+
+  prettier-linter-helpers@1.0.1:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@2.8.8: {}
+
+  process-nextick-args@2.0.1: {}
+
+  proto-list@1.2.4: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.1
+      long: 5.3.2
+
+  protocol-buffers-schema@3.6.1: {}
+
+  quickselect@3.0.0: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readdirp@5.0.0: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
+  robust-predicates@3.0.3: {}
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  rw@1.3.3: {}
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
+  sass@1.101.0:
+    dependencies:
+      chokidar: 5.0.0
+      immutable: 5.1.9
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+
+  semver@7.8.5: {}
+
+  setimmediate@1.0.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
+
+  snappyjs@0.6.1: {}
+
+  source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.3
+      wordwrapjs: 5.1.1
+
+  texture-compressor@1.0.2:
+    dependencies:
+      argparse: 1.0.10
+      image-size: 0.7.5
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyqueue@3.0.0: {}
+
+  tinyrainbow@3.1.0: {}
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  typical@7.3.0: {}
+
+  undici-types@7.18.2: {}
+
+  undici-types@8.3.0: {}
+
+  undici@6.19.7: {}
+
+  util-deprecate@1.0.2: {}
+
+  vite@5.4.21(@types/node@26.1.1)(sass@1.101.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.19
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 26.1.1
+      fsevents: 2.3.3
+      sass: 1.101.0
+
+  vitest@4.1.10(@types/node@26.1.1)(happy-dom@20.10.6)(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@5.4.21(@types/node@26.1.1)(sass@1.101.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 5.4.21(@types/node@26.1.1)(sass@1.101.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.1.1
+      happy-dom: 20.10.6
+    transitivePeerDependencies:
+      - msw
+
+  vscode-uri@3.1.0: {}
+
+  vue-component-type-helpers@3.3.7: {}
+
+  vue-demi@0.14.10(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.39(typescript@5.9.3)
+
+  vue-router@4.6.4(vue@3.5.39(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.39(typescript@5.9.3)
+
+  vue-tsc@3.3.7(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.3.7
+      typescript: 5.9.3
+
+  vue@3.5.39(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.39
+      '@vue/compiler-sfc': 3.5.39
+      '@vue/runtime-dom': 3.5.39
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@5.9.3))
+      '@vue/shared': 3.5.39
+    optionalDependencies:
+      typescript: 5.9.3
+
+  warning@3.0.0:
+    dependencies:
+      loose-envify: 1.4.0
+
+  websocket-driver@0.7.5:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
+
+  whatwg-mimetype@3.0.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wordwrapjs@5.1.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  ws@8.21.0: {}
+
+  xml-naming@0.3.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zstd-codec@0.1.5:
+    optional: true

--- a/socioprophet-web/client-vue/pnpm-workspace.yaml
+++ b/socioprophet-web/client-vue/pnpm-workspace.yaml
@@ -1,0 +1,26 @@
+allowBuilds:
+  '@carbon/colors': set this to true or false
+  '@carbon/feature-flags': set this to true or false
+  '@carbon/grid': set this to true or false
+  '@carbon/icon-helpers': set this to true or false
+  '@carbon/icons-vue': set this to true or false
+  '@carbon/layout': set this to true or false
+  '@carbon/motion': set this to true or false
+  '@carbon/styles': set this to true or false
+  '@carbon/themes': set this to true or false
+  '@carbon/type': set this to true or false
+  '@carbon/vue': set this to true or false
+  '@ibm/plex': set this to true or false
+  '@ibm/plex-mono': set this to true or false
+  '@ibm/plex-sans': set this to true or false
+  '@ibm/plex-sans-arabic': set this to true or false
+  '@ibm/plex-sans-devanagari': set this to true or false
+  '@ibm/plex-sans-hebrew': set this to true or false
+  '@ibm/plex-sans-thai': set this to true or false
+  '@ibm/plex-sans-thai-looped': set this to true or false
+  '@ibm/plex-serif': set this to true or false
+  '@parcel/watcher': set this to true or false
+  carbon-components: set this to true or false
+  esbuild: set this to true or false
+  protobufjs: set this to true or false
+  vue-demi: set this to true or false

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -117,6 +117,7 @@ export const DOMAIN_MENU: NavGroup[] = [
     items: [
       { label: 'Knowledge Graph', to: '/knowledge/graph' },
       { label: 'Search', to: '/data/search' },
+      { label: 'Discovery', to: '/discovery' },
       { label: 'Living Ontology', to: '/ontology' },
       { label: 'Noetica Chat', to: '/noetica' },
       { label: 'Research Capture', to: '/research' },
@@ -200,6 +201,26 @@ export const OPERATOR_SHORTCUTS: NavLeaf[] = [
 // / Code Search collected under SourceOS. Noetica Chat and HolographMe moved OUT to
 // user-facing places (Knowledge menu and the user dropdown).
 export const AGENT_COCKPIT: NavGroup[] = [
+  {
+    label: 'Studio',
+    to: '/studio',
+    items: [
+      { label: 'Notebooks', to: '/studio?section=notebooks' },
+      { label: 'Compute Plane', to: '/studio?section=compute' },
+      { label: 'Graph Explorer', to: '/studio?section=graph' },
+      { label: 'Query Console', to: '/studio?section=query' },
+      { label: 'Analytics', to: '/studio?section=analytics' },
+      { label: 'GraphRAG', to: '/studio?section=graphrag' },
+      { label: 'Resource Browser', to: '/studio?section=resource' },
+      { label: 'Reasoner', to: '/studio?section=reasoner' },
+      { label: 'Entity Resolution', to: '/studio?section=er' },
+      { label: 'Ontology', to: '/studio?section=ontology' },
+      { label: 'Experiments', to: '/studio?section=experiments' },
+      { label: 'Operations', to: '/studio?section=operations' },
+      { label: 'Governance', to: '/studio?section=governance' },
+      { label: 'Commons', to: '/studio?section=commons' },
+    ],
+  },
   {
     label: 'Infrastructure',
     to: '/agentic-os',

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -15,6 +15,8 @@ import WorkstationDeploy from './pages/WorkstationDeploy.vue';
 import WorkstationServices from './pages/WorkstationServices.vue';
 import WorkstationTerminal from './pages/WorkstationTerminal.vue';
 import ModelLabs from './pages/ModelLabs.vue';
+import Studio from './pages/Studio.vue';
+import Discovery from './pages/Discovery.vue';
 import DataSearch from './pages/DataSearch.vue';
 import KnowledgeGraph from './pages/KnowledgeGraph.vue';
 import ForgeImport from './pages/ForgeImport.vue';
@@ -100,7 +102,7 @@ const explicitRoutes = [
   { path: '/capability/entity-analytics', component: PeopleDirectory },
   { path: '/capability/sentiment-analytics', component: SocialSignals },
   { path: '/capability/ontology-epistemology', component: KnowledgeGraph },
-  { path: '/capability/economic-prophet', component: EconomySectorBoard },
+  { path: '/capability/economic-prophet', component: CausalValuation },
   { path: '/research', component: ResearchList },
   { path: '/professional-intelligence', component: ProfessionalIntelligence },
   { path: '/control-plane', component: ControlPlaneLifecycle },
@@ -119,6 +121,8 @@ const explicitRoutes = [
   { path: '/workstation/services', component: WorkstationServices },
   { path: '/workstation/terminal', component: WorkstationTerminal },
   { path: '/ai/labs', component: ModelLabs },
+  { path: '/studio', component: Studio },
+  { path: '/discovery', component: Discovery },
   { path: '/data/search', component: DataSearch },
   { path: '/knowledge/graph', component: KnowledgeGraph },
   { path: '/forge/import', component: ForgeImport },

--- a/socioprophet-web/client-vue/src/pages/AlgoTradingBoard.vue
+++ b/socioprophet-web/client-vue/src/pages/AlgoTradingBoard.vue
@@ -1,343 +1,233 @@
-<template>
-  <section class="at" aria-label="Algorithmic trading">
-    <SurfaceHeader :title="scope && !scope.isPrimary ? scope.label : 'Strategies'" :eyebrow="(scope && !scope.isPrimary) ? (scope.domain) : ''">
-      <template #badge><span class="at-pill">fixture</span></template>
-      <template #actions>
-        <div class="at-agg">
-        <span class="at-agg-k">Live NAV Δ</span><span class="at-num" :class="navClass">{{ signed(navDelta) }}%</span>
-        <span class="at-agg-k">Strategies</span><span class="at-num">{{ strategies.length }}</span>
-        <span class="at-agg-k">Live</span><span class="at-num">{{ liveCount }}</span>
-        </div>
-        <div class="at-filters">
-        <button v-for="s in statuses" :key="s" class="at-fbtn" :class="{ on: status === s }" @click="status = s">{{ s }}</button>
-        </div>
-      </template>
-    </SurfaceHeader>
-
-    <!-- Strategy Copilot — Robinhood-clean input, Claude-grade reasoning -->
-    <div class="at-copilot">
-      <span class="at-copilot-glyph">◇</span>
-      <input
-        v-model="copilotText"
-        class="at-copilot-input"
-        type="text"
-        spellcheck="false"
-        placeholder="Describe a strategy in plain English — e.g. buy semis on breakout with a 3% trailing stop…"
-        @keydown.enter="generateStrategy"
-      />
-      <button class="at-copilot-go" :disabled="!copilotText.trim() || generating" @click="generateStrategy">
-        {{ generating ? 'Generating…' : 'Generate strategy' }}
-      </button>
-    </div>
-    <div class="at-copilot-hints">
-      <span class="at-copilot-try">Try:</span>
-      <button v-for="ex in copilotExamples" :key="ex" class="at-copilot-chip" @click="copilotText = ex; generateStrategy()">{{ ex }}</button>
-      <span class="at-copilot-gov">Paper only · governed · not investment advice</span>
-    </div>
-
-    <SplitPane storage-key="algo-trading" label="strategies" :initial="360">
-      <template #list>
-      <!-- Strategy list -->
-      <div ref="listEl" class="at-list" aria-label="Strategies" @keydown="arrowRove($event, listEl, '.at-row')">
-        <p class="at-count">{{ results.length }} strateg{{ results.length === 1 ? 'y' : 'ies' }}</p>
-        <button v-for="s in results" :key="s.id" class="at-row" :class="{ on: s.id === selectedId }" @click="selectedId = s.id">
-          <div class="at-row-top">
-            <span class="at-klass" :class="s.klass">{{ s.klass }}</span>
-            <span class="at-status" :class="s.status">{{ s.status }}</span>
-          </div>
-          <div class="at-row-name">{{ s.name }}</div>
-          <div class="at-row-foot">
-            <span class="at-spark"><svg viewBox="0 0 120 26" preserveAspectRatio="none"><polyline :points="sparkPoints(s.equity, 120, 26)" fill="none" :stroke="s.returnPct >= 0 ? 'var(--up)' : 'var(--down)'" stroke-width="1.4" /></svg></span>
-            <span class="at-chg" :class="s.returnPct >= 0 ? 'up' : 'down'">{{ signed(s.returnPct) }}%</span>
-          </div>
-        </button>
-      </div>
-
-      <!-- Detail -->
-      </template>
-
-      <template #detail>
-      <article v-if="selected" class="at-detail" aria-label="Strategy detail">
-        <div class="at-ribbon">
-          <span class="at-ribbon-k">governance</span>
-          <span>risk-gated · paper routing to shared book</span>
-          <span class="at-ribbon-as">as of {{ asOfLabel }}</span>
-        </div>
-
-        <div class="at-actions">
-          <button class="at-route" type="button" @click="deployToBook">Route fills to book ▸</button>
-          <button class="at-ask" type="button" @click="askNoetica" title="Ask Noetica about this strategy">◇ Ask Noetica</button>
-          <RouterLink class="at-portlink" to="/capability/portfolios">Portfolio →</RouterLink>
-          <span v-if="deployMsg" class="at-deploymsg">{{ deployMsg }}</span>
-        </div>
-
-        <div class="at-d-head">
-          <div>
-            <div class="at-d-name">{{ selected.name }} <span class="at-status" :class="selected.status">{{ selected.status }}</span></div>
-            <div class="at-d-sub">{{ selected.klass }} · {{ selected.universe }}</div>
-          </div>
-          <div class="at-d-ret" :class="selected.returnPct >= 0 ? 'up' : 'down'">{{ signed(selected.returnPct) }}%<small>ann.</small></div>
-        </div>
-
-        <!-- Equity curve -->
-        <div class="at-chart">
-          <svg viewBox="0 0 720 150" preserveAspectRatio="none" role="img" aria-label="equity curve">
-            <defs>
-              <linearGradient :id="`atg-${selected.id}`" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" :stop-color="selected.returnPct >= 0 ? 'rgba(75,191,115,0.28)' : 'rgba(240,101,106,0.28)'" />
-                <stop offset="100%" stop-color="rgba(0,0,0,0)" />
-              </linearGradient>
-            </defs>
-            <polygon :points="areaPoints(selected.equity, 720, 150)" :fill="`url(#atg-${selected.id})`" />
-            <polyline :points="sparkPoints(selected.equity, 720, 150)" fill="none" :stroke="selected.returnPct >= 0 ? 'var(--up)' : 'var(--down)'" stroke-width="1.6" />
-          </svg>
-        </div>
-
-        <!-- Stats -->
-        <div class="at-stats">
-          <div class="at-stat"><span>Sharpe</span><strong>{{ selected.sharpe.toFixed(2) }}</strong></div>
-          <div class="at-stat"><span>Max drawdown</span><strong :class="'down'">{{ selected.maxDrawdownPct.toFixed(1) }}%</strong></div>
-          <div class="at-stat"><span>Win rate</span><strong>{{ selected.winRatePct }}%</strong></div>
-          <div class="at-stat"><span>Trades</span><strong>{{ selected.trades.toLocaleString() }}</strong></div>
-          <div class="at-stat"><span>Gross exposure</span><strong>{{ selected.exposurePct }}%</strong></div>
-        </div>
-
-        <p class="at-note">{{ selected.note }}</p>
-
-        <!-- Signals -->
-        <div class="at-signals">
-          <span v-for="(sig, i) in selected.signals" :key="i" class="at-sig" :class="sig.tone">{{ sig.label }}</span>
-        </div>
-
-        <!-- Recent fills -->
-        <div class="at-block">
-          <div class="at-block-h">Recent fills</div>
-          <div class="at-fills">
-            <div class="at-fill at-fill-head"><span>Symbol</span><span>Side</span><span class="r">Qty</span><span class="r">Price</span><span class="r">P&amp;L</span></div>
-            <button v-for="(f, i) in selected.fills" :key="i" class="at-fill" @click="openSymbol(f.symbol)">
-              <span class="at-sym">{{ f.symbol }}</span>
-              <span class="at-side" :class="f.side">{{ f.side }}</span>
-              <span class="r">{{ f.qty.toLocaleString() }}</span>
-              <span class="r">{{ f.price.toLocaleString() }}</span>
-              <span class="r" :class="f.pnlPct >= 0 ? 'up' : 'down'">{{ signed(f.pnlPct) }}%</span>
-            </button>
-          </div>
-        </div>
-      </article>
-      <div v-else class="at-detail empty">Select a strategy</div>
-      </template>
-    </SplitPane>
-  </section>
-</template>
-
 <script setup lang="ts">
+// Algorithmic Trading — REAL. Backtests run over real historical daily bars (algo-engine :8085,
+// Yahoo data); "author in plain English" maps NL → a strategy spec; "route fills to book" places
+// real paper orders into a live ledger with real mark-to-market P&L. No fixtures.
+import { ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import SurfaceHeader from '../components/SurfaceHeader.vue';
-import SplitPane from '../components/SplitPane.vue';
-import { ref, computed, watch } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
-import { strategies, asOf, type Strategy, type StrategyStatus, type StrategyClass } from '../data/algoTradingFixture';
-import { sparkPoints, areaPoints } from '../utils/sparkline';
 import { navScopeForPath } from '../config/cockpitNav';
-import { arrowRove } from '../utils/listKeys';
-import { usePortfolio } from '../stores/portfolio';
-import { useCockpit } from '../stores/cockpit';
-import { useSettings } from '../stores/settings';
-import { meshChatStream } from '../config/mesh';
+import {
+  listStrategies, runBacktest, strategyFromNl, paperState, placeOrder, resetPaper,
+  type Backtest, type StrategyDef, type PaperState,
+} from '../services/algoApi';
 
-const router = useRouter();
 const route = useRoute();
 const scope = computed(() => navScopeForPath(route.path));
-const portfolio = usePortfolio();
-const cockpit = useCockpit();
-const deployMsg = ref('');
 
-const statuses = ['all', 'live', 'paper', 'backtest', 'halted'] as const;
-const status = ref<(typeof statuses)[number]>('all');
-const selectedId = ref<string>(strategies[0]!.id);
-const listEl = ref<HTMLElement | null>(null);
+interface Row { id: string; name: string; klass: string; universe: string[]; bt: Backtest }
+const rows = ref<Row[]>([]);
+const catalog = ref<StrategyDef[]>([]);
+const selectedId = ref('');
+const selected = computed(() => rows.value.find((r) => r.id === selectedId.value) ?? rows.value[0]);
+const paper = ref<PaperState | null>(null);
+const nl = ref('');
+const busy = ref(false);
+const err = ref('');
+let seq = 0;
 
-// Copilot-generated (paper) strategies live above the fixture book.
-const genStrategies = ref<Strategy[]>([]);
-const pool = computed<Strategy[]>(() => [...genStrategies.value, ...strategies]);
-const results = computed<Strategy[]>(() =>
-  status.value === 'all' ? pool.value : pool.value.filter((s) => s.status === (status.value as StrategyStatus)),
-);
-const selected = computed<Strategy | undefined>(() => pool.value.find((s) => s.id === selectedId.value));
-watch(results, (r) => { if (!r.some((s) => s.id === selectedId.value) && r[0]) selectedId.value = r[0].id; });
-
-const liveCount = strategies.filter((s) => s.status === 'live').length;
-// Aggregate "NAV Δ" = mean of live strategies' latest equity-curve step.
-const navDelta = computed(() => {
-  const live = strategies.filter((s) => s.status === 'live');
-  const last = live.map((s) => { const e = s.equity; return e.length > 1 ? ((e[e.length - 1]! - e[e.length - 2]!) / e[e.length - 2]!) * 100 : 0; });
-  return Math.round((last.reduce((a, b) => a + b, 0) / (last.length || 1)) * 100) / 100;
-});
-const navClass = computed(() => (navDelta.value > 0 ? 'up' : navDelta.value < 0 ? 'down' : 'flat'));
-
-function signed(n: number): string { return `${n >= 0 ? '+' : ''}${n}`; }
-// Single-ticker fills deep-link into the market monitor; pairs/baskets don't map.
-function openSymbol(sym: string) { if (!/[/]/.test(sym)) router.push({ path: '/markets/indices-funds', query: { sym } }); }
-
-const asOfLabel = new Date(asOf).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
-
-// ── Strategy Copilot — describe an algo in plain English; the mesh writes the rationale ──
-const settings = useSettings();
-const copilotText = ref('');
-const generating = ref(false);
-const copilotExamples = [
+const DEFAULTS = [
+  { name: 'Semis Momentum', strategy: 'momentum', universe: ['NVDA', 'AMD', 'AVGO', 'INTC', 'MU', 'QCOM'] },
+  { name: 'Megacap Mean-Reversion', strategy: 'mean_reversion', universe: ['AAPL', 'MSFT', 'GOOGL', 'AMZN', 'META', 'NVDA'] },
+  { name: 'Index Trend', strategy: 'trend', universe: ['SPY', 'QQQ', 'IWM', 'DIA'] },
+  { name: 'Semis Market-Neutral', strategy: 'market_neutral', universe: ['NVDA', 'AMD', 'AVGO', 'INTC', 'MU', 'QCOM'] },
+];
+const EXAMPLES = [
   'Buy semis on breakout, 3% trailing stop',
   'Mean-reversion on oversold megacaps (RSI < 30)',
   'Market-neutral: long quality, short high-beta',
 ];
-function pickClass(t: string): StrategyClass {
-  const s = t.toLowerCase();
-  if (/rsi|revert|revers|oversold|dip|mean/.test(s)) return 'mean-reversion';
-  if (/pairs|neutral|hedge|long.?short/.test(s)) return 'market-neutral';
-  if (/trend|macd|moving average|ma cross/.test(s)) return 'trend';
-  if (/arb|spread|basis/.test(s)) return 'stat-arb';
-  return 'momentum';
-}
-function genCurve(seed: number, n = 40): number[] {
-  const out: number[] = []; let v = 100; let r = seed;
-  const rand = () => { r = (r * 1103515245 + 12345) & 0x7fffffff; return r / 0x7fffffff; };
-  const drift = 0.15 + rand() * 0.5;
-  for (let i = 0; i < n; i++) { v += drift + (rand() - 0.5) * 2.2; out.push(Math.round(v * 100) / 100); }
-  return out;
-}
-function tickersIn(t: string): string { const m = t.toUpperCase().match(/\b[A-Z]{2,5}\b/g); return m ? m.slice(0, 3).join(', ') : 'US equities'; }
+const CLASS_LABEL: Record<string, string> = { momentum: 'MOMENTUM', mean_reversion: 'MEAN-REVERSION', trend: 'TREND', market_neutral: 'MARKET-NEUTRAL' };
 
-async function generateStrategy() {
-  const text = copilotText.value.trim();
-  if (!text || generating.value) return;
-  generating.value = true;
-  const seed = Math.floor(Math.random() * 1e6);
-  const equity = genCurve(seed);
-  const klass = pickClass(text);
-  const s: Strategy = {
-    id: 'gen-' + seed,
-    name: text.length > 42 ? text.slice(0, 42) + '…' : text,
-    klass, status: 'paper', universe: tickersIn(text),
-    returnPct: Math.round((equity[equity.length - 1]! - 100) * 10) / 10,
-    sharpe: Math.round((0.6 + Math.random() * 1.6) * 100) / 100,
-    maxDrawdownPct: -Math.round((3 + Math.random() * 14) * 10) / 10,
-    winRatePct: 48 + Math.floor(Math.random() * 18),
-    trades: 40 + Math.floor(Math.random() * 400),
-    exposurePct: 40 + Math.floor(Math.random() * 60),
-    equity,
-    signals: [{ label: 'generated', tone: 'neutral' }, { label: klass, tone: 'up' }],
-    fills: [],
-    note: 'Generating rationale…',
-  };
-  genStrategies.value = [s, ...genStrategies.value];
-  selectedId.value = s.id;
-  copilotText.value = '';
+async function addBacktest(name: string, strategy: string, universe: string[], params: Record<string, any> = {}) {
+  const bt = await runBacktest({ strategy, universe, lookback_days: 400, params });
+  if (!bt.ok) throw new Error(bt.error || 'backtest failed');
+  const id = `bt-${++seq}`;
+  rows.value.unshift({ id, name, klass: CLASS_LABEL[strategy] ?? strategy, universe: bt.universe, bt });
+  selectedId.value = id;
+}
+async function loadAll() {
+  busy.value = true; err.value = '';
   try {
-    if (settings.meshChat) {
-      s.note = '';
-      await meshChatStream(
-        [{ role: 'user', content: `You are a quant strategy copilot. In 2-3 sentences, explain this trading strategy and its main risk. Paper-trading only, NOT investment advice.\n\nStrategy: "${text}"` }],
-        (d) => { s.note += d; },
-      );
-    } else {
-      s.note = `Paper strategy synthesized from your description (${klass}, ${s.universe}). Turn on Prophet Cloud Mesh in Settings → Connections for a live AI rationale. Advisory only — not investment advice.`;
-    }
-  } catch (e) {
-    s.note = `Paper strategy (${klass}). AI rationale unavailable: ${e instanceof Error ? e.message : 'mesh error'}. Not investment advice.`;
-  } finally {
-    generating.value = false;
-  }
+    catalog.value = (await listStrategies()).strategies;
+    for (const d of DEFAULTS) { try { await addBacktest(d.name, d.strategy, d.universe); } catch { /* skip a failed name */ } }
+    rows.value.reverse();
+    selectedId.value = rows.value[0]?.id ?? '';
+    paper.value = await paperState();
+  } catch (e) { err.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; }
 }
+onMounted(loadAll);
 
-// ── Integration: route a strategy's fills into the SHARED portfolio book ──
-function deployToBook() {
-  const s = selected.value;
-  if (!s) return;
-  let ok = 0;
-  let skipped = 0;
-  for (const f of s.fills) {
-    if (/[/]/.test(f.symbol)) { skipped += 1; continue; } // pairs/baskets don't map to a single position
-    const side = /sell|short/i.test(f.side) ? 'sell' : 'buy';
-    if (portfolio.placeOrder({ symbol: f.symbol, name: f.symbol, side, qty: f.qty, price: f.price, source: `algo:${s.id}` }).ok) ok += 1;
-    else skipped += 1;
-  }
-  deployMsg.value = ok
-    ? `Routed ${ok} fill(s) from ${s.name} to your Portfolio${skipped ? ` · ${skipped} skipped` : ''}.`
-    : 'No routable single-ticker fills (pairs/baskets or risk-gated).';
+async function author(text?: string) {
+  const t = (text ?? nl.value).trim(); if (!t) return;
+  busy.value = true; err.value = '';
+  try { const spec = await strategyFromNl(t); await addBacktest(spec.name, spec.strategy, spec.universe, spec.params); nl.value = ''; }
+  catch (e) { err.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; }
 }
-function askNoetica() {
-  const s = selected.value;
-  if (!s) return;
-  cockpit.askAbout(`Assess the "${s.name}" strategy (${s.klass}, ${s.status}): return ${signed(s.returnPct)}%, Sharpe ${s.sharpe}, max drawdown ${s.maxDrawdownPct}%, win rate ${s.winRatePct}%. Is the risk acceptable, and would you allocate?`);
+async function routeToBook() {
+  const s = selected.value; if (!s) return;
+  busy.value = true; err.value = '';
+  try {
+    const sleeve = 250_000;
+    for (const f of s.bt.fills) {
+      const qty = Math.max(1, Math.round((Math.abs(f.weight_delta) * sleeve) / f.price));
+      await placeOrder({ symbol: f.symbol, side: f.side, qty, price: f.price });
+    }
+    paper.value = await paperState();
+  } catch (e) { err.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; }
 }
-watch(selected, (s) => {
-  if (s) cockpit.setContext({ surface: 'Algorithmic Trading', entityLabel: s.name, detail: `${signed(s.returnPct)}% · ${s.status}`, route: route.path });
-}, { immediate: true });
+async function resetBook() { paper.value = await resetPaper(); }
+
+function poly(curve: number[], w: number, h: number): string {
+  if (curve.length < 2) return '';
+  const min = Math.min(...curve), max = Math.max(...curve), rng = max - min || 1;
+  return curve.map((v, i) => `${((i / (curve.length - 1)) * w).toFixed(1)},${(h - ((v - min) / rng) * h).toFixed(1)}`).join(' ');
+}
+const pct = (x: number) => (x * 100).toFixed(1) + '%';
+const signed = (x: number) => (x >= 0 ? '+' : '') + (x * 100).toFixed(1) + '%';
+const money = (x: number) => '$' + Math.round(x).toLocaleString();
 </script>
 
+<template>
+  <section class="at" aria-label="Algorithmic trading">
+    <SurfaceHeader :title="scope && !scope.isPrimary ? scope.label : 'Algorithmic Trading'" :eyebrow="scope && !scope.isPrimary ? scope.domain : 'Capital & Markets'">
+      <template #badge><span class="at-pill live">live</span></template>
+      <template #actions>
+        <div class="at-agg" v-if="paper">
+          <span class="at-agg-k">Paper equity</span><span class="at-num">{{ money(paper.equity) }}</span>
+          <span class="at-agg-k">Unrealized P&amp;L</span><span class="at-num" :class="paper.unrealized_pnl >= 0 ? 'up' : 'down'">{{ paper.unrealized_pnl >= 0 ? '+' : '' }}{{ money(paper.unrealized_pnl) }}</span>
+          <span class="at-agg-k">Strategies</span><span class="at-num">{{ rows.length }}</span>
+        </div>
+      </template>
+    </SurfaceHeader>
+
+    <div class="at-copilot">
+      <span class="at-glyph">◇</span>
+      <input v-model="nl" class="at-input" placeholder="Describe a strategy in plain English — e.g. buy semis on breakout with a 3% trailing stop" @keyup.enter="author()" />
+      <button class="at-gen" :disabled="busy || !nl.trim()" @click="author()">{{ busy ? 'Working…' : 'Author &amp; backtest' }}</button>
+    </div>
+    <div class="at-examples">
+      <span class="at-try">Try</span>
+      <button v-for="e in EXAMPLES" :key="e" class="at-chip" @click="author(e)">{{ e }}</button>
+      <span class="at-adv">Paper · governed · real historical backtest · not investment advice</span>
+    </div>
+    <p v-if="err" class="at-err">{{ err }}</p>
+
+    <div class="at-grid">
+      <aside class="at-list">
+        <div class="at-list-h">{{ rows.length }} strategies · backtested</div>
+        <button v-for="r in rows" :key="r.id" class="at-scard" :class="{ on: r.id === selectedId }" @click="selectedId = r.id">
+          <div class="at-scard-top"><span class="at-klass">{{ r.klass }}</span><span class="at-ret" :class="r.bt.metrics.total_return >= 0 ? 'up' : 'down'">{{ signed(r.bt.metrics.total_return) }}</span></div>
+          <div class="at-sname">{{ r.name }}</div>
+          <svg class="at-mini" viewBox="0 0 120 30" preserveAspectRatio="none"><polyline :points="poly(r.bt.equity_curve, 120, 30)" fill="none" :stroke="r.bt.metrics.total_return >= 0 ? 'var(--up)' : 'var(--down)'" stroke-width="1.5" /></svg>
+          <div class="at-scard-sub">Sharpe {{ r.bt.metrics.sharpe }} · {{ r.universe.length }} names</div>
+        </button>
+        <div v-if="busy && !rows.length" class="at-empty">Running real backtests…</div>
+      </aside>
+
+      <div class="at-detail" v-if="selected">
+        <div class="at-d-head">
+          <div>
+            <div class="at-d-name">{{ selected.name }} <span class="at-pill live">backtested</span></div>
+            <div class="at-d-sub">{{ selected.klass.toLowerCase() }} · {{ selected.universe.join(', ') }} · as of {{ selected.bt.as_of }}</div>
+          </div>
+          <div class="at-d-ret" :class="selected.bt.metrics.total_return >= 0 ? 'up' : 'down'">{{ signed(selected.bt.metrics.total_return) }}</div>
+        </div>
+        <svg class="at-equity" viewBox="0 0 680 150" preserveAspectRatio="none">
+          <polyline :points="poly(selected.bt.equity_curve, 680, 150)" fill="none" :stroke="selected.bt.metrics.total_return >= 0 ? 'var(--up)' : 'var(--down)'" stroke-width="2" />
+        </svg>
+        <div class="at-metrics">
+          <div><span class="at-m-k">Sharpe</span><span class="at-m-v">{{ selected.bt.metrics.sharpe }}</span></div>
+          <div><span class="at-m-k">Max Drawdown</span><span class="at-m-v down">{{ pct(selected.bt.metrics.max_drawdown) }}</span></div>
+          <div><span class="at-m-k">Win Rate</span><span class="at-m-v">{{ pct(selected.bt.metrics.win_rate) }}</span></div>
+          <div><span class="at-m-k">CAGR</span><span class="at-m-v">{{ pct(selected.bt.metrics.cagr) }}</span></div>
+          <div><span class="at-m-k">Ann. Vol</span><span class="at-m-v">{{ pct(selected.bt.metrics.vol) }}</span></div>
+          <div><span class="at-m-k">Gross Exposure</span><span class="at-m-v">{{ (selected.bt.gross_exposure * 100).toFixed(0) }}%</span></div>
+        </div>
+        <div class="at-run">
+          <button class="at-route" :disabled="busy || !selected.bt.fills.length" @click="routeToBook">Route fills to paper book →</button>
+          <span class="at-prov">{{ selected.bt.provenance.data_source }} · {{ selected.bt.provenance.bars_per_name }} bars/name · not investment advice</span>
+        </div>
+        <div class="at-fills" v-if="selected.bt.fills.length">
+          <div class="at-fills-h">Target rebalance · latest bar</div>
+          <table class="at-tbl">
+            <thead><tr><th>Symbol</th><th>Side</th><th>Δ weight</th><th>Price</th></tr></thead>
+            <tbody><tr v-for="(f, i) in selected.bt.fills" :key="i"><td>{{ f.symbol }}</td><td><span class="at-side" :class="f.side.toLowerCase()">{{ f.side }}</span></td><td>{{ (f.weight_delta * 100).toFixed(1) }}%</td><td>{{ f.price }}</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="at-book" v-if="paper">
+      <div class="at-book-h">
+        <span class="at-book-t">Paper book</span>
+        <span class="at-book-eq">Equity {{ money(paper.equity) }} · P&amp;L <b :class="paper.unrealized_pnl >= 0 ? 'up' : 'down'">{{ paper.unrealized_pnl >= 0 ? '+' : '' }}{{ money(paper.unrealized_pnl) }}</b> · Cash {{ money(paper.cash) }}</span>
+        <button class="at-reset" @click="resetBook">Reset</button>
+      </div>
+      <table class="at-tbl" v-if="paper.positions.length">
+        <thead><tr><th>Symbol</th><th>Qty</th><th>Price</th><th>Market value</th></tr></thead>
+        <tbody><tr v-for="p in paper.positions" :key="p.symbol"><td>{{ p.symbol }}</td><td>{{ p.qty }}</td><td>{{ p.price }}</td><td>{{ money(p.market_value) }}</td></tr></tbody>
+      </table>
+      <p v-else class="at-empty">No paper positions yet — route a strategy's fills to the book.</p>
+    </div>
+  </section>
+</template>
+
 <style scoped>
-.at { height: 100%; min-height: 0; display: grid; grid-template-rows: auto 1fr; gap: 0.75rem; padding: 0.85rem 1rem 1rem; background: var(--bg); color: var(--text); }
-.at-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
-.at-title { display: flex; align-items: baseline; gap: 0.6rem; } .at-title h1 { margin: 0; font-size: 1.2rem; letter-spacing: -0.01em; color: var(--text); font-weight: 640; }
-.at-eyebrow { margin: 0 0 0.1rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); }
-.at-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); background: var(--accent-soft); border-radius: 5px; padding: 0.1rem 0.35rem; }
-.at-agg { display: flex; align-items: center; gap: 0.5rem; font-size: 0.72rem; color: var(--text-3); } .at-agg-k { text-transform: uppercase; letter-spacing: 0.05em; }
-.at-agg .at-num { color: var(--text); font-variant-numeric: tabular-nums; margin-right: 0.4rem; } .at-agg .at-num.up { color: var(--up); } .at-agg .at-num.down { color: var(--down); }
-.at-filters { display: flex; gap: 0.25rem; }
-.at-fbtn { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 8px; padding: 0.3rem 0.6rem; font-size: 0.74rem; text-transform: capitalize; cursor: pointer; } .at-fbtn.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
-
-.at-body { min-height: 0; display: grid; grid-template-columns: minmax(280px, 0.8fr) minmax(420px, 1.4fr); gap: 0.75rem; }
-@media (max-width: 1080px) { .at-body { grid-template-columns: 1fr; } .at-detail { display: none; } }
-
-.at-list { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; }
-.at-count { margin: 0; padding: 0.5rem 0.85rem; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); border-bottom: 1px solid var(--line); }
-.at-row { width: 100%; display: grid; gap: 0.3rem; border: none; border-bottom: 1px solid var(--line); background: transparent; color: inherit; padding: 0.6rem 0.85rem; cursor: pointer; text-align: left; } .at-row:hover { background: var(--surface-2); } .at-row.on { background: var(--accent-soft); box-shadow: inset 3px 0 0 var(--accent); }
-.at-row-top { display: flex; align-items: center; gap: 0.4rem; }
-.at-row-name { font-size: 0.9rem; font-weight: 600; }
-.at-row-foot { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }
-.at-spark { width: 120px; height: 26px; } .at-spark svg { width: 100%; height: 100%; display: block; }
-.at-chg { font-size: 0.82rem; font-variant-numeric: tabular-nums; font-weight: 600; } .at-chg.up { color: var(--up); } .at-chg.down { color: var(--down); }
-
-.at-actions { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin: 0.6rem 0 0.2rem; }
-.at-route { border: none; border-radius: 8px; padding: 0.4rem 0.9rem; font-size: 0.78rem; font-weight: 700; cursor: pointer; background: var(--up); color: #06210f; } .at-route:hover { filter: brightness(1.08); }
-.at-ask { border: 1px solid rgba(120, 160, 255, 0.45); background: rgba(120, 160, 255, 0.08); color: #93b4ff; border-radius: 8px; padding: 0.4rem 0.7rem; font-size: 0.76rem; cursor: pointer; } .at-ask:hover { background: rgba(120, 160, 255, 0.16); color: #fff; }
-.at-portlink { color: var(--accent); text-decoration: none; font-size: 0.76rem; align-self: center; } .at-portlink:hover { text-decoration: underline; }
-.at-deploymsg { font-size: 0.72rem; color: var(--text-2); }
-.at-klass, .at-status, .at-sig, .at-side { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; }
-.at-klass { color: #93c5fd; background: rgba(88, 166, 255, 0.14); }
-.at-status { margin-left: auto; }
-.at-status.live { color: var(--up); background: rgba(75, 191, 115, 0.16); } .at-status.paper { color: var(--accent); background: rgba(216, 162, 80, 0.16); } .at-status.backtest { color: #93c5fd; background: rgba(88, 166, 255, 0.14); } .at-status.halted { color: var(--down); background: rgba(240, 101, 106, 0.16); }
-.at-d-head .at-status { margin-left: 0; }
-
-.at-detail { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; padding: 0 1.1rem 1.1rem; }
-.at-detail.empty { display: grid; place-items: center; color: var(--text-3); font-size: 0.85rem; padding: 1.1rem; }
-.at-ribbon { display: flex; align-items: center; gap: 0.6rem; margin: 0 -1.1rem 0.9rem; padding: 0.4rem 1.1rem; background: var(--accent-soft); border-bottom: 1px solid var(--line-2); font-size: 0.7rem; color: var(--text-2); }
-.at-ribbon-k { text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); font-weight: 700; font-size: 0.6rem; } .at-ribbon-as { margin-left: auto; color: var(--text-3); }
-.at-d-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-top: 0.9rem; }
-.at-d-name { font-size: 1.25rem; font-weight: 640; display: flex; align-items: center; gap: 0.5rem; } .at-d-sub { font-size: 0.78rem; color: var(--text-3); margin-top: 0.15rem; text-transform: capitalize; }
-.at-d-ret { font-size: 1.6rem; font-weight: 700; font-variant-numeric: tabular-nums; } .at-d-ret small { font-size: 0.62rem; font-weight: 600; color: var(--text-3); margin-left: 0.25rem; } .at-d-ret.up { color: var(--up); } .at-d-ret.down { color: var(--down); }
-.at-chart { margin: 0.9rem 0; height: 150px; } .at-chart svg { width: 100%; height: 100%; display: block; }
-.at-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 0.5rem; }
-.at-stat { border: 1px solid var(--line); border-radius: 9px; padding: 0.5rem 0.65rem; background: var(--surface-2); } .at-stat span { display: block; font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-3); } .at-stat strong { font-size: 1.05rem; font-variant-numeric: tabular-nums; font-weight: 660; } .at-stat strong.down { color: var(--down); }
-.at-note { margin: 0.9rem 0 0; font-size: 0.86rem; line-height: 1.6; color: var(--text-2); }
-.at-signals { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.7rem; }
-.at-sig.up { color: var(--up); background: rgba(75, 191, 115, 0.14); } .at-sig.down { color: var(--down); background: rgba(240, 101, 106, 0.14); } .at-sig.neutral { color: var(--text-2); background: rgba(255, 255, 255, 0.05); }
-.at-block { margin-top: 1rem; border-top: 1px solid var(--line-2); padding-top: 0.85rem; }
-.at-block-h { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); margin-bottom: 0.6rem; }
-.at-fills { display: grid; }
-.at-fill { display: grid; grid-template-columns: 1.4fr 0.7fr 0.9fr 1fr 0.8fr; align-items: center; gap: 0.5rem; border: none; background: transparent; color: inherit; padding: 0.4rem 0.35rem; border-bottom: 1px solid var(--line); font-size: 0.8rem; cursor: pointer; text-align: left; font-variant-numeric: tabular-nums; } .at-fill:hover:not(.at-fill-head) { background: var(--surface-2); }
-.at-fill .r { text-align: right; } .at-fill .r.up { color: var(--up); } .at-fill .r.down { color: var(--down); }
-.at-fill-head { color: var(--text-3); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; cursor: default; }
-.at-sym { font-family: ui-monospace, monospace; font-weight: 600; }
-.at-side.buy { color: var(--up); background: rgba(75, 191, 115, 0.14); justify-self: start; } .at-side.sell { color: var(--down); background: rgba(240, 101, 106, 0.14); justify-self: start; }
-.at-copilot { display: flex; align-items: center; gap: 0.6rem; margin: 0.5rem 0 0.4rem; padding: 0.6rem 0.9rem; background: var(--surface); border: 1px solid var(--line-2); border-radius: 12px; }
-.at-copilot-glyph { color: var(--accent); font-size: 1.05rem; }
-.at-copilot-input { flex: 1; background: transparent; border: none; outline: none; color: var(--text); font-size: 0.95rem; }
-.at-copilot-input::placeholder { color: var(--text-3); }
-.at-copilot-go { border: none; background: var(--accent); color: #17130a; border-radius: 8px; padding: 0.45rem 0.9rem; font-size: 0.82rem; font-weight: 700; cursor: pointer; white-space: nowrap; }
-.at-copilot-go:disabled { opacity: 0.5; cursor: default; }
-.at-copilot-hints { display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 0.6rem; }
-.at-copilot-try { font-size: 0.74rem; color: var(--text-3); }
-.at-copilot-chip { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 999px; padding: 0.2rem 0.6rem; font-size: 0.74rem; cursor: pointer; }
-.at-copilot-chip:hover { color: var(--accent); border-color: var(--accent); }
-.at-copilot-gov { margin-left: auto; font-size: 0.72rem; color: var(--text-3); }
+.at { padding: 1rem 1.25rem; max-width: 1180px; margin: 0 auto; color: var(--text); }
+.at-pill { font-size: .62rem; text-transform: uppercase; letter-spacing: .05em; padding: .1rem .45rem; border-radius: 999px; border: 1px solid var(--line-2); color: var(--text-2); }
+.at-pill.live { color: var(--up); border-color: rgba(75,191,115,.4); background: rgba(75,191,115,.12); }
+.at-agg { display: flex; align-items: center; gap: .5rem; font-size: .78rem; }
+.at-agg-k { color: var(--text-3); text-transform: uppercase; font-size: .62rem; letter-spacing: .06em; }
+.at-num { font-weight: 700; } .up { color: var(--up); } .down { color: var(--down); }
+.at-copilot { display: flex; align-items: center; gap: .6rem; border: 1px solid var(--line-2); background: var(--surface); border-radius: 12px; padding: .5rem .7rem; margin: 1rem 0 .5rem; }
+.at-glyph { color: var(--accent); }
+.at-input { flex: 1; background: transparent; border: 0; color: var(--text); font-size: .9rem; outline: none; }
+.at-gen { background: var(--accent); color: #1a1204; border: 0; border-radius: 8px; padding: .45rem .9rem; font-weight: 700; cursor: pointer; }
+.at-gen:disabled { opacity: .5; cursor: default; }
+.at-examples { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; margin-bottom: .4rem; }
+.at-try { color: var(--text-3); font-size: .74rem; }
+.at-chip { background: var(--surface-2); border: 1px solid var(--line); color: var(--text-2); border-radius: 999px; padding: .2rem .6rem; font-size: .74rem; cursor: pointer; }
+.at-chip:hover { border-color: var(--accent); color: var(--text); }
+.at-adv { margin-left: auto; color: var(--text-3); font-size: .72rem; }
+.at-err { color: var(--down); font-size: .82rem; }
+.at-grid { display: grid; grid-template-columns: 300px 1fr; gap: 1rem; margin-top: .6rem; }
+.at-list { display: flex; flex-direction: column; gap: .5rem; }
+.at-list-h { color: var(--text-3); font-size: .68rem; text-transform: uppercase; letter-spacing: .06em; }
+.at-scard { text-align: left; border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .6rem .7rem; cursor: pointer; color: var(--text); }
+.at-scard.on { border-color: var(--accent); background: var(--accent-soft); }
+.at-scard-top { display: flex; justify-content: space-between; align-items: center; }
+.at-klass { font-size: .6rem; letter-spacing: .06em; color: var(--text-3); }
+.at-ret { font-weight: 700; font-size: .82rem; }
+.at-sname { font-weight: 650; margin: .15rem 0; }
+.at-mini { width: 100%; height: 30px; display: block; }
+.at-scard-sub { color: var(--text-3); font-size: .72rem; }
+.at-detail { border: 1px solid var(--line-2); border-radius: 14px; background: var(--surface); padding: 1rem 1.1rem; }
+.at-d-head { display: flex; justify-content: space-between; align-items: flex-start; }
+.at-d-name { font-size: 1.15rem; font-weight: 700; display: flex; align-items: center; gap: .5rem; }
+.at-d-sub { color: var(--text-3); font-size: .78rem; margin-top: .1rem; }
+.at-d-ret { font-size: 1.6rem; font-weight: 800; }
+.at-equity { width: 100%; height: 150px; display: block; margin: .8rem 0; }
+.at-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: .6rem; }
+.at-metrics > div { display: flex; flex-direction: column; border: 1px solid var(--line); border-radius: 10px; padding: .5rem .6rem; }
+.at-m-k { color: var(--text-3); font-size: .64rem; text-transform: uppercase; letter-spacing: .05em; }
+.at-m-v { font-size: 1.05rem; font-weight: 700; }
+.at-run { display: flex; align-items: center; gap: .8rem; margin: .9rem 0 .3rem; flex-wrap: wrap; }
+.at-route { background: var(--up); color: #05271c; border: 0; border-radius: 8px; padding: .5rem .9rem; font-weight: 700; cursor: pointer; }
+.at-route:disabled { opacity: .5; cursor: default; }
+.at-prov { color: var(--text-3); font-size: .72rem; }
+.at-fills-h, .at-book-t { color: var(--text-3); font-size: .68rem; text-transform: uppercase; letter-spacing: .06em; margin: .6rem 0 .3rem; }
+.at-tbl { width: 100%; border-collapse: collapse; font-size: .82rem; }
+.at-tbl th { text-align: left; color: var(--text-3); font-weight: 500; border-bottom: 1px solid var(--line-2); padding: .35rem .4rem; }
+.at-tbl td { border-bottom: 1px solid var(--line); padding: .35rem .4rem; }
+.at-side { font-size: .64rem; font-weight: 700; padding: .05rem .4rem; border-radius: 4px; }
+.at-side.buy { color: var(--up); background: rgba(75,191,115,.14); } .at-side.sell { color: var(--down); background: rgba(240,101,106,.14); }
+.at-book { border: 1px solid var(--line-2); border-radius: 14px; background: var(--surface); padding: .8rem 1rem; margin-top: 1rem; }
+.at-book-h { display: flex; align-items: center; gap: .8rem; }
+.at-book-eq { font-size: .84rem; color: var(--text-2); } .at-book-eq b { font-weight: 700; }
+.at-reset { margin-left: auto; background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text-2); border-radius: 8px; padding: .3rem .7rem; cursor: pointer; font-size: .78rem; }
+.at-empty { color: var(--text-3); font-size: .82rem; padding: .5rem 0; }
+@media (max-width: 900px) { .at-grid { grid-template-columns: 1fr; } }
 </style>

--- a/socioprophet-web/client-vue/src/pages/CausalValuation.vue
+++ b/socioprophet-web/client-vue/src/pages/CausalValuation.vue
@@ -98,11 +98,11 @@ function money(n: number, c = 'AUD') {
 }
 const bounds = (p: string) => (p === 'lower_better' ? { min: -20, max: 0 } : { min: 0, max: 40 });
 
-const nodeById = computed(() => new Map((cv.value?.causal_graph.nodes ?? []).map((n) => [n.id, n])));
-const supplyNodes = computed(() => (cv.value?.causal_graph.nodes ?? []).filter((n) => n.labels.includes('SupplyChainNode')));
-const causalEdges = computed(() => (cv.value?.causal_graph.edges ?? []).filter((e) => ['CAUSES', 'CONSTRAINS', 'REDUCES'].includes(e.label)));
-const kpis = computed(() => [...(cv.value?.vdt.per_kpi_contribution ?? [])].sort((a, b) => b.value_contribution - a.value_contribution));
-const drivers = computed(() => Object.entries(cv.value?.vdt.per_driver_uplift ?? {}).sort((a, b) => b[1] - a[1]));
+const nodeById = computed(() => new Map((cv.value?.causal_graph?.nodes ?? []).map((n) => [n.id, n])));
+const supplyNodes = computed(() => (cv.value?.causal_graph?.nodes ?? []).filter((n) => (n.labels ?? []).includes('SupplyChainNode')));
+const causalEdges = computed(() => (cv.value?.causal_graph?.edges ?? []).filter((e) => ['CAUSES', 'CONSTRAINS', 'REDUCES'].includes(e.label)));
+const kpis = computed(() => [...(cv.value?.vdt?.per_kpi_contribution ?? [])].sort((a, b) => b.value_contribution - a.value_contribution));
+const drivers = computed(() => Object.entries(cv.value?.vdt?.per_driver_uplift ?? {}).sort((a, b) => b[1] - a[1]));
 const maxContribution = computed(() => Math.max(1, ...kpis.value.map((k) => k.value_contribution)));
 function drivenBy(id: string) {
   return causalEdges.value.filter((e) => e.from === id).map((e) => ({ kpi: nodeById.value.get(e.to)?.properties?.name ?? e.to, mechanism: e.properties?.mechanism ?? '', relation: e.label }));
@@ -202,9 +202,10 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
         <div class="cv-card">
           <h3>1 · Supply chain → levers</h3>
           <div class="cv-sc" v-for="n in supplyNodes" :key="n.id">
-            <div class="cv-sc-name">{{ n.properties.name }}</div>
+            <div class="cv-sc-name">{{ n.properties?.name ?? n.id }}</div>
             <ul><li v-for="(d, i) in drivenBy(n.id)" :key="i"><code>{{ d.relation }}</code> <strong>{{ d.kpi }}</strong> — {{ d.mechanism }}</li></ul>
           </div>
+          <p v-if="!supplyNodes.length" class="cv-hint">Loading supply-chain graph…</p>
         </div>
         <div class="cv-card">
           <h3>2 · KPI contribution</h3>
@@ -244,9 +245,9 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
         <div class="cv-grid2">
           <div class="cv-card">
             <svg :viewBox="`0 0 ${W} ${H}`" class="cv-map">
-              <polygon :points="outlinePoints" fill="#eef2f7" stroke="#cbd5e1" stroke-width="1" />
+              <polygon :points="outlinePoints" fill="rgba(255,255,255,0.045)" stroke="rgba(255,255,255,0.16)" stroke-width="1" />
               <circle v-for="l in loc.locations" :key="l.id" :cx="px(l.lng)" :cy="py(l.lat)" :r="dotR(l.modeled_weekly_footfall)"
-                :fill="dotColor(l.format)" :fill-opacity="selected===l.id ? 1 : 0.72" :stroke="selected===l.id ? '#0f172a' : 'white'" :stroke-width="selected===l.id ? 2 : 1"
+                :fill="dotColor(l.format)" :fill-opacity="selected===l.id ? 1 : 0.8" :stroke="selected===l.id ? '#edeef2' : '#0c0d11'" :stroke-width="selected===l.id ? 2 : 1"
                 style="cursor:pointer" @click="selected = l.id" />
             </svg>
             <p class="cv-hint">Dot size ∝ modeled weekly footfall · click a dot for detail · coordinates approximate.</p>
@@ -280,65 +281,66 @@ const selectedLoc = computed(() => loc.value?.locations.find((l) => l.id === sel
 </template>
 
 <style scoped>
-.cv { padding: 1rem 1.25rem; max-width: 1100px; font-family: ui-sans-serif, system-ui; }
-.cv-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; opacity: .6; margin: 0; }
-.cv-title { font-size: 1.4rem; font-weight: 700; margin: .25rem 0; display: flex; align-items: center; gap: .5rem; }
-.cv-sub { margin: 0; opacity: .78; max-width: 820px; }
-.cv-pill { font-size: .7rem; padding: .1rem .5rem; border-radius: 999px; border: 1px solid #cbd5e1; text-transform: uppercase; }
-.cv-pill.live { background: #ecfdf5; color: #065f46; border-color: #a7f3d0; }
-.cv-pill.unavailable { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
-.cv-warn { border: 1px solid #fecaca; background: #fef2f2; color: #991b1b; border-radius: 10px; padding: .75rem; }
-.cv-studio { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .75rem .85rem; margin-bottom: 1rem; }
+.cv { padding: 1rem 1.25rem; max-width: 1100px; font-family: ui-sans-serif, system-ui; color: var(--text); }
+.cv-eyebrow { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--text-3); margin: 0; }
+.cv-title { font-size: 1.4rem; font-weight: 700; margin: .25rem 0; display: flex; align-items: center; gap: .5rem; color: var(--text); }
+.cv-sub { margin: 0; color: var(--text-2); max-width: 820px; }
+.cv-pill { font-size: .7rem; padding: .1rem .5rem; border-radius: 999px; border: 1px solid var(--line-2); text-transform: uppercase; color: var(--text-2); }
+.cv-pill.live { background: rgba(16,185,129,.14); color: #6ee7b7; border-color: rgba(16,185,129,.4); }
+.cv-pill.unavailable { background: rgba(239,68,68,.14); color: #fca5a5; border-color: rgba(239,68,68,.4); }
+.cv-warn { border: 1px solid rgba(239,68,68,.4); background: rgba(239,68,68,.12); color: #fca5a5; border-radius: 10px; padding: .75rem; }
+.cv-studio { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .75rem .85rem; margin-bottom: 1rem; }
 .cv-studio-row { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; margin-bottom: .5rem; }
-.cv-studio-eyebrow { font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 700; opacity: .6; }
-.cv-studio-toggle { font-size: .8rem; display: inline-flex; gap: .3rem; align-items: center; margin-left: auto; }
-.cv-studio-in { flex: 1; min-width: 180px; padding: .45rem .7rem; border: 1px solid #cbd5e1; border-radius: 8px; }
+.cv-studio-eyebrow { font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; font-weight: 700; color: var(--text-3); }
+.cv-studio-toggle { font-size: .8rem; display: inline-flex; gap: .3rem; align-items: center; margin-left: auto; color: var(--text-2); }
+.cv-studio-in { flex: 1; min-width: 180px; padding: .45rem .7rem; border: 1px solid var(--line-2); border-radius: 8px; background: var(--surface-2); color: var(--text); }
 .cv-studio-ev { flex: 0 0 210px; }
-.cv-studio-sel { padding: .45rem .6rem; border: 1px solid #cbd5e1; border-radius: 8px; }
-.cv-studio-hint { font-size: .76rem; opacity: .6; margin: 0; }
+.cv-studio-sel { padding: .45rem .6rem; border: 1px solid var(--line-2); border-radius: 8px; background: var(--surface-2); color: var(--text); }
+.cv-studio-hint { font-size: .76rem; color: var(--text-3); margin: 0; }
 .cv-metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: .75rem; margin: 1rem 0; }
-.cv-metric { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; display: flex; flex-direction: column; }
-.cv-m-label { font-size: .72rem; opacity: .6; text-transform: uppercase; letter-spacing: .04em; }
-.cv-m-val { font-size: 1.35rem; font-weight: 700; }
-.cv-metric.up .cv-m-val, .up { color: #065f46; }
-.cv-m-sub { font-size: .85rem; opacity: .7; }
-.cv-panel { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; margin-bottom: 1rem; }
-.cv-panel-h { display: flex; justify-content: space-between; align-items: center; gap: .5rem; flex-wrap: wrap; font-weight: 600; }
-.cv-tag { font-size: .7rem; font-weight: 600; color: #065f46; background: #ecfdf5; border: 1px solid #a7f3d0; border-radius: 999px; padding: .1rem .5rem; }
-.cv-hint { font-size: .8rem; opacity: .6; margin: .35rem 0; font-weight: 400; }
+.cv-metric { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .85rem; display: flex; flex-direction: column; }
+.cv-m-label { font-size: .72rem; color: var(--text-3); text-transform: uppercase; letter-spacing: .04em; }
+.cv-m-val { font-size: 1.35rem; font-weight: 700; color: var(--text); }
+.cv-metric.up { border-color: rgba(16,185,129,.4); }
+.cv-metric.up .cv-m-val, .up { color: #6ee7b7; }
+.cv-m-sub { font-size: .85rem; color: var(--text-2); }
+.cv-panel { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .85rem; margin-bottom: 1rem; }
+.cv-panel-h { display: flex; justify-content: space-between; align-items: center; gap: .5rem; flex-wrap: wrap; font-weight: 600; color: var(--text); }
+.cv-tag { font-size: .7rem; font-weight: 600; color: #6ee7b7; background: rgba(16,185,129,.14); border: 1px solid rgba(16,185,129,.4); border-radius: 999px; padding: .1rem .5rem; }
+.cv-hint { font-size: .8rem; color: var(--text-3); margin: .35rem 0; font-weight: 400; }
 .cv-controls { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: .5rem 1.25rem; margin-top: .5rem; }
-.cv-ctrl-h { display: flex; justify-content: space-between; font-size: .82rem; }
-.cv-ctrl input { width: 100%; }
-.cv-btn { padding: .4rem .8rem; border: 1px solid #cbd5e1; border-radius: 8px; background: #fff; cursor: pointer; }
-.cv-btn.primary { background: #10b981; border-color: #10b981; color: #fff; }
+.cv-ctrl-h { display: flex; justify-content: space-between; font-size: .82rem; color: var(--text-2); }
+.cv-ctrl input { width: 100%; accent-color: var(--accent); }
+.cv-btn { padding: .4rem .8rem; border: 1px solid var(--line-2); border-radius: 8px; background: var(--surface-2); color: var(--text); cursor: pointer; }
+.cv-btn.primary { background: #10b981; border-color: #10b981; color: #05271c; font-weight: 700; }
 .cv-btn:disabled { opacity: .5; cursor: default; }
 .cv-grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; margin-bottom: 1rem; }
 .cv-grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
-.cv-card { border: 1px solid #e2e8f0; border-radius: 12px; background: #fff; padding: .85rem; }
-.cv-card h3 { margin: 0 0 .5rem; font-size: 1rem; }
-.cv-sc { border: 1px solid #eef2f7; border-radius: 10px; padding: .5rem; margin: .45rem 0; }
-.cv-sc-name { font-weight: 650; }
-.cv-sc ul { margin: .35rem 0 0; padding-left: 1rem; font-size: .82rem; }
-.cv-sc code, .cv-sc-name code { font-size: .72rem; background: #f1f5f9; padding: .05rem .3rem; border-radius: 4px; }
+.cv-card { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .85rem; color: var(--text); }
+.cv-card h3 { margin: 0 0 .5rem; font-size: 1rem; color: var(--text); }
+.cv-sc { border: 1px solid var(--line); border-radius: 10px; padding: .5rem; margin: .45rem 0; }
+.cv-sc-name { font-weight: 650; color: var(--text); }
+.cv-sc ul { margin: .35rem 0 0; padding-left: 1rem; font-size: .82rem; color: var(--text-2); }
+.cv-sc code, .cv-sc-name code { font-size: .72rem; background: var(--surface-2); color: var(--text); padding: .05rem .3rem; border-radius: 4px; }
 .cv-kpi { margin: .5rem 0; }
-.cv-kpi-h { display: flex; justify-content: space-between; font-size: .85rem; }
-.cv-bar { height: 8px; background: #eef2f7; border-radius: 6px; margin-top: .25rem; overflow: hidden; }
+.cv-kpi-h { display: flex; justify-content: space-between; font-size: .85rem; color: var(--text-2); }
+.cv-bar { height: 8px; background: var(--surface-2); border-radius: 6px; margin-top: .25rem; overflow: hidden; }
 .cv-bar div { height: 100%; background: #10b981; }
-.cv-drv { display: flex; justify-content: space-between; padding: .5rem; border: 1px solid #eef2f7; border-radius: 10px; margin: .35rem 0; }
-.cv-drv.total { background: #ecfdf5; border-color: #a7f3d0; font-weight: 750; }
+.cv-drv { display: flex; justify-content: space-between; padding: .5rem; border: 1px solid var(--line); border-radius: 10px; margin: .35rem 0; color: var(--text); }
+.cv-drv.total { background: rgba(16,185,129,.12); border-color: rgba(16,185,129,.4); font-weight: 750; }
 .cv-traj { display: flex; align-items: flex-end; gap: .5rem; height: 130px; margin-top: 1rem; }
 .cv-traj-col { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: flex-end; height: 100%; }
-.cv-traj-v { font-size: .7rem; font-weight: 600; color: #065f46; }
+.cv-traj-v { font-size: .7rem; font-weight: 600; color: #6ee7b7; }
 .cv-traj-bar { width: 100%; max-width: 46px; background: #10b981; border-radius: 6px 6px 0 0; min-height: 4px; margin-top: .2rem; }
-.cv-traj-y { font-size: .74rem; opacity: .6; margin-top: .25rem; }
+.cv-traj-y { font-size: .74rem; color: var(--text-3); margin-top: .25rem; }
 .cv-search { display: flex; gap: .5rem; margin: .5rem 0; }
-.cv-search input { flex: 1; padding: .45rem .7rem; border: 1px solid #cbd5e1; border-radius: 8px; }
-.cv-legend { font-size: .72rem; display: flex; gap: .6rem; align-items: center; font-weight: 400; }
+.cv-search input { flex: 1; padding: .45rem .7rem; border: 1px solid var(--line-2); border-radius: 8px; background: var(--surface-2); color: var(--text); }
+.cv-legend { font-size: .72rem; display: flex; gap: .6rem; align-items: center; font-weight: 400; color: var(--text-2); }
 .cv-legend i { display: inline-block; width: 9px; height: 9px; border-radius: 50%; margin-right: 2px; }
 .cv-map { width: 100%; height: auto; }
 .cv-twin { display: grid; grid-template-columns: 1fr 1fr; gap: .6rem; }
 .cv-states { display: flex; flex-wrap: wrap; gap: .35rem; margin: .6rem 0; }
-.cv-states span { font-size: .78rem; padding: .15rem .5rem; border: 1px solid #e2e8f0; border-radius: 999px; }
-.cv-locsel { border-top: 1px solid #eef2f7; margin-top: .6rem; padding-top: .6rem; }
-.cv-lims { margin: .25rem 0 0; padding-left: 1rem; font-size: .82rem; opacity: .8; }
+.cv-states span { font-size: .78rem; padding: .15rem .5rem; border: 1px solid var(--line-2); border-radius: 999px; color: var(--text-2); }
+.cv-locsel { border-top: 1px solid var(--line); margin-top: .6rem; padding-top: .6rem; }
+.cv-lims { margin: .25rem 0 0; padding-left: 1rem; font-size: .82rem; color: var(--text-2); }
 </style>

--- a/socioprophet-web/client-vue/src/pages/Discovery.vue
+++ b/socioprophet-web/client-vue/src/pages/Discovery.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+// Sherlock Discovery — sovereign, ontology-driven search over a corpus (Tantivy/Rust, no JVM),
+// integrated with Holmes: any result can be verified against real HellGraph evidence.
+// First corpus: the frontier-model-lab competition.
+import { ref, computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import { navScopeForPath } from '../config/cockpitNav';
+import { search, facets, type Hit, type Facets } from '../services/sherlockApi';
+import { verifyClaims, type Verdict } from '../services/ieApi';
+
+const route = useRoute();
+const scope = computed(() => navScopeForPath(route.path));
+
+const q = ref('sovereign proof-carrying provenance');
+const hits = ref<Hit[]>([]);
+const total = ref(0);
+const fac = ref<Facets | null>(null);
+const busy = ref(false);
+const err = ref('');
+const verdicts = ref<Record<string, Verdict>>({});
+
+async function runSearch() {
+  busy.value = true; err.value = ''; verdicts.value = {};
+  try { const r = await search(q.value, 12); hits.value = r.hits; total.value = r.total; }
+  catch (e) { err.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; }
+}
+async function verify(h: Hit) {
+  busy.value = true;
+  try { const r = await verifyClaims([h.title.split('—')[0].trim() + ' ' + h.category]); if (r.results[0]) verdicts.value = { ...verdicts.value, [h.id]: r.results[0] }; }
+  catch (e) { err.value = e instanceof Error ? e.message : String(e); }
+  finally { busy.value = false; }
+}
+onMounted(async () => { await runSearch(); try { fac.value = await facets(); } catch { /* facets best-effort */ } });
+
+const EXAMPLES = ['open weight efficient reasoning', 'AI safety interpretability governance', 'multimodal scientific reasoning', 'constitutional harmlessness'];
+</script>
+
+<template>
+  <section class="dz" aria-label="Discovery search">
+    <SurfaceHeader :title="scope && !scope.isPrimary ? scope.label : 'Discovery'" :eyebrow="scope && !scope.isPrimary ? scope.domain : 'Knowledge'">
+      <template #badge><span class="dz-pill live">Tantivy · sovereign · no-JVM</span></template>
+    </SurfaceHeader>
+
+    <div class="dz-search">
+      <span class="dz-glyph">⌕</span>
+      <input v-model="q" class="dz-input" placeholder="Search the corpus — ontology-driven, BM25 ranked" @keyup.enter="runSearch" />
+      <button class="dz-btn" :disabled="busy" @click="runSearch">{{ busy ? 'Searching…' : 'Search' }}</button>
+    </div>
+    <div class="dz-ex"><span class="dz-try">Try</span><button v-for="e in EXAMPLES" :key="e" class="dz-chip" @click="q = e; runSearch()">{{ e }}</button>
+      <span class="dz-corpus">corpus: frontier-model-lab competition · {{ total }} hits</span></div>
+    <p v-if="err" class="dz-err">{{ err }}</p>
+
+    <div class="dz-grid">
+      <aside class="dz-facets" v-if="fac">
+        <div class="dz-fac"><div class="dz-fac-h">Category</div><div v-for="(n, k) in fac.category" :key="k" class="dz-fac-row" @click="q = String(k); runSearch()"><span>{{ k }}</span><span class="dz-fac-n">{{ n }}</span></div></div>
+        <div class="dz-fac"><div class="dz-fac-h">Region</div><div v-for="(n, k) in fac.region" :key="k" class="dz-fac-row"><span>{{ k }}</span><span class="dz-fac-n">{{ n }}</span></div></div>
+        <div class="dz-fac"><div class="dz-fac-h">Doc type</div><div v-for="(n, k) in fac.doctype" :key="k" class="dz-fac-row"><span>{{ k }}</span><span class="dz-fac-n">{{ n }}</span></div></div>
+      </aside>
+
+      <div class="dz-results">
+        <div v-for="h in hits" :key="h.id" class="dz-hit">
+          <div class="dz-hit-h">
+            <span class="dz-hit-t">{{ h.title }}</span>
+            <span class="dz-bm25" title="BM25 relevance">{{ h.bm25.toFixed(2) }}</span>
+          </div>
+          <div class="dz-hit-meta"><span class="dz-tag">{{ h.doctype }}</span><span class="dz-tag">{{ h.category }}</span><span class="dz-tag">{{ h.region }}</span><span class="dz-tag score">score {{ h.score }}</span></div>
+          <p class="dz-snip" v-html="h.snippet || ''"></p>
+          <div class="dz-hit-actions">
+            <button class="dz-verify" :disabled="busy" @click="verify(h)">🔎 Verify with Holmes</button>
+            <span v-if="verdicts[h.id]" class="dz-holmes" :class="verdicts[h.id].verdict">{{ verdicts[h.id].verdict }}<span v-if="verdicts[h.id].evidence_count"> · {{ verdicts[h.id].evidence_count }} evidence</span></span>
+          </div>
+        </div>
+        <p v-if="!busy && !hits.length" class="dz-empty">No matches. Try a broader query.</p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dz { padding: 1rem 1.25rem; max-width: 1120px; margin: 0 auto; color: var(--text); }
+.dz-pill { font-size: .62rem; text-transform: uppercase; letter-spacing: .04em; padding: .1rem .5rem; border-radius: 999px; color: var(--live); border: 1px solid rgba(75,191,115,.4); background: rgba(75,191,115,.12); }
+.dz-search { display: flex; align-items: center; gap: .6rem; border: 1px solid var(--line-2); background: var(--surface); border-radius: 12px; padding: .55rem .8rem; margin: 1rem 0 .5rem; }
+.dz-glyph { color: var(--accent); font-size: 1.1rem; }
+.dz-input { flex: 1; background: transparent; border: 0; color: var(--text); font-size: .95rem; outline: none; }
+.dz-btn { background: var(--accent); color: #1a1204; border: 0; border-radius: 8px; padding: .45rem 1rem; font-weight: 700; cursor: pointer; }
+.dz-btn:disabled { opacity: .5; cursor: default; }
+.dz-ex { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; margin-bottom: .5rem; }
+.dz-try { color: var(--text-3); font-size: .74rem; }
+.dz-chip { background: var(--surface-2); border: 1px solid var(--line); color: var(--text-2); border-radius: 999px; padding: .2rem .6rem; font-size: .74rem; cursor: pointer; }
+.dz-chip:hover { border-color: var(--accent); color: var(--text); }
+.dz-corpus { margin-left: auto; color: var(--text-3); font-size: .72rem; }
+.dz-err { color: var(--down); font-size: .82rem; }
+.dz-grid { display: grid; grid-template-columns: 210px 1fr; gap: 1rem; margin-top: .5rem; }
+.dz-facets { display: flex; flex-direction: column; gap: .8rem; }
+.dz-fac { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .6rem .7rem; }
+.dz-fac-h { color: var(--text-3); font-size: .64rem; text-transform: uppercase; letter-spacing: .06em; margin-bottom: .35rem; }
+.dz-fac-row { display: flex; justify-content: space-between; font-size: .78rem; padding: .15rem 0; color: var(--text-2); cursor: pointer; }
+.dz-fac-row:hover { color: var(--text); }
+.dz-fac-n { color: var(--text-3); }
+.dz-results { display: flex; flex-direction: column; gap: .7rem; }
+.dz-hit { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .8rem .9rem; }
+.dz-hit-h { display: flex; justify-content: space-between; align-items: baseline; gap: .5rem; }
+.dz-hit-t { font-weight: 650; font-size: 1rem; }
+.dz-bm25 { color: var(--accent-2); font-weight: 700; font-size: .82rem; }
+.dz-hit-meta { display: flex; gap: .35rem; flex-wrap: wrap; margin: .3rem 0; }
+.dz-tag { font-size: .64rem; color: var(--text-3); border: 1px solid var(--line); border-radius: 6px; padding: .05rem .4rem; }
+.dz-tag.score { color: var(--accent-2); border-color: rgba(216,162,80,.3); }
+.dz-snip { font-size: .84rem; color: var(--text-2); line-height: 1.5; margin: .3rem 0; }
+.dz-snip :deep(b) { color: var(--text); background: rgba(216,162,80,.22); border-radius: 3px; padding: 0 2px; }
+.dz-hit-actions { display: flex; align-items: center; gap: .6rem; margin-top: .4rem; }
+.dz-verify { background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text-2); border-radius: 8px; padding: .25rem .6rem; font-size: .72rem; cursor: pointer; }
+.dz-verify:hover:not(:disabled) { border-color: var(--accent); color: var(--text); }
+.dz-holmes { font-size: .66rem; font-weight: 700; text-transform: uppercase; padding: .1rem .45rem; border-radius: 6px; }
+.dz-holmes.supported { color: var(--live); background: rgba(75,191,115,.16); }
+.dz-holmes.weakly-supported { color: var(--amber); background: rgba(227,179,65,.16); }
+.dz-holmes.unverified, .dz-holmes.unreachable { color: var(--text-3); background: var(--surface-2); }
+.dz-empty { color: var(--text-3); font-size: .85rem; }
+@media (max-width: 900px) { .dz-grid { grid-template-columns: 1fr; } }
+</style>

--- a/socioprophet-web/client-vue/src/pages/KnowledgeGraph.vue
+++ b/socioprophet-web/client-vue/src/pages/KnowledgeGraph.vue
@@ -42,7 +42,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import { graphSurface, graphHealth, type SurfaceResult, type GraphHealth } from '../services/agentMachineApi';
+// Reads the CANONICAL hellgraph-service (shared with the Prophet Studio Graph Explorer) — one graph
+// across every surface. Types still come from agentMachineApi (the surface contract is mirrored).
+import { graphSurface, graphHealth } from '../services/hellgraphApi';
+import type { SurfaceResult, GraphHealth } from '../services/agentMachineApi';
 import { navScopeForPath } from '../config/cockpitNav';
 
 const route = useRoute();

--- a/socioprophet-web/client-vue/src/pages/NlpExtractionBench.vue
+++ b/socioprophet-web/client-vue/src/pages/NlpExtractionBench.vue
@@ -1,132 +1,265 @@
+<script setup lang="ts">
+// NLP & Information Extraction — a REAL suite workbench. Five live tabs over our own services:
+//   Extract   → spaCy NER + dependency relations + claims (ie-engine :8086)
+//   Glossary  → salient terms + definitions (ie-engine)
+//   Vectors   → embedding similarity (ie-engine)
+//   Type System → RDFS/OWL entailment authoring (owl-reasoner :8081)
+//   Resolve   → entity resolution → golden records (entity-resolution :8082)
+// Extraction can be written into the canonical HellGraph. Sherlock / SynapseIQ / Holmes are surfaced
+// as suite tools (deeper wiring pending — they need their own build/boot).
+import { ref, computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import { navScopeForPath } from '../config/cockpitNav';
+import { extract, toGraph, glossary, vectorize, reason, resolve, verifyClaims, kkoClassify, type Extraction, type Term, type Verdict } from '../services/ieApi';
+
+const route = useRoute();
+const router = useRouter();
+const scope = computed(() => navScopeForPath(route.path));
+
+const TABS = [
+  { id: 'extract', label: 'Extract' }, { id: 'glossary', label: 'Glossary' }, { id: 'vectors', label: 'Vectors' },
+  { id: 'types', label: 'Type System' }, { id: 'resolve', label: 'Resolve' },
+] as const;
+const tab = ref<string>('extract');
+const busy = ref(false);
+const err = ref('');
+
+const DEMO = 'The Open Data Governance Board opened public comment on July 3, 2026 for a rule requiring model-provenance disclosure. Chair Dana Whitfield said the European Commission is expected to align a parallel framework. Compliance costs are estimated at $4.2M across covered providers, concentrated in Brussels and Washington.';
+const text = ref(DEMO);
+const ex = ref<Extraction | null>(null);
+const wrote = ref<{ nodes: number; edges: number } | null>(null);
+
+const TYPE_COLOR: Record<string, string> = {
+  Org: 'var(--violet)', Person: 'var(--info)', Date: 'var(--amber)', Money: 'var(--up)', Place: 'var(--teal)',
+  Topic: 'var(--accent)', Concept: 'var(--accent)', Product: 'var(--cyan)', Law: 'var(--ask)', Group: 'var(--violet)',
+  Event: 'var(--cyan)', Percent: 'var(--up)', Quantity: 'var(--neutral)',
+};
+const color = (t: string) => TYPE_COLOR[t] ?? 'var(--neutral)';
+const namedEntities = computed(() => (ex.value?.entities ?? []).filter((e) => e.type !== 'Topic'));
+const legendTypes = computed(() => [...new Set(namedEntities.value.map((e) => e.type))]);
+
+async function run<T>(fn: () => Promise<T>, set: (v: T) => void) {
+  busy.value = true; err.value = '';
+  try { set(await fn()); } catch (e) { err.value = e instanceof Error ? e.message : String(e); } finally { busy.value = false; }
+}
+const runExtract = () => { wrote.value = null; return run(() => extract(text.value), (v) => (ex.value = v)); };
+const pushGraph = () => run(() => toGraph(text.value), (g) => { ex.value = g; wrote.value = { nodes: g.nodes_written, edges: g.edges_written }; });
+runExtract();
+
+// Holmes — verify the extracted claims against real HellGraph evidence
+const verdicts = ref<Record<string, Verdict>>({});
+const runVerify = () => run(() => verifyClaims((ex.value?.claims ?? []).map((c) => c.text)),
+  (r) => { verdicts.value = Object.fromEntries(r.results.map((v) => [v.claim, v])); });
+
+// SynapseIQ — classify each entity TYPE into the KKO (Peircean) ontology
+const kko = ref<Record<string, string>>({});
+const runKko = () => run(() => kkoClassify([...new Set(namedEntities.value.map((e) => e.type))]),
+  (r) => { kko.value = Object.fromEntries(r.results.map((k) => [k.type, k.kko])); });
+
+// Glossary
+const gloss = ref<Term[]>([]);
+const runGloss = () => run(() => glossary(text.value), (v) => (gloss.value = v.terms));
+
+// Vectors
+const vecText = ref('model provenance disclosure rule\nprovenance of an AI model\nquarterly revenue growth\nEBITDA margin expansion');
+const sim = ref<number[][]>([]);
+const vecLines = computed(() => vecText.value.split('\n').map((s) => s.trim()).filter(Boolean));
+const runVec = () => run(() => vectorize(vecLines.value), (v) => (sim.value = v.similarity));
+const heat = (x: number) => `rgba(75,191,115,${(x * 0.9).toFixed(2)})`;
+
+// Type System (owl-reasoner)
+const ttl = ref('@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix ex: <http://ex/> .\nex:Regulator rdfs:subClassOf ex:Institution .\nex:Institution rdfs:subClassOf ex:Agent .\nex:ODGB a ex:Regulator .');
+const ent = ref<{ input: number; entailed: number; rows: any[] } | null>(null);
+const runReason = () => run(() => reason(ttl.value, 'rdfs'), (r) => (ent.value = { input: r.input_triples, entailed: r.entailed_triples, rows: r.entailments || [] }));
+
+// Resolve (entity-resolution) — resolve the extracted named entities
+const golden = ref<any[]>([]);
+const resolveInput = computed(() => namedEntities.value.map((e, i) => ({ id: `e${i}`, name: e.text })));
+const runResolve = () => run(() => resolve(resolveInput.value.length ? resolveInput.value : [{ id: 'a', name: 'Acme Corp' }, { id: 'b', name: 'ACME Corporation' }]), (r) => (golden.value = r.golden_records || []));
+
+const SUITE = [
+  { label: 'Ontology', to: '/studio?section=ontology' }, { label: 'Entity Resolution', to: '/studio?section=er' },
+  { label: 'Graph', to: '/studio?section=graph' }, { label: 'GraphRAG', to: '/studio?section=graphrag' },
+];
+</script>
+
 <template>
-  <section class="ie" aria-label="Information extraction">
-    <SurfaceHeader :title="scope && !scope.isPrimary ? scope.label : 'Extraction Bench'" :eyebrow="(scope && !scope.isPrimary) ? (scope.domain) : ''">
-      <template #badge><span class="ie-pill">fixture</span></template>
+  <section class="ie" aria-label="NLP and information extraction">
+    <SurfaceHeader :title="scope && !scope.isPrimary ? scope.label : 'NLP & Information Extraction'" :eyebrow="scope && !scope.isPrimary ? scope.domain : 'Knowledge'">
+      <template #badge><span class="ie-pill live">live suite</span></template>
       <template #actions>
-        <div class="ie-docpick">
-        <button v-for="d in docs" :key="d.id" class="ie-doc" :class="{ on: d.id === selectedId }" @click="selectedId = d.id">{{ d.source }}</button>
+        <div class="ie-suite">
+          <button v-for="s in SUITE" :key="s.to" class="ie-tool" @click="router.push(s.to)">{{ s.label }}</button>
+          <span class="ie-tool live" title="Holmes claim-verifier is live — Verify in the Claims panel">Holmes ✓</span>
+          <span class="ie-tool live" title="SynapseIQ language intelligence is live — KKO-type in the Entities panel">SynapseIQ ✓</span>
+          <span class="ie-tool pending" title="Sherlock (procybernetica dashboard) — build-out pending">Sherlock</span>
         </div>
       </template>
     </SurfaceHeader>
 
-    <SplitPane v-if="selected" storage-key="nlp-extraction" label="document" :initial="420">
-      <template #list>
-      <!-- Document with entity highlights -->
-      <article class="ie-text" aria-label="Document">
-        <div class="ie-doc-head">
-          <h2>{{ selected.title }}</h2>
-          <span class="ie-doc-meta">{{ selected.source }} · {{ dateLabel(selected.date) }}</span>
+    <div class="ie-tabs">
+      <button v-for="t in TABS" :key="t.id" class="ie-tab" :class="{ on: tab === t.id }" @click="tab = t.id">{{ t.label }}</button>
+    </div>
+    <p v-if="err" class="ie-err">{{ err }}</p>
+
+    <!-- EXTRACT -->
+    <div v-show="tab === 'extract'" class="ie-grid">
+      <div class="ie-in">
+        <div class="ie-in-h">Text · paste anything</div>
+        <textarea v-model="text" class="ie-ta" rows="9" spellcheck="false"></textarea>
+        <div class="ie-actions">
+          <button class="ie-btn primary" :disabled="busy || !text.trim()" @click="runExtract">{{ busy ? 'Extracting…' : 'Extract' }}</button>
+          <button class="ie-btn" :disabled="busy || !text.trim()" @click="pushGraph">Extract → HellGraph →</button>
         </div>
-        <p class="ie-passage">
-          <template v-for="(s, i) in selected.segments" :key="i"><mark v-if="s.ent" class="ie-ent" :class="s.ent" :title="`${s.ent} · ${(s.conf ? s.conf * 100 : 0).toFixed(0)}%`">{{ s.t }}<sup class="ie-ent-t">{{ tag(s.ent) }}</sup></mark><template v-else>{{ s.t }}</template></template>
-        </p>
-        <div class="ie-legend">
-          <span v-for="t in usedTypes" :key="t" class="ie-leg"><i class="ie-ent" :class="t" />{{ t }}</span>
-        </div>
-        <div class="ie-sent">
-          <span class="ie-sent-k">Sentiment</span>
-          <span class="ie-sent-pill" :class="selected.sentiment.label">{{ selected.sentiment.label }}</span>
-          <span class="ie-sent-score">{{ selected.sentiment.score >= 0 ? '+' : '' }}{{ selected.sentiment.score.toFixed(2) }}</span>
-        </div>
-      </article>
-      </template>
-
-      <template #detail>
-
-      <!-- Extractions -->
-      <div class="ie-out">
-        <section class="ie-panel">
-          <div class="ie-panel-h">Entities <span class="ie-c">{{ entities.length }}</span></div>
-          <div v-for="(e, i) in entities" :key="i" class="ie-erow">
-            <span class="ie-ent-badge" :class="e.ent">{{ tag(e.ent!) }}</span>
-            <span class="ie-erow-t">{{ e.t }}</span>
-            <span class="ie-conf">{{ ((e.conf ?? 0) * 100).toFixed(0) }}%</span>
-          </div>
-        </section>
-
-        <section class="ie-panel">
-          <div class="ie-panel-h">Relations <span class="ie-c">{{ selected.relations.length }}</span></div>
-          <div v-for="(r, i) in selected.relations" :key="i" class="ie-triple">
-            <span class="ie-node subj">{{ r.subj }}</span>
-            <span class="ie-pred">{{ r.pred }} →</span>
-            <span class="ie-node obj">{{ r.obj }}</span>
-            <span class="ie-conf">{{ (r.conf * 100).toFixed(0) }}%</span>
-          </div>
-        </section>
-
-        <section class="ie-panel">
-          <div class="ie-panel-h">Claims <span class="ie-c">{{ selected.claims.length }}</span></div>
-          <div v-for="(c, i) in selected.claims" :key="i" class="ie-claim">
-            <span class="ie-claim-k" :class="c.kind">{{ c.kind }}</span>
-            <span class="ie-claim-t">{{ c.text }}</span>
-            <span class="ie-verif" :class="c.verifiable ? 'yes' : 'no'">{{ c.verifiable ? 'verifiable' : 'unverifiable' }}</span>
-          </div>
-        </section>
-
-        <div class="ie-boundary">Read-only extraction · no PII writeback · no live model. A live extractor swaps in behind this shape.</div>
+        <p v-if="wrote" class="ie-wrote">Wrote <b>{{ wrote.nodes }}</b> nodes · <b>{{ wrote.edges }}</b> edges into the canonical graph.</p>
+        <div v-if="ex" class="ie-legend"><span v-for="t in legendTypes" :key="t" class="ie-lg"><i :style="{ background: color(t) }"></i>{{ t }}</span></div>
+        <p v-if="ex" class="ie-prov">{{ ex.provenance.model }} · {{ ex.counts.tokens }} tokens · real extraction</p>
       </div>
-      </template>
-    </SplitPane>
+      <div class="ie-out" v-if="ex">
+        <div class="ie-sec">
+          <div class="ie-sec-h" style="display:flex;justify-content:space-between;align-items:center">
+            <span>Entities <span class="ie-n">{{ namedEntities.length }}</span></span>
+            <button class="ie-verify-btn" :disabled="busy" @click="runKko" title="Classify each entity type into the KKO (Peircean) ontology via SynapseIQ">◇ KKO-type via SynapseIQ</button>
+          </div>
+          <div class="ie-ents"><span v-for="(e, i) in namedEntities" :key="i" class="ie-ent"><span class="ie-etag" :style="{ background: color(e.type) }">{{ e.type }}</span>{{ e.text }}<span v-if="kko[e.type]" class="ie-kko" :title="'KKO: ' + kko[e.type]">{{ kko[e.type] }}</span></span></div>
+          <p v-if="Object.keys(kko).length" class="ie-prov">SynapseIQ · entity types classified into the KKO ontology (Particulars / Generals / Possibilities)</p>
+        </div>
+        <div class="ie-sec" v-if="ex.relations.length">
+          <div class="ie-sec-h">Relations <span class="ie-n">{{ ex.relations.length }}</span></div>
+          <div v-for="(r, i) in ex.relations" :key="i" class="ie-rel"><span class="ie-rel-e">{{ r.from }}</span><span class="ie-rel-v">{{ r.relation }} →</span><span class="ie-rel-e">{{ r.to }}</span></div>
+        </div>
+        <div class="ie-sec" v-if="ex.claims.length">
+          <div class="ie-sec-h" style="display:flex;justify-content:space-between;align-items:center">
+            <span>Claims <span class="ie-n">{{ ex.claims.length }}</span></span>
+            <button class="ie-verify-btn" :disabled="busy" @click="runVerify" title="Verify each claim against real HellGraph evidence">🔎 Verify with Holmes</button>
+          </div>
+          <div v-for="(c, i) in ex.claims" :key="i" class="ie-claim">
+            <span class="ie-ctag" :class="c.type.toLowerCase()">{{ c.type }}</span>
+            <span class="ie-ctext">{{ c.text }}</span>
+            <span v-if="verdicts[c.text]" class="ie-holmes" :class="verdicts[c.text].verdict" :title="'matched: ' + (verdicts[c.text].matched_terms || []).join(', ') + ' · ' + verdicts[c.text].evidence_count + ' evidence facts'">{{ verdicts[c.text].verdict }}</span>
+            <span v-else class="ie-verif" :class="c.verifiable ? 'yes' : 'no'">{{ c.verifiable ? 'verifiable' : 'unverifiable' }}</span>
+          </div>
+          <p v-if="Object.keys(verdicts).length" class="ie-prov">Holmes deduction engine · verdicts grounded in HellGraph evidence (term-matched)</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- GLOSSARY -->
+    <div v-show="tab === 'glossary'" class="ie-grid">
+      <div class="ie-in">
+        <div class="ie-in-h">Derive a glossary from text</div>
+        <textarea v-model="text" class="ie-ta" rows="9" spellcheck="false"></textarea>
+        <div class="ie-actions"><button class="ie-btn primary" :disabled="busy" @click="runGloss">Derive glossary</button></div>
+      </div>
+      <div class="ie-out">
+        <table class="ie-tbl" v-if="gloss.length"><thead><tr><th>Term</th><th>Type</th><th>×</th><th>Definition (in context)</th></tr></thead>
+        <tbody><tr v-for="(t, i) in gloss" :key="i"><td><b>{{ t.term }}</b></td><td><span class="ie-etag sm" :style="{ background: color(t.type) }">{{ t.type }}</span></td><td>{{ t.count }}</td><td class="ie-def">{{ t.definition }}</td></tr></tbody></table>
+        <p v-else class="ie-empty">Derive a glossary → salient terms with their in-context definitions.</p>
+      </div>
+    </div>
+
+    <!-- VECTORS -->
+    <div v-show="tab === 'vectors'" class="ie-grid">
+      <div class="ie-in">
+        <div class="ie-in-h">Texts · one per line</div>
+        <textarea v-model="vecText" class="ie-ta" rows="9" spellcheck="false"></textarea>
+        <div class="ie-actions"><button class="ie-btn primary" :disabled="busy || vecLines.length < 2" @click="runVec">Vectorize &amp; compare</button></div>
+      </div>
+      <div class="ie-out">
+        <div class="ie-sec" v-if="sim.length">
+          <div class="ie-sec-h">Cosine similarity</div>
+          <table class="ie-heat"><tbody><tr v-for="(row, i) in sim" :key="i"><td class="ie-hlabel">{{ vecLines[i]?.slice(0, 22) }}</td><td v-for="(v, j) in row" :key="j" :style="{ background: heat(v) }" :title="v.toFixed(2)">{{ v.toFixed(2) }}</td></tr></tbody></table>
+        </div>
+        <p v-else class="ie-empty">Enter ≥2 lines → real vector similarity between them.</p>
+      </div>
+    </div>
+
+    <!-- TYPE SYSTEM -->
+    <div v-show="tab === 'types'" class="ie-grid">
+      <div class="ie-in">
+        <div class="ie-in-h">Type system · Turtle (RDFS/OWL)</div>
+        <textarea v-model="ttl" class="ie-ta mono" rows="9" spellcheck="false"></textarea>
+        <div class="ie-actions"><button class="ie-btn primary" :disabled="busy" @click="runReason">Infer entailments</button></div>
+      </div>
+      <div class="ie-out">
+        <div class="ie-sec" v-if="ent">
+          <div class="ie-sec-h">{{ ent.input }} asserted → <b>{{ ent.entailed }}</b> entailed triples</div>
+          <div v-for="(r, i) in ent.rows.slice(0, 14)" :key="i" class="ie-rel"><span class="ie-rel-e mono">{{ (r.s || r.subject || '').split(/[#/]/).pop() }}</span><span class="ie-rel-v mono">{{ (r.p || r.predicate || '').split(/[#/]/).pop() }} →</span><span class="ie-rel-e mono">{{ (r.o || r.object || '').split(/[#/]/).pop() }}</span></div>
+        </div>
+        <p v-else class="ie-empty">Author a type system → owl-reasoner infers the entailed class/instance triples.</p>
+      </div>
+    </div>
+
+    <!-- RESOLVE -->
+    <div v-show="tab === 'resolve'" class="ie-grid">
+      <div class="ie-in">
+        <div class="ie-in-h">Resolve the extracted entities</div>
+        <div class="ie-mentions"><span v-for="(m, i) in resolveInput" :key="i" class="ie-topic">{{ m.name }}</span><span v-if="!resolveInput.length" class="ie-empty">Run Extract first, or a sample pair is used.</span></div>
+        <div class="ie-actions"><button class="ie-btn primary" :disabled="busy" @click="runResolve">Resolve → golden records</button></div>
+      </div>
+      <div class="ie-out">
+        <table class="ie-tbl" v-if="golden.length"><thead><tr><th>Golden record</th><th>Members</th></tr></thead>
+        <tbody><tr v-for="(g, i) in golden" :key="i"><td><b>{{ g.name || g.canonical || g.id }}</b></td><td>{{ (g.members || g.records || []).length || 1 }}</td></tr></tbody></table>
+        <p v-else class="ie-empty">Resolve → entity-resolution clusters mentions into proof-carrying golden records.</p>
+      </div>
+    </div>
   </section>
 </template>
 
-<script setup lang="ts">
-import SurfaceHeader from '../components/SurfaceHeader.vue';
-import SplitPane from '../components/SplitPane.vue';
-import { ref, computed } from 'vue';
-import { useRoute } from 'vue-router';
-import { docs, type Doc, type NerType } from '../data/nlpFixture';
-import { navScopeForPath } from '../config/cockpitNav';
-
-const route = useRoute();
-const scope = computed(() => navScopeForPath(route.path));
-
-const selectedId = ref<string>(docs[0]!.id);
-const selected = computed<Doc | undefined>(() => docs.find((d) => d.id === selectedId.value));
-const entities = computed(() => (selected.value?.segments ?? []).filter((s) => s.ent));
-const usedTypes = computed<NerType[]>(() => Array.from(new Set(entities.value.map((e) => e.ent!))));
-
-const TAG: Record<NerType, string> = { person: 'PER', org: 'ORG', place: 'LOC', date: 'DATE', money: 'MONEY', topic: 'TOPIC' };
-function tag(t: NerType): string { return TAG[t]; }
-function dateLabel(iso: string): string { return new Date(iso).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }); }
-</script>
-
 <style scoped>
-.ie { height: 100%; min-height: 0; display: grid; grid-template-rows: auto 1fr; gap: 0.75rem; padding: 0.85rem 1rem 1rem; background: var(--bg); color: var(--text); }
-.ie-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
-.ie-title { display: flex; align-items: baseline; gap: 0.6rem; } .ie-title h1 { margin: 0; font-size: 1.2rem; letter-spacing: -0.01em; color: var(--text); font-weight: 640; }
-.ie-eyebrow { margin: 0 0 0.1rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); }
-.ie-pill { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); background: var(--accent-soft); border-radius: 5px; padding: 0.1rem 0.35rem; }
-.ie-docpick { display: flex; gap: 0.25rem; flex-wrap: wrap; }
-.ie-doc { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 8px; padding: 0.3rem 0.6rem; font-size: 0.74rem; cursor: pointer; } .ie-doc.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
-
-.ie-body { min-height: 0; display: grid; grid-template-columns: minmax(360px, 1.1fr) minmax(340px, 1fr); gap: 0.75rem; }
-@media (max-width: 1080px) { .ie-body { grid-template-columns: 1fr; } }
-
-.ie-text { min-height: 0; overflow-y: auto; border: 1px solid var(--line-2); border-radius: 12px; padding: 1rem 1.1rem; }
-.ie-doc-head h2 { margin: 0; font-size: 1.15rem; line-height: 1.3; } .ie-doc-meta { font-size: 0.72rem; color: var(--text-3); }
-.ie-passage { margin: 1rem 0; font-size: 1rem; line-height: 2.1; color: var(--text); }
-.ie-ent { border-radius: 4px; padding: 0.05rem 0.15rem; color: inherit; }
-mark.ie-ent { background: rgba(255,255,255,0.06); box-shadow: inset 0 -2px 0 var(--et, #8b949e); color: var(--text); }
-.ie-ent.person { --et: #58a6ff; } .ie-ent.org { --et: #c58af9; } .ie-ent.place { --et: var(--up); } .ie-ent.date { --et: var(--accent); } .ie-ent.money { --et: #4bbf73; } .ie-ent.topic { --et: #f0883e; }
-i.ie-ent { display: inline-block; width: 10px; height: 10px; border-radius: 3px; box-shadow: none; background: var(--et); margin-right: 0.3rem; }
-.ie-ent-t { font-size: 0.5rem; font-weight: 800; letter-spacing: 0.03em; color: var(--et); vertical-align: super; margin-left: 0.1rem; }
-.ie-legend { display: flex; flex-wrap: wrap; gap: 0.6rem; padding-top: 0.6rem; border-top: 1px solid var(--line); font-size: 0.7rem; color: var(--text-3); text-transform: capitalize; } .ie-leg { display: flex; align-items: center; }
-.ie-sent { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.8rem; font-size: 0.78rem; } .ie-sent-k { color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; font-size: 0.64rem; }
-.ie-sent-pill { font-size: 0.62rem; text-transform: uppercase; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.4rem; } .ie-sent-pill.positive { color: var(--up); background: rgba(75,191,115,0.16); } .ie-sent-pill.neutral { color: #8b949e; background: rgba(139,148,158,0.16); } .ie-sent-pill.negative { color: var(--down); background: rgba(240,101,106,0.16); }
-.ie-sent-score { font-variant-numeric: tabular-nums; color: var(--text-2); }
-
-.ie-out { min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 0.75rem; }
-.ie-panel { border: 1px solid var(--line-2); border-radius: 12px; overflow: hidden; }
-.ie-panel-h { display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); } .ie-c { color: var(--text-2); }
-.ie-erow { display: flex; align-items: center; gap: 0.55rem; padding: 0.4rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.84rem; } .ie-erow:last-child { border-bottom: none; }
-.ie-ent-badge { font-size: 0.52rem; font-weight: 800; letter-spacing: 0.03em; border-radius: 3px; padding: 0.05rem 0.3rem; color: #04121f; background: var(--et, #8b949e); } .ie-ent-badge.person { --et: #58a6ff; } .ie-ent-badge.org { --et: #c58af9; } .ie-ent-badge.place { --et: var(--up); } .ie-ent-badge.date { --et: var(--accent); } .ie-ent-badge.money { --et: #4bbf73; } .ie-ent-badge.topic { --et: #f0883e; }
-.ie-erow-t { flex: 1; } .ie-conf { font-size: 0.72rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
-.ie-triple { display: flex; align-items: center; flex-wrap: wrap; gap: 0.4rem; padding: 0.45rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.8rem; } .ie-triple:last-child { border-bottom: none; }
-.ie-node { border-radius: 5px; padding: 0.1rem 0.4rem; background: var(--surface-2); } .ie-node.subj { color: #93c5fd; } .ie-node.obj { color: #e3b341; }
-.ie-pred { color: var(--text-3); font-family: ui-monospace, monospace; font-size: 0.72rem; } .ie-triple .ie-conf { margin-left: auto; }
-.ie-claim { display: flex; align-items: flex-start; gap: 0.5rem; padding: 0.5rem 0.85rem; border-bottom: 1px solid var(--line); font-size: 0.82rem; } .ie-claim:last-child { border-bottom: none; }
-.ie-claim-k { flex: 0 0 auto; font-size: 0.54rem; font-weight: 800; text-transform: uppercase; border-radius: 3px; padding: 0.1rem 0.3rem; margin-top: 0.1rem; } .ie-claim-k.assert { color: var(--up); background: rgba(75,191,115,0.15); } .ie-claim-k.hedge { color: var(--accent); background: rgba(216,162,80,0.16); } .ie-claim-k.deny { color: var(--down); background: rgba(240,101,106,0.16); }
-.ie-claim-t { flex: 1; line-height: 1.45; } .ie-verif { flex: 0 0 auto; font-size: 0.62rem; color: var(--text-3); } .ie-verif.yes { color: var(--up); } .ie-verif.no { color: var(--text-3); }
-.ie-boundary { font-size: 0.72rem; color: var(--text-3); padding: 0.6rem 0.2rem; line-height: 1.5; }
+.ie { padding: 1rem 1.25rem; max-width: 1180px; margin: 0 auto; color: var(--text); }
+.ie-pill { font-size: .62rem; text-transform: uppercase; letter-spacing: .05em; padding: .1rem .45rem; border-radius: 999px; border: 1px solid var(--line-2); color: var(--text-2); }
+.ie-pill.live { color: var(--live); border-color: rgba(75,191,115,.4); background: rgba(75,191,115,.12); }
+.ie-suite { display: flex; gap: .35rem; flex-wrap: wrap; align-items: center; }
+.ie-tool { background: var(--surface-2); border: 1px solid var(--line); color: var(--text-2); border-radius: 8px; padding: .25rem .55rem; font-size: .72rem; cursor: pointer; }
+.ie-tool:hover { border-color: var(--accent); color: var(--text); }
+.ie-tool.pending { cursor: default; opacity: .6; }
+.ie-tool.live { cursor: default; color: var(--live); border-color: rgba(75,191,115,.4); background: rgba(75,191,115,.1); }
+.ie-verify-btn { background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text-2); border-radius: 8px; padding: .25rem .6rem; font-size: .72rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
+.ie-verify-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--text); }
+.ie-verify-btn:disabled { opacity: .5; cursor: default; }
+.ie-holmes { font-size: .64rem; font-weight: 700; padding: .1rem .45rem; border-radius: 6px; text-transform: uppercase; }
+.ie-holmes.supported { color: var(--live); background: rgba(75,191,115,.16); }
+.ie-holmes.weakly-supported { color: var(--amber); background: rgba(227,179,65,.16); }
+.ie-holmes.unverified, .ie-holmes.unreachable { color: var(--text-3); background: var(--surface-2); }
+.ie-kko { font-size: .56rem; font-weight: 700; text-transform: uppercase; color: var(--ask); background: rgba(147,180,255,.14); padding: .05rem .3rem; border-radius: 4px; }
+.ie-tabs { display: flex; gap: .3rem; margin: .8rem 0 .5rem; border-bottom: 1px solid var(--line); }
+.ie-tab { background: none; border: 0; border-bottom: 2px solid transparent; color: var(--text-2); padding: .45rem .8rem; cursor: pointer; font-size: .86rem; }
+.ie-tab.on { color: var(--text); border-bottom-color: var(--accent); }
+.ie-err { color: var(--down); font-size: .8rem; }
+.ie-grid { display: grid; grid-template-columns: 420px 1fr; gap: 1rem; }
+.ie-in-h, .ie-sec-h { color: var(--text-3); font-size: .66rem; text-transform: uppercase; letter-spacing: .06em; margin-bottom: .3rem; }
+.ie-ta { width: 100%; background: var(--surface); color: var(--text); border: 1px solid var(--line-2); border-radius: 10px; padding: .6rem .7rem; font-size: .84rem; line-height: 1.5; resize: vertical; outline: none; }
+.ie-ta.mono { font-family: var(--font-mono, ui-monospace, monospace); font-size: .78rem; }
+.ie-ta:focus { border-color: var(--accent); }
+.ie-actions { display: flex; gap: .5rem; margin: .6rem 0; }
+.ie-btn { border: 1px solid var(--line-2); background: var(--surface-2); color: var(--text); border-radius: 8px; padding: .45rem .8rem; font-weight: 600; cursor: pointer; font-size: .82rem; }
+.ie-btn.primary { background: var(--accent); border-color: var(--accent); color: #1a1204; }
+.ie-btn:disabled { opacity: .5; cursor: default; }
+.ie-wrote { font-size: .8rem; color: var(--live); } .ie-wrote b { font-weight: 700; }
+.ie-legend { display: flex; gap: .7rem; flex-wrap: wrap; margin-top: .6rem; }
+.ie-lg { display: inline-flex; align-items: center; gap: .3rem; font-size: .72rem; color: var(--text-2); } .ie-lg i { width: 9px; height: 9px; border-radius: 50%; }
+.ie-prov { color: var(--text-3); font-size: .72rem; margin-top: .5rem; }
+.ie-out { display: flex; flex-direction: column; gap: 1rem; }
+.ie-empty { color: var(--text-3); font-size: .84rem; }
+.ie-sec { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: .7rem .85rem; }
+.ie-n { color: var(--text-3); font-weight: 400; }
+.ie-ents { display: flex; flex-wrap: wrap; gap: .4rem; }
+.ie-ent { display: inline-flex; align-items: center; gap: .35rem; border: 1px solid var(--line); border-radius: 8px; padding: .2rem .5rem; font-size: .85rem; }
+.ie-etag { font-size: .58rem; font-weight: 700; text-transform: uppercase; padding: .05rem .35rem; border-radius: 4px; color: #0b0d11; letter-spacing: .03em; }
+.ie-etag.sm { font-size: .55rem; }
+.ie-rel { display: flex; align-items: center; gap: .5rem; padding: .25rem 0; font-size: .84rem; border-bottom: 1px solid var(--line); }
+.ie-rel-e { color: var(--text); } .ie-rel-v { color: var(--text-3); font-size: .76rem; } .mono { font-family: var(--font-mono, ui-monospace, monospace); }
+.ie-claim { display: flex; align-items: center; gap: .5rem; padding: .3rem 0; border-bottom: 1px solid var(--line); font-size: .84rem; }
+.ie-ctag { font-size: .58rem; font-weight: 700; padding: .05rem .4rem; border-radius: 4px; }
+.ie-ctag.assert { color: var(--live); background: rgba(75,191,115,.14); } .ie-ctag.hedge { color: var(--amber); background: rgba(227,179,65,.14); }
+.ie-ctext { flex: 1; color: var(--text-2); } .ie-verif { font-size: .68rem; } .ie-verif.yes { color: var(--live); } .ie-verif.no { color: var(--text-3); }
+.ie-tbl { width: 100%; border-collapse: collapse; font-size: .82rem; }
+.ie-tbl th { text-align: left; color: var(--text-3); font-weight: 500; border-bottom: 1px solid var(--line-2); padding: .35rem .4rem; }
+.ie-tbl td { border-bottom: 1px solid var(--line); padding: .35rem .4rem; vertical-align: top; } .ie-def { color: var(--text-2); }
+.ie-heat { border-collapse: collapse; font-size: .72rem; } .ie-heat td { border: 1px solid var(--bg); padding: .25rem .4rem; text-align: center; color: var(--text); min-width: 44px; } .ie-hlabel { text-align: left !important; color: var(--text-3); background: var(--surface) !important; }
+.ie-mentions { display: flex; flex-wrap: wrap; gap: .35rem; }
+.ie-topic { border: 1px solid var(--line); border-radius: 999px; padding: .15rem .55rem; font-size: .76rem; color: var(--text-2); }
+@media (max-width: 900px) { .ie-grid { grid-template-columns: 1fr; } }
 </style>

--- a/socioprophet-web/client-vue/src/pages/Studio.vue
+++ b/socioprophet-web/client-vue/src/pages/Studio.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+// The unified Studio workspace inside the cockpit — a Foundry/Databricks-class shell with
+// governed Notebooks + Universal Compute Plane (from app-vue) and the full knowledge-engineering
+// bench (Graph Explorer, Query, Analytics, GraphRAG, Resource Browser, Reasoner, Entity Resolution,
+// Ontology — from Prophet Studio). One surface, one design system (.studio-scope), reading the
+// canonical hellgraph-service / owl-reasoner / entity-resolution backends via /svc/*.
+import { ref, computed, watch, markRaw } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import './studio/studio-tokens.css';
+import StudioNotebooks from './studio/StudioNotebooks.vue';
+import StudioCompute from './studio/StudioCompute.vue';
+import GraphExplorer from './studio/GraphExplorer.vue';
+import QueryConsole from './studio/QueryConsole.vue';
+import Analytics from './studio/Analytics.vue';
+import GraphRAG from './studio/GraphRAG.vue';
+import ResourceBrowser from './studio/ResourceBrowser.vue';
+import Reasoner from './studio/Reasoner.vue';
+import EntityResolution from './studio/EntityResolution.vue';
+import Ontology from './studio/Ontology.vue';
+import StudioExperiments from './studio/StudioExperiments.vue';
+import StudioOps from './studio/StudioOps.vue';
+import StudioGovernance from './studio/StudioGovernance.vue';
+import StudioCommons from './studio/StudioCommons.vue';
+
+type Sec = { id: string; label: string; ic: string; comp: any; sub: string; project?: boolean };
+const GROUPS: { group: string; items: Sec[] }[] = [
+  { group: 'Workbench', items: [
+    { id: 'notebooks', label: 'Notebooks', ic: '⬢', comp: markRaw(StudioNotebooks), project: true, sub: 'Ray-backed governed notebooks — receipt per cell' },
+    { id: 'compute', label: 'Compute Plane', ic: '⛩', comp: markRaw(StudioCompute), project: true, sub: 'Universal Compute Plane — one governed, proof-carrying door' },
+  ]},
+  { group: 'Knowledge engineering', items: [
+    { id: 'graph', label: 'Graph Explorer', ic: '⟡', comp: markRaw(GraphExplorer), sub: 'Force-directed graph + provenance inspector' },
+    { id: 'query', label: 'Query Console', ic: '⌘', comp: markRaw(QueryConsole), sub: 'SPARQL · Cypher · Gremlin over the live kernel' },
+    { id: 'analytics', label: 'Analytics', ic: '📈', comp: markRaw(Analytics), sub: 'PageRank / components on the Rust kernel' },
+    { id: 'graphrag', label: 'GraphRAG', ic: '✦', comp: markRaw(GraphRAG), sub: 'Ask the graph, cited answers' },
+    { id: 'resource', label: 'Resource Browser', ic: '◈', comp: markRaw(ResourceBrowser), sub: 'Dereferenceable Linked Data' },
+  ]},
+  { group: 'Reason & Resolve', items: [
+    { id: 'reasoner', label: 'Reasoner', ic: '⊢', comp: markRaw(Reasoner), sub: 'RDFS/OWL entailment + proof trees' },
+    { id: 'er', label: 'Entity Resolution', ic: '⚭', comp: markRaw(EntityResolution), sub: 'Proof-carrying record linkage' },
+    { id: 'ontology', label: 'Ontology', ic: '❖', comp: markRaw(Ontology), sub: 'Docs + TBox graph' },
+  ]},
+  { group: 'Operations & Governance', items: [
+    { id: 'experiments', label: 'Experiments', ic: '⚗', comp: markRaw(StudioExperiments), project: true, sub: 'Runs as proof-carrying graph facts' },
+    { id: 'operations', label: 'Operations', ic: '⚙', comp: markRaw(StudioOps), project: true, sub: 'Pipelines · registry · catalog · communities' },
+    { id: 'governance', label: 'Governance', ic: '🛡', comp: markRaw(StudioGovernance), project: true, sub: 'Ontology · SHACL actions · GAIA membrane' },
+    { id: 'commons', label: 'Commons', ic: '❖', comp: markRaw(StudioCommons), project: true, sub: 'Proof-carrying knowledge commons' },
+  ]},
+];
+const flat = GROUPS.flatMap((g) => g.items);
+
+const route = useRoute();
+const router = useRouter();
+const project = ref('Untitled project');
+const current = ref(sectionFromQuery());
+function sectionFromQuery(): string {
+  const s = (route.query.section as string) || (route.query.tab === 'compute' ? 'compute' : 'notebooks');
+  return flat.some((i) => i.id === s) ? s : 'notebooks';
+}
+watch(() => route.query.section, () => { current.value = sectionFromQuery(); });
+const active = computed(() => flat.find((i) => i.id === current.value) ?? flat[0]);
+function go(id: string) { current.value = id; router.replace({ query: { ...route.query, section: id, tab: undefined } }); }
+</script>
+
+<template>
+  <div class="studio-scope studio-shell">
+    <aside class="st-rail">
+      <div class="st-brand"><b>Studio</b><small>sovereign data + AI workbench</small></div>
+      <nav class="st-nav">
+        <template v-for="g in GROUPS" :key="g.group">
+          <div class="st-group">{{ g.group }}</div>
+          <a v-for="i in g.items" :key="i.id" :class="{ on: current === i.id }" @click="go(i.id)">
+            <span class="st-ic">{{ i.ic }}</span>{{ i.label }}
+          </a>
+        </template>
+      </nav>
+    </aside>
+    <section class="st-main">
+      <header class="st-top">
+        <div><h1>{{ active.label }}</h1><span class="st-sub">{{ active.sub }}</span></div>
+        <span class="pill accent">proof-carrying · sovereign</span>
+      </header>
+      <div class="st-view">
+        <component :is="active.comp" :key="active.id" v-bind="active.project ? { project } : {}" />
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.studio-shell { display: grid; grid-template-columns: 216px 1fr; height: calc(100vh - 7rem); min-height: 520px; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: var(--bg); color: var(--text); }
+.st-rail { background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
+.st-brand { padding: .9rem 1rem; border-bottom: 1px solid var(--border); }
+.st-brand b { font-size: 1rem; }
+.st-brand small { display: block; color: var(--faint); font-size: .62rem; text-transform: uppercase; letter-spacing: .08em; margin-top: .1rem; }
+.st-nav { padding: .5rem; overflow-y: auto; flex: 1; }
+.st-group { color: var(--faint); font-size: .62rem; text-transform: uppercase; letter-spacing: .09em; padding: .8rem .6rem .25rem; }
+.st-nav a { display: flex; align-items: center; gap: .55rem; padding: .45rem .6rem; border-radius: 8px; color: var(--muted); cursor: pointer; font-size: .84rem; user-select: none; }
+.st-nav a:hover { background: var(--panel-2); color: var(--text); }
+.st-nav a.on { background: #1b2740; color: var(--text); }
+.st-ic { width: 16px; text-align: center; opacity: .85; }
+.st-main { display: flex; flex-direction: column; overflow: hidden; }
+.st-top { display: flex; align-items: center; justify-content: space-between; gap: .8rem; padding: .7rem 1.1rem; border-bottom: 1px solid var(--border); background: var(--panel); }
+.st-top h1 { font-size: 1rem; margin: 0; font-weight: 600; }
+.st-sub { color: var(--muted); font-size: .8rem; }
+.st-view { flex: 1; overflow: auto; padding: 1.1rem 1.2rem; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/Analytics.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/Analytics.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from './api'
+
+const busy = ref(false)
+const err = ref('')
+const pr = ref<any | null>(null)
+const cc = ref<any | null>(null)
+
+async function runPr() { busy.value = true; err.value = ''; try { pr.value = await graph.analytics('pagerank', 25) } catch (e) { err.value = fmt(e) } finally { busy.value = false } }
+async function runCc() { busy.value = true; err.value = ''; try { cc.value = await graph.analytics('components', 1) } catch (e) { err.value = fmt(e) } finally { busy.value = false } }
+function fmt(e: unknown) { return e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+</script>
+
+<template>
+  <div class="card">
+    <h3>Graph analytics — the benchmarked Rust CSR kernel</h3>
+    <p class="desc">PageRank &amp; connected components run on the <code>hg_analytics</code> kernel measured in the published benchmark, compiled into the service via N-API. Every result reports which backend served it.</p>
+    <div class="row"><button class="btn" :disabled="busy" @click="runPr">Run PageRank</button><button class="btn ghost" :disabled="busy" @click="runCc">Connected components</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="pr || cc">
+    <div class="card" v-if="pr">
+      <div class="row" style="justify-content:space-between"><h3>PageRank</h3><span class="pill accent">{{ pr.backend }}</span></div>
+      <div class="row" style="gap:2rem; margin:.5rem 0 .8rem">
+        <div><div class="kpi">{{ pr.nodes }}</div><div class="kpi-l">nodes</div></div>
+        <div><div class="kpi">{{ pr.edges }}</div><div class="kpi-l">edges</div></div>
+      </div>
+      <div class="scroll"><table class="tbl"><thead><tr><th>#</th><th>node</th><th>score</th></tr></thead>
+        <tbody><tr v-for="(t,i) in pr.top" :key="t.id"><td>{{ i+1 }}</td><td style="word-break:break-all">{{ t.id }}</td><td>{{ t.score }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card" v-if="cc">
+      <div class="row" style="justify-content:space-between"><h3>Connected components</h3><span class="pill accent">{{ cc.backend }}</span></div>
+      <div class="row" style="gap:2rem; margin-top:.6rem">
+        <div><div class="kpi">{{ cc.components }}</div><div class="kpi-l">components</div></div>
+        <div><div class="kpi">{{ cc.largest }}</div><div class="kpi-l">largest</div></div>
+        <div><div class="kpi">{{ cc.nodes }}</div><div class="kpi-l">nodes</div></div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/EntityResolution.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/EntityResolution.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { er, ApiError } from './api'
+
+const SAMPLE = JSON.stringify([
+  { id: 'r1', name: 'Acme Corporation', attributes: { city: 'NYC', email: 'info@acme.com' } },
+  { id: 'r2', name: 'Acme Corp', attributes: { city: 'NYC' } },
+  { id: 'r3', name: 'Acme Corporation', attributes: { city: 'NYC', email: 'other@acme.com' } },
+], null, 2)
+const input = ref(SAMPLE)
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function run() {
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await er.resolve(JSON.parse(input.value)) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+const decisionClass = (d: string) => d === 'MERGE_VERIFIED' ? 'good' : d === 'MERGE_BLOCKED' ? 'bad' : ''
+</script>
+
+<template>
+  <div class="card">
+    <h3>Entity resolution — proof-carrying, identity-is-prime-conformant</h3>
+    <p class="desc">Blocking → similarity → margin-gated + conflict-aware clustering. Records with conflicting exclusive keys can never merge (not even transitively), and every decision is a replayable certificate.</p>
+    <textarea v-model="input" rows="9" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem"><button class="btn" :disabled="busy" @click="run">{{ busy ? 'Resolving…' : 'Resolve ▶' }}</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <template v-if="res">
+    <div class="card">
+      <div class="row" style="gap:2rem">
+        <div><div class="kpi">{{ res.records }}</div><div class="kpi-l">records</div></div>
+        <div><div class="kpi">{{ res.entities.length }}</div><div class="kpi-l">entities</div></div>
+        <div><div class="kpi">{{ res.merged }}</div><div class="kpi-l">merged</div></div>
+        <div><div class="kpi">{{ (res.review_queue||[]).length }}</div><div class="kpi-l">review</div></div>
+        <div><div class="kpi">{{ (res.blocked||[]).length }}</div><div class="kpi-l">blocked</div></div>
+      </div>
+      <div class="muted mono" style="margin-top:.6rem; font-size:.72rem" v-if="res.replay_key">replay key · {{ res.replay_key.resolver_version }} / {{ res.replay_key.policy_version }} / {{ res.replay_key.template_version }}</div>
+    </div>
+    <div class="card">
+      <h3>Golden records</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>entity</th><th>survivor</th><th>name</th><th>members</th></tr></thead>
+        <tbody><tr v-for="(g,eid) in res.golden_records" :key="eid"><td>{{ eid }}</td><td>{{ g.survivor }}</td><td>{{ g.name }}</td><td>{{ (g.members||[]).join(', ') }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Decision ledger</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>a</th><th>b</th><th>decision</th><th>score</th><th>evidence</th></tr></thead>
+        <tbody><tr v-for="(d,i) in res.decision_ledger" :key="i">
+          <td>{{ d.a }}</td><td>{{ d.b }}</td><td><span class="pill" :class="decisionClass(d.decision)">{{ d.decision }}</span></td>
+          <td>{{ d.score }}</td><td class="muted">{{ d.evidence?.conflict_field ? 'conflict:'+d.evidence.conflict_field : (d.evidence?.prime_veto || (d.evidence?.matched_attributes||[]).join(',')) }}</td>
+        </tr></tbody></table></div>
+    </div>
+  </template>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/ForceGraph.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/ForceGraph.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+/** Dependency-free force-directed graph on <canvas> — Fruchterman-Reingold-ish, with drag + click-to-select. */
+import { ref, onMounted, onBeforeUnmount, watch } from 'vue'
+
+const props = defineProps<{ nodes: { id: string; label?: string; group?: string }[]; edges: { source: string; target: string }[] }>()
+const emit = defineEmits<{ (e: 'select', id: string): void }>()
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+let raf = 0
+type P = { id: string; label: string; group?: string; x: number; y: number; vx: number; vy: number }
+let pts: P[] = []
+let idx = new Map<string, P>()
+let links: { a: P; b: P }[] = []
+let dragging: P | null = null
+let hover: P | null = null
+const PALETTE = ['#4f8cff', '#6ad2b0', '#f0b849', '#c98bff', '#ff8fa3', '#66d9e8', '#9ae66e']
+const groupColor = new Map<string, string>()
+function colorFor(g?: string): string {
+  const key = g ?? '·'
+  if (!groupColor.has(key)) groupColor.set(key, PALETTE[groupColor.size % PALETTE.length])
+  return groupColor.get(key)!
+}
+
+function build() {
+  const c = canvas.value!; const w = c.width, h = c.height
+  pts = props.nodes.slice(0, 600).map((n, i) => ({
+    id: n.id, label: n.label ?? n.id.split(/[:/#]/).pop() ?? n.id, group: n.group,
+    x: w / 2 + Math.cos(i) * (80 + i % 120), y: h / 2 + Math.sin(i) * (80 + i % 120), vx: 0, vy: 0,
+  }))
+  idx = new Map(pts.map((p) => [p.id, p]))
+  links = props.edges.map((e) => ({ a: idx.get(e.source)!, b: idx.get(e.target)! })).filter((l) => l.a && l.b)
+}
+
+function step() {
+  const c = canvas.value; if (!c) return
+  const w = c.width, h = c.height, ctx = c.getContext('2d')!
+  const k = 42 // ideal edge length scale
+  // repulsion
+  for (let i = 0; i < pts.length; i++) for (let j = i + 1; j < pts.length; j++) {
+    const a = pts[i], b = pts[j]; let dx = a.x - b.x, dy = a.y - b.y; let d2 = dx * dx + dy * dy || 0.01
+    const f = (k * k) / d2; const d = Math.sqrt(d2)
+    const fx = (dx / d) * f, fy = (dy / d) * f
+    a.vx += fx; a.vy += fy; b.vx -= fx; b.vy -= fy
+  }
+  // attraction along edges
+  for (const l of links) {
+    let dx = l.a.x - l.b.x, dy = l.a.y - l.b.y; const d = Math.sqrt(dx * dx + dy * dy) || 0.01
+    const f = (d * d) / k / 8; const fx = (dx / d) * f, fy = (dy / d) * f
+    l.a.vx -= fx; l.a.vy -= fy; l.b.vx += fx; l.b.vy += fy
+  }
+  // integrate + gravity to center + damping
+  for (const p of pts) {
+    if (p === dragging) { p.vx = p.vy = 0; continue }
+    p.vx += (w / 2 - p.x) * 0.002; p.vy += (h / 2 - p.y) * 0.002
+    p.vx *= 0.86; p.vy *= 0.86
+    p.x += Math.max(-8, Math.min(8, p.vx)); p.y += Math.max(-8, Math.min(8, p.vy))
+    p.x = Math.max(14, Math.min(w - 14, p.x)); p.y = Math.max(14, Math.min(h - 14, p.y))
+  }
+  // draw
+  ctx.clearRect(0, 0, w, h)
+  ctx.strokeStyle = 'rgba(120,140,170,0.22)'; ctx.lineWidth = 1
+  for (const l of links) { ctx.beginPath(); ctx.moveTo(l.a.x, l.a.y); ctx.lineTo(l.b.x, l.b.y); ctx.stroke() }
+  for (const p of pts) {
+    const r = p === hover ? 7 : 5
+    ctx.beginPath(); ctx.arc(p.x, p.y, r, 0, Math.PI * 2); ctx.fillStyle = colorFor(p.group); ctx.fill()
+    if (p === hover || pts.length < 60) {
+      ctx.fillStyle = '#c7d2e0'; ctx.font = '11px ui-monospace, monospace'
+      ctx.fillText(p.label.slice(0, 22), p.x + 8, p.y + 3)
+    }
+  }
+  raf = requestAnimationFrame(step)
+}
+
+function at(ev: MouseEvent): P | null {
+  const c = canvas.value!; const rect = c.getBoundingClientRect()
+  const x = (ev.clientX - rect.left) * (c.width / rect.width), y = (ev.clientY - rect.top) * (c.height / rect.height)
+  let best: P | null = null, bd = 144
+  for (const p of pts) { const d = (p.x - x) ** 2 + (p.y - y) ** 2; if (d < bd) { bd = d; best = p } }
+  return best
+}
+function down(e: MouseEvent) { dragging = at(e); if (dragging) emit('select', dragging.id) }
+function move(e: MouseEvent) {
+  hover = at(e)
+  if (dragging) { const c = canvas.value!, rect = c.getBoundingClientRect()
+    dragging.x = (e.clientX - rect.left) * (c.width / rect.width); dragging.y = (e.clientY - rect.top) * (c.height / rect.height) }
+}
+function up() { dragging = null }
+
+function resize() { const c = canvas.value; if (!c) return; const r = c.parentElement!.getBoundingClientRect(); c.width = r.width; c.height = r.height }
+onMounted(() => { resize(); build(); step(); window.addEventListener('resize', resize) })
+onBeforeUnmount(() => { cancelAnimationFrame(raf); window.removeEventListener('resize', resize) })
+watch(() => [props.nodes, props.edges], () => { resize(); build() }, { deep: true })
+</script>
+
+<template>
+  <div style="position:relative; width:100%; height:100%; min-height:420px;">
+    <canvas ref="canvas" style="width:100%; height:100%; display:block; cursor:grab;"
+      @mousedown="down" @mousemove="move" @mouseup="up" @mouseleave="up" />
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/GraphExplorer.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/GraphExplorer.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { graph, ApiError } from './api'
+import ForceGraph from './ForceGraph.vue'
+
+const label = ref('')
+const limit = ref(300)
+const busy = ref(false)
+const err = ref('')
+const nodes = ref<{ id: string; label?: string; group?: string }[]>([])
+const edges = ref<{ source: string; target: string }[]>([])
+const stats = ref<{ count: number; edges: number }>({ count: 0, edges: 0 })
+const selected = ref<any | null>(null)
+const rawNodes = ref<Record<string, any>>({})
+
+async function load() {
+  busy.value = true; err.value = ''; selected.value = null
+  try {
+    const r = await graph.subgraph(label.value, limit.value)
+    stats.value = { count: r.count, edges: r.edges }
+    rawNodes.value = Object.fromEntries(r.nodes.map((n: any) => [n.id, n]))
+    nodes.value = r.nodes.map((n: any) => ({ id: n.id, label: n.properties?.name ?? n.labels?.[0] ?? n.id, group: n.labels?.[0] }))
+    edges.value = r.edgeList.map((e: any) => ({ source: e.from, target: e.to }))
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function onSelect(id: string) { selected.value = rawNodes.value[id] ?? { id } }
+onMounted(load)
+</script>
+
+<template>
+  <div class="grid" style="grid-template-columns: 1fr 320px; height: calc(100vh - 132px)">
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <div class="row" style="margin-bottom:.7rem">
+        <input v-model="label" type="text" placeholder="filter by label (blank = whole graph)" style="max-width:280px" @keyup.enter="load" />
+        <select v-model.number="limit" style="width:auto"><option :value="100">100</option><option :value="300">300</option><option :value="600">600</option></select>
+        <button class="btn" :disabled="busy" @click="load">{{ busy ? 'Loading…' : 'Explore' }}</button>
+        <span class="muted">·</span>
+        <span class="pill">{{ stats.count }} nodes</span><span class="pill">{{ stats.edges }} edges</span>
+      </div>
+      <div v-if="err" class="err" style="margin-bottom:.5rem">⚠ {{ err }}</div>
+      <div style="flex:1; min-height:0; border:1px solid var(--border); border-radius:8px; overflow:hidden">
+        <ForceGraph :nodes="nodes" :edges="edges" @select="onSelect" />
+      </div>
+    </div>
+
+    <div class="card" style="overflow:auto">
+      <h3>Inspector</h3>
+      <p class="desc">Click a node. Every node carries its provenance — the moat a plain graph viewer can't show.</p>
+      <div v-if="!selected" class="muted">No selection.</div>
+      <template v-else>
+        <div class="kpi-l">ID</div>
+        <div class="mono" style="word-break:break-all; margin-bottom:.6rem">{{ selected.id }}</div>
+        <div class="kpi-l">Labels</div>
+        <div class="row" style="margin-bottom:.6rem"><span v-for="l in (selected.labels ?? [])" :key="l" class="pill accent">{{ l }}</span></div>
+        <div class="kpi-l">Properties</div>
+        <table class="tbl" style="margin-top:.3rem"><tbody>
+          <tr v-for="(v,k) in (selected.properties ?? {})" :key="k"><td class="muted">{{ k }}</td><td>{{ v }}</td></tr>
+        </tbody></table>
+        <div style="margin-top:.8rem"><a class="link" :href="`#resource:${encodeURIComponent(selected.id)}`">Open in Resource Browser →</a></div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/GraphRAG.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/GraphRAG.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from './api'
+
+const q = ref('')
+const hops = ref(1)
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function ask() {
+  if (!q.value.trim()) return
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await graph.ask(q.value) } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+async function ground() {
+  if (!q.value.trim()) return
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = { grounding: await graph.ground(q.value, hops.value) } } catch (e) { err.value = String(e) } finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>GraphRAG — ask the graph, get a provenance-cited answer</h3>
+    <p class="desc">Retrieval seeds semantically (embedding cosine) when a sovereign embeddings endpoint is configured, else lexically; the answer may only cite retrieved facts — every citation carries an assertion-time receipt.</p>
+    <textarea v-model="q" rows="2" placeholder="e.g. what is Acme Aerospace connected to?" @keyup.ctrl.enter="ask"></textarea>
+    <div class="row" style="margin-top:.6rem">
+      <button class="btn" :disabled="busy" @click="ask">Ask ▶</button>
+      <button class="btn ghost" :disabled="busy" @click="ground">Show grounding</button>
+      <span class="muted">hops</span>
+      <select v-model.number="hops" style="width:auto"><option :value="1">1</option><option :value="2">2</option><option :value="3">3</option></select>
+    </div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="card" v-if="res && res.answer">
+    <div class="row" style="justify-content:space-between"><h3>Answer</h3>
+      <span class="pill" :class="res.synthesized ? 'good' : ''">{{ res.synthesized ? 'synthesized' : 'extractive (no LLM configured)' }}</span></div>
+    <p v-if="res.answer" style="line-height:1.55; white-space:pre-wrap">{{ res.answer }}</p>
+    <p v-else class="muted">No LLM configured — the citations below are the grounded answer.</p>
+  </div>
+
+  <div class="card" v-if="res">
+    <div class="row" style="justify-content:space-between"><h3>Citations ({{ (res.citations ?? res.grounding?.citations ?? []).length }})</h3>
+      <span v-if="res.grounding?.retrieval || res.retrieval" class="pill accent">{{ res.grounding?.retrieval || res.retrieval }}</span></div>
+    <div class="scroll"><table class="tbl"><thead><tr><th>#</th><th>fact</th><th>asserted</th></tr></thead>
+      <tbody><tr v-for="c in (res.citations ?? res.grounding?.citations ?? [])" :key="c.n">
+        <td>{{ c.n }}</td><td style="word-break:break-word">{{ c.fact }}</td><td class="muted">{{ (c.assertedAt||'').slice(0,19) }}</td>
+      </tr></tbody></table></div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/Ontology.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/Ontology.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { reasoner, ApiError } from './api'
+import ForceGraph from './ForceGraph.vue'
+
+const SAMPLE = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex: <http://ex/> .
+ex: a owl:Ontology ; rdfs:label "Example" .
+ex:Animal a owl:Class ; rdfs:label "Animal" ; rdfs:comment "A living creature." .
+ex:Dog a owl:Class ; rdfs:label "Dog" ; rdfs:subClassOf ex:Animal .
+ex:Person a owl:Class ; rdfs:label "Person" .
+ex:owns a owl:ObjectProperty ; rdfs:label "owns" ; rdfs:domain ex:Person ; rdfs:range ex:Dog .`
+const turtle = ref(SAMPLE)
+const busy = ref(false)
+const err = ref('')
+const doc = ref<any | null>(null)
+const gnodes = ref<any[]>([])
+const gedges = ref<any[]>([])
+
+async function run() {
+  busy.value = true; err.value = ''; doc.value = null
+  try {
+    const [d, g] = await Promise.all([reasoner.ontologyDoc(turtle.value), reasoner.ontologyGraph(turtle.value)])
+    doc.value = d
+    gnodes.value = (g.nodes || []).map((n: any) => ({ id: n.id, label: n.label, group: n.type }))
+    gedges.value = (g.edges || []).map((e: any) => ({ source: e.source, target: e.target }))
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>Ontology workbench — docs + VOWL-style class graph</h3>
+    <p class="desc">Paste OWL/Turtle → browsable documentation (pyLODE/Widoco-class) and a rendered TBox graph of classes and object-property domain→range.</p>
+    <textarea v-model="turtle" rows="8" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem"><button class="btn" :disabled="busy" @click="run">{{ busy ? 'Building…' : 'Render' }}</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="doc" style="height: 60vh">
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <h3>{{ doc.header?.title || 'Ontology' }}</h3>
+      <p class="desc">{{ doc.counts?.classes }} classes · {{ doc.counts?.properties }} properties</p>
+      <div class="scroll" style="flex:1">
+        <table class="tbl"><thead><tr><th>class</th><th>super-classes</th><th>comment</th></tr></thead>
+          <tbody><tr v-for="c in doc.classes" :key="c.uri"><td>{{ c.label }}</td><td class="muted">{{ (c.superClasses||[]).map((s:string)=>s.split(/[#/]/).pop()).join(', ') }}</td><td class="muted">{{ c.comment }}</td></tr></tbody></table>
+      </div>
+    </div>
+    <div class="card" style="display:flex; flex-direction:column; min-height:0">
+      <h3>TBox graph</h3>
+      <div style="flex:1; min-height:0; border:1px solid var(--border); border-radius:8px; overflow:hidden"><ForceGraph :nodes="gnodes" :edges="gedges" /></div>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/QueryConsole.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/QueryConsole.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { graph, ApiError } from './api'
+
+const lang = ref<'sparql' | 'cypher' | 'gremlin'>('sparql')
+const samples: Record<string, string> = {
+  sparql: 'SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 25',
+  cypher: 'MATCH (n) RETURN n LIMIT 25',
+  gremlin: 'g.V().limit(25)',
+}
+const q = ref(samples.sparql)
+const busy = ref(false)
+const err = ref('')
+const cols = ref<string[]>([])
+const rows = ref<any[]>([])
+const meta = ref<Record<string, any>>({})
+
+function pick(l: 'sparql' | 'cypher' | 'gremlin') { lang.value = l; q.value = samples[l]; cols.value = []; rows.value = []; err.value = '' }
+
+async function run() {
+  busy.value = true; err.value = ''; cols.value = []; rows.value = []; meta.value = {}
+  try {
+    const r = lang.value === 'sparql' ? await graph.sparql(q.value)
+      : lang.value === 'cypher' ? await graph.cypher(q.value)
+        : await graph.gremlin(q.value)
+    if (lang.value === 'sparql') { cols.value = r.variables ?? []; rows.value = (r.bindings ?? []).map((b: any) => cols.value.map((c) => b[c])) ; meta.value = { evaluatedAtSeq: r.evaluatedAtSeq } }
+    else if (lang.value === 'cypher') { cols.value = r.columns ?? []; rows.value = (r.rows ?? []).map((row: any) => cols.value.map((c) => row[c])); meta.value = { queryHash: r.queryHash, evaluatedAtSeq: r.evaluatedAtSeq } }
+    else { cols.value = ['value']; rows.value = (r.values ?? []).map((v: any) => [typeof v === 'object' ? JSON.stringify(v) : v]); meta.value = { count: r.count } }
+  } catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="row" style="justify-content:space-between">
+      <div class="row">
+        <button v-for="l in (['sparql','cypher','gremlin'] as const)" :key="l" class="btn ghost"
+          :style="lang===l ? 'border-color:var(--accent); color:var(--accent)' : ''" @click="pick(l)">{{ l.toUpperCase() }}</button>
+      </div>
+      <button class="btn" :disabled="busy" @click="run">{{ busy ? 'Running…' : 'Run ▶' }}</button>
+    </div>
+    <p class="desc" style="margin-top:.7rem">Proof-carrying query surface. Unsupported syntax throws an explicit error — never a silently-wrong empty result.</p>
+    <textarea v-model="q" rows="5" spellcheck="false"></textarea>
+  </div>
+
+  <div class="card" v-if="err"><div class="err">⚠ {{ err }}</div></div>
+
+  <div class="card" v-if="cols.length">
+    <div class="row" style="justify-content:space-between; margin-bottom:.6rem">
+      <h3>{{ rows.length }} rows</h3>
+      <div class="row">
+        <span v-if="meta.queryHash" class="pill accent mono" :title="meta.queryHash">⛓ {{ String(meta.queryHash).slice(0, 18) }}…</span>
+        <span v-if="meta.evaluatedAtSeq!=null" class="pill">seq {{ meta.evaluatedAtSeq }}</span>
+      </div>
+    </div>
+    <div class="scroll">
+      <table class="tbl">
+        <thead><tr><th v-for="c in cols" :key="c">{{ c }}</th></tr></thead>
+        <tbody><tr v-for="(r,i) in rows" :key="i"><td v-for="(cell,j) in r" :key="j">{{ cell }}</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/Reasoner.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/Reasoner.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { reasoner, ApiError } from './api'
+
+const SAMPLE = `@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://ex/> .
+ex:A rdfs:subClassOf ex:B .
+ex:B rdfs:subClassOf ex:C .
+ex:C rdfs:subClassOf ex:D .
+ex:x a ex:A .`
+const turtle = ref(SAMPLE)
+const inference = ref('rdfs')
+const busy = ref(false)
+const err = ref('')
+const res = ref<any | null>(null)
+
+async function run() {
+  busy.value = true; err.value = ''; res.value = null
+  try { res.value = await reasoner.reason(turtle.value, inference.value, true) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function renderProof(node: any, depth = 0): string {
+  const pad = '  '.repeat(depth)
+  if (node.asserted) return `${pad}• ${node.conclusion}  (asserted)`
+  const head = `${pad}⊢ ${node.conclusion}   [${node.rule}]`
+  return [head, ...(node.premises ?? []).map((p: any) => renderProof(p, depth + 1))].join('\n')
+}
+</script>
+
+<template>
+  <div class="card">
+    <h3>Reasoner — RDFS / OWL 2 RL entailment with SOUND proof trees</h3>
+    <p class="desc">Every entailment is justified by a proof grounded in <em>asserted</em> facts (never underived premises), and coverage is reported honestly — the "why" opaque reasoners hide.</p>
+    <textarea v-model="turtle" rows="7" spellcheck="false"></textarea>
+    <div class="row" style="margin-top:.6rem">
+      <select v-model="inference" style="width:auto"><option value="rdfs">RDFS</option><option value="owl2rl">OWL 2 RL</option><option value="both">Both</option></select>
+      <button class="btn" :disabled="busy" @click="run">{{ busy ? 'Reasoning…' : 'Reason ▶' }}</button>
+    </div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="res">
+    <div class="card">
+      <div class="row" style="gap:2rem">
+        <div><div class="kpi">{{ res.entailed_triples }}</div><div class="kpi-l">entailed</div></div>
+        <div><div class="kpi">{{ res.justification_coverage?.explained ?? '—' }}</div><div class="kpi-l">explained</div></div>
+        <div><div class="kpi">{{ res.profile }}</div><div class="kpi-l">profile</div></div>
+      </div>
+      <h3 style="margin-top:1rem">Entailments</h3>
+      <div class="scroll"><table class="tbl"><tbody><tr v-for="(e,i) in res.entailments" :key="i"><td>{{ e }}</td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Proof trees</h3>
+      <p class="desc" v-if="res.justification_coverage">{{ res.justification_coverage.explained }} of {{ res.justification_coverage.of }} explained; the rest are OWL-RL axiomatic noise or rules outside the covered subset — counted, not hidden.</p>
+      <pre class="out" v-for="(j,i) in (res.justifications ?? [])" :key="i">{{ renderProof(j) }}</pre>
+      <div v-if="!(res.justifications ?? []).length" class="muted">No attributable proofs for this input.</div>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/ResourceBrowser.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/ResourceBrowser.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { graph, ApiError } from './api'
+
+const uri = ref('')
+const busy = ref(false)
+const err = ref('')
+const cbd = ref<any | null>(null)
+
+async function load() {
+  if (!uri.value.trim()) return
+  busy.value = true; err.value = ''; cbd.value = null
+  try { cbd.value = await graph.resource(uri.value) }
+  catch (e) { err.value = e instanceof ApiError ? `${e.status}: ${e.message}` : String(e) }
+  finally { busy.value = false }
+}
+function open(u: string) { uri.value = u; load() }
+onMounted(() => {
+  const m = location.hash.match(/^#resource:(.+)$/)
+  if (m) { uri.value = decodeURIComponent(m[1]); load() }
+})
+</script>
+
+<template>
+  <div class="card">
+    <h3>Resource browser — dereferenceable Linked Data</h3>
+    <p class="desc">Paste any resource URI → its Concise Bounded Description (facts + back-links), the gist/Prez/Pubby affordance. Object IRIs are clickable — walk the graph.</p>
+    <div class="row"><input v-model="uri" type="text" placeholder="e.g. proj-x:ent:acme" @keyup.enter="load" /><button class="btn" :disabled="busy" @click="load">Resolve</button></div>
+    <div v-if="err" class="err" style="margin-top:.6rem">⚠ {{ err }}</div>
+  </div>
+
+  <div class="grid cols-2" v-if="cbd">
+    <div class="card">
+      <h3>Facts ({{ (cbd.outgoing||[]).length }})</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>predicate</th><th>object</th></tr></thead>
+        <tbody><tr v-for="(t,i) in cbd.outgoing" :key="i"><td class="muted">{{ t.predicate }}</td>
+          <td><a v-if="t.isIri" class="link" @click="open(String(t.object))">{{ t.object }}</a><span v-else>{{ t.object }}</span></td></tr></tbody></table></div>
+    </div>
+    <div class="card">
+      <h3>Referenced by ({{ (cbd.incoming||[]).length }})</h3>
+      <div class="scroll"><table class="tbl"><thead><tr><th>subject</th><th>via</th></tr></thead>
+        <tbody><tr v-for="(t,i) in cbd.incoming" :key="i"><td><a class="link" @click="open(t.subject)">{{ t.subject }}</a></td><td class="muted">{{ t.predicate }}</td></tr></tbody></table></div>
+    </div>
+  </div>
+</template>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioCommons.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioCommons.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+// The proof-carrying knowledge COMMONS panel (WS#36–39): surfaces preservation/versioning, FAIR+ metadata,
+// scholarly + agent ecosystem hooks, commons-at-scale stats, and epistemic-weighted community curation —
+// the repository fundamentals (Zenodo/OSF/Wikidata) MET, then BEATEN with our epistemic + provenance layer.
+import { ref, onMounted, watch } from "vue";
+import {
+  loadCommons, loadFair, loadEcosystem, loadVersions, loadCuration, endorse, EPISTEMIC_COLORS,
+  type Commons, type Fair, type Ecosystem, type Versions, type Curation,
+} from "../../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const commons = ref<Commons | null>(null);
+const fair = ref<Fair | null>(null);
+const eco = ref<Ecosystem | null>(null);
+const versions = ref<Versions | null>(null);
+const curation = ref<Curation | null>(null);
+const loading = ref(true);
+const err = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try {
+    [commons.value, fair.value, eco.value, versions.value, curation.value] = await Promise.all([
+      loadCommons(props.project), loadFair(props.project), loadEcosystem(props.project),
+      loadVersions(props.project), loadCuration(props.project),
+    ]);
+  } catch (e) { err.value = e instanceof Error ? e.message : "failed to load commons"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+// endorse form
+const showEndorse = ref(false);
+const eTarget = ref("");
+const eEndorser = ref("");
+const eNote = ref("");
+const eToken = ref("");
+const posting = ref(false);
+const eMsg = ref(""); const eErr = ref("");
+async function submitEndorse() {
+  posting.value = true; eMsg.value = ""; eErr.value = "";
+  try {
+    if (!eTarget.value.trim() || !eEndorser.value.trim()) throw new Error("target and endorser required");
+    const r = await endorse({ project: props.project, target: eTarget.value.trim(), endorser: eEndorser.value.trim(), note: eNote.value.trim() || undefined }, eToken.value);
+    eMsg.value = `Endorsed ${r.target}`; eTarget.value = ""; eNote.value = "";
+    await load();
+  } catch (e) { eErr.value = e instanceof Error ? e.message : "endorse failed"; }
+  finally { posting.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
+function fairFlag(v: boolean): string { return v ? "✓" : "—"; }
+</script>
+
+<template>
+  <div class="cm">
+    <div class="cbar">
+      <span class="cnt" v-if="commons">{{ commons.scale.facts }} facts · {{ commons.scale.preserved_versions }} versions · {{ commons.scale.endorsements }} endorsements</span>
+      <div class="spacer" />
+      <button class="run" @click="showEndorse = !showEndorse">＋ Endorse a fact</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload commons">↻</button>
+    </div>
+
+    <div v-if="showEndorse" class="logbox">
+      <div class="lrow">
+        <input v-model="eTarget" class="j mono" placeholder="target node id (e.g. proj-x:ent:hellgraph)" />
+        <input v-model="eEndorser" class="j" placeholder="endorser (ORCID / sovereign id)" />
+        <input v-model="eNote" class="j" placeholder="note (optional)" />
+        <input v-model="eToken" type="password" class="tok" placeholder="write token" />
+        <button class="primary" @click="submitEndorse" :disabled="posting">{{ posting ? "…" : "Endorse" }}</button>
+      </div>
+      <p v-if="eErr" class="lfeedback err">{{ eErr }}</p>
+      <p v-else-if="eMsg" class="lfeedback ok">✓ {{ eMsg }} — a governed, revocable, proof-carrying endorsement</p>
+    </div>
+
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading the commons…</p>
+
+    <div v-else class="grid">
+      <!-- FAIR+ scorecard -->
+      <section class="card" v-if="fair">
+        <header class="ch"><span class="ci">◈</span> FAIR<span class="plus">+</span> metadata<span class="score" :class="{ hi: fair.fair.score >= 0.75 }">{{ Math.round(fair.fair.score * 100) }}%</span></header>
+        <div class="fair">
+          <span class="fq" :class="{ on: fair.fair.findable }">{{ fairFlag(fair.fair.findable) }} Findable</span>
+          <span class="fq" :class="{ on: fair.fair.accessible }">{{ fairFlag(fair.fair.accessible) }} Accessible</span>
+          <span class="fq" :class="{ on: fair.fair.interoperable }">{{ fairFlag(fair.fair.interoperable) }} Interoperable</span>
+          <span class="fq" :class="{ on: fair.fair.reusable }">{{ fairFlag(fair.fair.reusable) }} Reusable</span>
+        </div>
+        <div class="plusrow">
+          <span class="ptag" v-if="fair.fair_plus.epistemic">epistemic status</span>
+          <span class="ptag" v-if="fair.fair_plus.provenance_chain">provenance chain</span>
+          <span class="ptag" v-if="fair.fair_plus.hash_sealed">hash-sealed</span>
+        </div>
+        <p v-if="fair.hint" class="hint">→ {{ fair.hint }}</p>
+        <div class="ids" v-if="fair.doi || fair.pid">
+          <code v-if="fair.doi" class="mono" :title="'DataCite DOI'">DOI {{ fair.doi }}</code>
+          <code v-if="fair.pid" class="mono" :title="'sovereign persistent id'">{{ fair.pid }}</code>
+        </div>
+        <p class="sub">schema.org/Dataset · DataCite · PROV-O Turtle — beats a bare metadata record: the record carries epistemic status + a verifiable provenance chain.</p>
+      </section>
+
+      <!-- commons at scale + epistemic quality -->
+      <section class="card" v-if="commons">
+        <header class="ch"><span class="ci">◎</span> Commons at scale<span v-if="commons.epistemic_quality_index != null" class="score hi" :title="'epistemic quality index (0–1)'">Q {{ commons.epistemic_quality_index }}</span></header>
+        <div class="scale">
+          <div class="st"><b>{{ commons.scale.facts }}</b><span>facts</span></div>
+          <div class="st"><b>{{ commons.scale.citations }}</b><span>citations</span></div>
+          <div class="st"><b>{{ commons.scale.preserved_versions }}</b><span>versions</span></div>
+          <div class="st"><b>{{ commons.scale.endorsements }}</b><span>endorsements</span></div>
+          <div class="st"><b>{{ commons.scale.contributors }}</b><span>contributors</span></div>
+        </div>
+        <span class="mb-bar" v-if="commons.scale.facts" title="epistemic distribution of the commons">
+          <i v-for="(n, mode) in commons.epistemic_distribution" :key="mode"
+             :style="{ width: (n / commons.scale.facts * 100) + '%', background: color(mode) }" :title="mode + ': ' + n" />
+        </span>
+        <p class="sub">The <b>quality index</b> weights facts by epistemic status — a signal a volume-only repository can't show.</p>
+      </section>
+
+      <!-- preservation chain -->
+      <section class="card" v-if="versions">
+        <header class="ch"><span class="ci">⛭</span> Preservation<span class="score">{{ versions.count }} sealed</span></header>
+        <ul class="vlist" v-if="versions.versions.length">
+          <li v-for="v in versions.versions" :key="v.snapshot_id">
+            <span class="vv">v{{ v.version }}</span>
+            <code class="mono hash" :title="'content hash — re-hash to verify'">{{ (v.content_hash || '').slice(0, 12) }}</code>
+            <span class="when">{{ v.sealed_at }}</span>
+            <span v-if="v.note" class="vnote">{{ v.note }}</span>
+          </li>
+        </ul>
+        <p v-else class="msg">No snapshots yet — Preserve seals a tamper-evident, versioned copy.</p>
+        <p class="sub">Content-addressed &amp; chained (each links its predecessor). An archived fact stays proof-carrying.</p>
+      </section>
+
+      <!-- scholarly + agent ecosystem -->
+      <section class="card" v-if="eco">
+        <header class="ch"><span class="ci">⌘</span> Ecosystem hooks</header>
+        <div class="row2">
+          <a v-if="eco.scholarly.doi_url" class="link mono" :href="eco.scholarly.doi_url" target="_blank" rel="noopener">DOI ↗</a>
+          <span v-if="eco.scholarly.openaire.harvestable" class="ptag">OpenAIRE-harvestable</span>
+        </div>
+        <div class="orcids" v-if="eco.scholarly.orcid_contributors.length">
+          <a v-for="c in eco.scholarly.orcid_contributors" :key="c.orcid" class="orcid" :href="c.orcid_url" target="_blank" rel="noopener" :title="c.orcid">
+            <span class="oic">iD</span> {{ c.name }}
+          </a>
+        </div>
+        <div class="manifest">
+          <span class="mtitle">agent manifest <span v-if="eco.agent_manifest.proof_carrying" class="ptag sm">proof-carrying</span></span>
+          <div class="verbs">
+            <span v-for="vb in eco.agent_manifest.access" :key="vb.name" class="verb" :class="{ off: !vb.endpoint }" :title="vb.endpoint || 'not available'">
+              {{ vb.name }}<i v-if="vb.verifiable && vb.endpoint" class="vok">✓</i>
+            </span>
+          </div>
+        </div>
+        <p class="sub">Discovery repos expose to <i>humans</i>, we also expose to <i>agents</i>: a machine-readable card of verifiable access verbs.</p>
+      </section>
+
+      <!-- community curation -->
+      <section class="card wide" v-if="curation">
+        <header class="ch"><span class="ci">✶</span> Community curation<span class="score" :title="'epistemic-weighted curation score'">score {{ curation.curation_score }}</span></header>
+        <div v-if="curation.endorsements.length" class="cscroll">
+          <table class="cgrid">
+            <thead><tr><th>Endorsed fact</th><th>Endorser</th><th>Note</th><th>When</th></tr></thead>
+            <tbody>
+              <tr v-for="(e, i) in curation.endorsements" :key="i">
+                <td class="mono">{{ e.target }}</td>
+                <td class="mono nm">{{ e.endorser }}</td>
+                <td>{{ e.note || "—" }}</td>
+                <td class="when">{{ e.at }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p v-else class="msg">No endorsements yet — endorse a fact above; it lands as a governed, revocable graph fact.</p>
+        <p class="sub">The score is <b>epistemic-weighted</b>: endorsing an <i>attested</i> fact counts more than a <i>hypothesis</i> — curation follows grounding, not popularity. Revoked endorsements never count.</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cm { font: 14px/1.5 var(--ui); color: var(--ink); }
+.cm :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.cbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
+.cbar .cnt { color: var(--muted); font-size: 12px; } .cbar .spacer { flex: 1; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: var(--r-3); background: var(--sunken); padding: 10px 12px; margin-bottom: 14px; }
+.lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.lrow input.j { flex: 1; min-width: 150px; } .lrow input.tok { width: 120px; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary:disabled { opacity: .6; cursor: default; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); }
+.card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: var(--accent); } .ch .plus { color: var(--accent); font-weight: 700; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.score.hi { color: var(--ok); background: var(--ok-wash); }
+.mono { font-family: var(--mono); font-size: 12px; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
+
+.fair { display: flex; flex-wrap: wrap; gap: 6px; }
+.fq { font-size: 12px; border: 1px solid var(--hairline); color: var(--faint); border-radius: var(--r-2); padding: 3px 9px; }
+.fq.on { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.plusrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.ptag { font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--r-2); padding: 2px 8px; }
+.ptag.sm { font-size: 9.5px; padding: 1px 6px; }
+.hint { color: var(--warn); font-size: 12px; margin: 8px 0 0; }
+.ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.ids code { background: var(--sunken); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 2px 7px; }
+
+.scale { display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 10px; }
+.st { display: flex; flex-direction: column; } .st b { font-size: 20px; font-variant-numeric: tabular-nums; } .st span { font-size: 11px; color: var(--muted); }
+.mb-bar { display: flex; height: 8px; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
+
+.vlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.vlist li { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; }
+.vv { font-weight: 700; color: var(--accent); font-variant-numeric: tabular-nums; } .hash { background: var(--sunken); border-radius: var(--r-1); padding: 1px 6px; }
+.when { color: var(--muted); font-size: 11px; } .vnote { color: var(--muted); font-style: italic; }
+
+.row2 { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 8px; }
+.link { color: var(--accent); text-decoration: none; } .link:hover { text-decoration: underline; }
+.orcids { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+.orcid { display: inline-flex; align-items: center; gap: 5px; font-size: 12px; color: var(--ink); text-decoration: none; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 2px 8px; }
+.orcid .oic { background: #a6ce39; color: #fff; font-size: 9px; font-weight: 700; border-radius: var(--r-1); padding: 1px 3px; }
+.manifest { border-top: 1px solid var(--sunken); padding-top: 8px; }
+.mtitle { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); display: flex; align-items: center; gap: 6px; }
+.verbs { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.verb { font-size: 11.5px; background: var(--sunken); border-radius: var(--r-2); padding: 2px 8px; color: var(--ink); } .verb.off { color: var(--faint); }
+.verb .vok { color: var(--ok); font-style: normal; margin-left: 3px; }
+
+.cscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: var(--r-3); }
+.cgrid { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+.cgrid th { text-align: left; padding: 7px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.cgrid td { padding: 7px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; } .cgrid tr:last-child td { border-bottom: 0; }
+.cgrid .nm { font-weight: 600; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioCompute.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioCompute.vue
@@ -1,0 +1,582 @@
+<script setup lang="ts">
+import { ref, computed, reactive, onMounted } from "vue";
+import {
+  loadComputeRegistry, runCompute, planCompute, EPISTEMIC_COLORS,
+  type ComputeKind, type ComputeResultLite, type ComputePlan,
+} from "../../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+// ── planner: the registry as an agent action space (capabilities → governed plan) ──
+const planCaps = ref("");
+const plan = ref<ComputePlan | null>(null);
+const planning = ref(false);
+const planErr = ref("");
+
+async function doPlan() {
+  const caps = planCaps.value.split(",").map((c) => c.trim()).filter(Boolean);
+  if (!caps.length || planning.value) return;
+  planning.value = true; planErr.value = ""; plan.value = null;
+  try {
+    plan.value = await planCompute({ capabilities: caps, project: props.project });
+  } catch (e) {
+    planErr.value = e instanceof Error ? e.message : "plan failed";
+  } finally {
+    planning.value = false;
+  }
+}
+async function runPlan() {
+  const p = plan.value?.plan;
+  if (!p || running.value) return;
+  running.value = true; runErr.value = ""; result.value = null;
+  try {
+    const res = await runCompute({ kind: "workflow", spec: p.spec as Record<string, unknown>, project: props.project });
+    result.value = res;
+    if (res.status === "ok" || res.status === "degraded") chain.value.unshift(res);
+  } catch (e) {
+    runErr.value = e instanceof Error ? e.message : "run failed";
+  } finally {
+    running.value = false;
+  }
+}
+
+// ── registry (the catalog: "any compute, one door") ──
+const kinds = ref<ComputeKind[]>([]);
+const loading = ref(true);
+const regErr = ref("");
+const selectedKind = ref<string | null>(null);
+
+const selected = computed<ComputeKind | null>(() => kinds.value.find((k) => k.kind === selectedKind.value) ?? null);
+
+onMounted(async () => {
+  try {
+    const r = await loadComputeRegistry(props.project);
+    kinds.value = r.kinds;
+    // default the run panel to the first runnable (live + entitled) kind, else the first kind.
+    const runnable = r.kinds.find((k) => k.status === "live" && k.entitled);
+    pick((runnable ?? r.kinds[0])?.kind ?? null);
+  } catch (e) {
+    regErr.value = e instanceof Error ? e.message : "registry load failed";
+  } finally {
+    loading.value = false;
+  }
+});
+
+// ── epistemic-warrant chip styling — colour off the shared ramp so this reads as the same ink everywhere ──
+const EPI_WASH: Record<string, string> = {
+  hypothesis: "var(--epi-hypothesis-wash)", observed: "var(--epi-observed-wash)",
+  derived: "var(--epi-derived-wash)", verified: "var(--epi-verified-wash)", attested: "var(--epi-attested-wash)",
+};
+function epiStyle(mode: string) {
+  const c = EPISTEMIC_COLORS[mode] || EPISTEMIC_COLORS.unknown;
+  return { color: c, background: EPI_WASH[mode] || "var(--sunken)", borderColor: `color-mix(in srgb, ${c} 40%, transparent)` };
+}
+
+// ── spec editor — fields driven off the selected kind ──
+interface SpecField { key: string; label: string; type: "code" | "text" | "select" | "json"; placeholder?: string; options?: string[]; rows?: number }
+const WORKFLOW_EXAMPLE = `[
+  { "id": "read",  "kind": "graph-stats", "spec": {} },
+  { "id": "cell",  "kind": "notebook",    "spec": { "code": "df.shape" }, "needs": ["read"] }
+]`;
+function fieldsFor(k: ComputeKind | null): SpecField[] {
+  if (!k) return [];
+  switch (k.kind) {
+    case "notebook": return [{ key: "code", label: "Cell code", type: "code", rows: 5, placeholder: "df = load('apple_2024_breach')  # governed dataset\ndf.shape" }];
+    case "spark":    return [{ key: "code", label: "Spark job", type: "code", rows: 5, placeholder: "spark.read.parquet('s3://…').groupBy('cohort').count().show()" }];
+    case "graph-query": return [
+      { key: "lang", label: "Language", type: "select", options: ["sparql", "cypher", "gremlin"] },
+      { key: "query", label: "Query", type: "code", rows: 4, placeholder: "MATCH (n) RETURN n LIMIT 10" },
+    ];
+    case "graph-stats": return [{ key: "metric", label: "Metric", type: "select", options: ["degree", "centrality", "communities"] }];
+    case "inference": return [{ key: "prompt", label: "Prompt", type: "code", rows: 4, placeholder: "Summarize the warrant distribution across the corpus…" }];
+    // the composite kind — a DAG of governed sub-computes; each step gets its own receipt.
+    case "workflow": return [{ key: "steps", label: "Workflow steps (DAG · id · kind · spec · needs)", type: "json", rows: 8, placeholder: WORKFLOW_EXAMPLE }];
+    default: return [{ key: "input", label: "Input", type: "text", placeholder: "spec…" }];
+  }
+}
+const fields = computed(() => fieldsFor(selected.value));
+const spec = reactive<Record<string, string>>({});
+const backend = ref<string>("");
+
+function pick(kind: string | null) {
+  selectedKind.value = kind;
+  // reset the spec to this kind's field defaults
+  for (const key of Object.keys(spec)) delete spec[key];
+  for (const f of fieldsFor(selected.value)) spec[f.key] = f.type === "select" ? (f.options?.[0] ?? "") : (f.type === "json" ? (f.placeholder ?? "") : "");
+  backend.value = selected.value?.default ?? "";
+}
+
+// ── run ──
+const running = ref(false);
+const runErr = ref("");
+const result = ref<ComputeResultLite | null>(null);
+// the receipt chain: every sealed run in this session, newest first (the tamper-evident record).
+const chain = ref<ComputeResultLite[]>([]);
+
+const canRun = computed(() => !!selected.value && !running.value && fields.value.some((f) => (spec[f.key] ?? "").trim().length > 0 || f.type === "select"));
+
+// the gateway returns the provenance subgraph itself (node/edge arrays); surface it as counts.
+const deltaCounts = computed(() => {
+  const d = result.value?.graph_delta;
+  const n = d?.nodes?.length ?? 0, e = d?.edges?.length ?? 0;
+  return (n || e) ? { n, e } : null;
+});
+
+// a workflow result carries its per-step summaries — the DAG execution, each step its own receipt.
+interface WfStep { id: string; kind: string; backend: string; status: string; epistemic_status: string; receipt?: string | null; memoized?: boolean }
+const wfSteps = computed<WfStep[]>(() => {
+  const r = result.value;
+  if (!r || r.kind !== "workflow") return [];
+  const data = r.outputs?.[0]?.data as { steps?: WfStep[] } | undefined;
+  return data?.steps ?? [];
+});
+
+async function run() {
+  const k = selected.value;
+  if (!k || running.value) return;
+  // a workflow's spec is a parsed DAG; everything else passes its fields straight through.
+  let payloadSpec: Record<string, unknown> = { ...spec };
+  if (k.kind === "workflow") {
+    try {
+      const steps = JSON.parse(spec.steps || "[]");
+      if (!Array.isArray(steps)) throw new Error("steps must be a JSON array");
+      payloadSpec = { steps };
+    } catch (e) {
+      runErr.value = `workflow steps: ${e instanceof Error ? e.message : "invalid JSON"}`;
+      return;
+    }
+  }
+  running.value = true; runErr.value = ""; result.value = null;
+  try {
+    const res = await runCompute({ kind: k.kind, spec: payloadSpec, project: props.project, backend: backend.value || undefined });
+    result.value = res;
+    if (res.status === "ok" || res.status === "degraded") chain.value.unshift(res);
+  } catch (e) {
+    runErr.value = e instanceof Error ? e.message : "run failed";
+  } finally {
+    running.value = false;
+  }
+}
+
+function short(id?: string | null) { return id ? String(id).replace(/^sha256:/, "").slice(0, 10) : ""; }
+// mime may be a single string or a list (the gateway's ComputeOutput.mime is a list); find an image type.
+function imageMime(mime?: string | string[]): string | null {
+  const arr = Array.isArray(mime) ? mime : mime ? [mime] : [];
+  return arr.find((m) => m.startsWith("image/")) ?? null;
+}
+function onKey(e: KeyboardEvent) { if (e.key === "Enter" && (e.shiftKey || e.ctrlKey || e.metaKey)) { e.preventDefault(); run(); } }
+</script>
+
+<template>
+  <div class="cp">
+    <!-- ─────────────── planner: the registry as an agent action space ─────────────── -->
+    <section class="planner">
+      <div class="pl-head">
+        <div>
+          <h2>Plan a governed pipeline</h2>
+          <p class="sub">Name the <b>capabilities</b> you want and the planner composes a governed workflow over the
+            registry — observed reads first, then derivations — as a <b>preview you can run</b>. Planning is free;
+            only execution is gated.</p>
+        </div>
+        <span class="wand" aria-hidden="true">✦</span>
+      </div>
+      <div class="pl-in">
+        <input v-model="planCaps" placeholder="counts, python, embed  —  comma-separated capabilities"
+               @keydown.enter="doPlan" />
+        <button class="primary" :disabled="!planCaps.trim() || planning" @click="doPlan">
+          <span v-if="planning" class="spin" />{{ planning ? 'Planning…' : 'Plan' }}
+        </button>
+      </div>
+      <p v-if="planErr" class="note err">plan: {{ planErr }}</p>
+
+      <div v-if="plan" class="pl-out" :class="{ nope: !plan.runnable }">
+        <template v-if="plan.degraded">
+          <span class="dwarn">⚠ {{ plan.degraded }}</span>
+        </template>
+        <template v-else>
+          <div class="pl-meta">
+            <span class="strat">{{ plan.strategy }}</span>
+            <span v-if="plan.warrant_preview" class="epi-chip" :style="epiStyle(plan.warrant_preview)"
+                  title="the plan's warrant = its weakest step">
+              <i class="dot" :style="{ background: EPISTEMIC_COLORS[plan.warrant_preview] }" />warrant {{ plan.warrant_preview }}
+            </span>
+            <span class="rn" :class="{ ok: plan.runnable }">{{ plan.runnable ? '✓ runnable' : '✕ not runnable' }}</span>
+          </div>
+          <ol class="pl-steps">
+            <li v-for="(s, i) in plan.steps" :key="s.id" class="pl-step">
+              <span class="wf-idx">{{ i + 1 }}</span>
+              <span class="wf-id">{{ s.kind }}</span>
+              <span class="wf-kind">{{ s.backend }} · satisfies “{{ s.satisfies }}”</span>
+              <span class="epi-chip sm" :style="epiStyle(s.epistemic)">{{ s.epistemic }}</span>
+              <span v-if="!s.entitled" class="lockmini" title="not entitled">🔒</span>
+            </li>
+          </ol>
+          <div v-if="plan.unmet_capabilities?.length || plan.unmet_entitlements?.length" class="unmet">
+            <span v-if="plan.unmet_capabilities?.length">no kind provides: {{ plan.unmet_capabilities.join(', ') }}</span>
+            <span v-if="plan.unmet_entitlements?.length">not entitled: {{ plan.unmet_entitlements.join(', ') }}</span>
+          </div>
+          <button class="primary run-plan" :disabled="!plan.runnable || running" @click="runPlan">
+            <span v-if="running" class="spin" />▸ Run this plan
+          </button>
+        </template>
+      </div>
+    </section>
+
+    <!-- ─────────────── the catalog: any compute, one door (the hero) ─────────────── -->
+    <section class="reg">
+      <div class="reg-head">
+        <div>
+          <h2>Compute registry</h2>
+          <p class="sub">Every kind of compute — one governed door. Each declares its backends, capabilities, a
+            default <b>epistemic warrant</b>, whether it executes your code, and whether you're entitled. Every run
+            returns a proof-carrying receipt.</p>
+        </div>
+        <span class="door" aria-hidden="true">⛩</span>
+      </div>
+
+      <div v-if="loading" class="grid">
+        <div v-for="i in 4" :key="i" class="kcard sk"><div class="sk-line w50" /><div class="sk-line w70" /></div>
+      </div>
+      <p v-else-if="regErr" class="note err">registry: {{ regErr }}</p>
+
+      <div v-else class="grid" role="list">
+        <button v-for="k in kinds" :key="k.kind" class="kcard" role="listitem"
+                :class="{ on: selectedKind === k.kind, locked: !k.entitled }" @click="pick(k.kind)">
+          <div class="krow">
+            <span class="kname">{{ k.kind }}</span>
+            <span class="ent" :class="{ open: k.entitled }" :title="k.entitled ? 'entitled' : 'not entitled — pay-gated'">
+              {{ k.entitled ? '✓ entitled' : '🔒 locked' }}
+            </span>
+          </div>
+          <div class="kmeta">
+            <span class="epi-chip" :style="epiStyle(k.epistemic)" :title="'default epistemic warrant: ' + k.epistemic">
+              <i class="dot" :style="{ background: EPISTEMIC_COLORS[k.epistemic] }" />{{ k.epistemic }}
+            </span>
+            <span class="stat" :class="k.status">{{ k.status === 'live' ? '● live' : '○ declared' }}</span>
+            <span v-if="k.executes_user_code" class="uc" title="runs your code in a sandbox">▷ user-code</span>
+          </div>
+          <div class="kback"><span class="klbl">backends</span>
+            <span v-for="b in k.backends" :key="b" class="bk" :class="{ def: b === k.default }">{{ b }}</span>
+          </div>
+          <div class="kcaps">
+            <span v-for="c in k.capabilities" :key="c" class="cap">{{ c }}</span>
+          </div>
+        </button>
+      </div>
+    </section>
+
+    <!-- ─────────────── run panel ─────────────── -->
+    <section v-if="selected" class="run">
+      <div class="run-head">
+        <h3>Run <span class="rk">{{ selected.kind }}</span></h3>
+        <label class="bsel">backend
+          <select v-model="backend">
+            <option v-for="b in selected.backends" :key="b" :value="b">{{ b }}{{ b === selected.default ? ' · default' : '' }}</option>
+          </select>
+        </label>
+        <span class="epi-chip" :style="epiStyle(selected.epistemic)" :title="'results default to epistemic: ' + selected.epistemic">
+          <i class="dot" :style="{ background: EPISTEMIC_COLORS[selected.epistemic] }" />warrant {{ selected.epistemic }}
+        </span>
+        <div class="sp" />
+        <button class="primary" :disabled="!canRun" @click="run">
+          <span v-if="running" class="spin" />{{ running ? 'Running…' : '▸ Run' }}
+        </button>
+      </div>
+
+      <!-- spec editor — fields are driven off the selected kind -->
+      <div class="spec">
+        <div v-for="f in fields" :key="f.key" class="field" :class="{ wide: f.type === 'code' }">
+          <label :for="'f-' + f.key">{{ f.label }}</label>
+          <select v-if="f.type === 'select'" :id="'f-' + f.key" v-model="spec[f.key]">
+            <option v-for="o in f.options" :key="o" :value="o">{{ o }}</option>
+          </select>
+          <textarea v-else-if="f.type === 'code' || f.type === 'json'" :id="'f-' + f.key" v-model="spec[f.key]" class="code"
+                    :rows="f.rows || 4" :placeholder="f.placeholder" spellcheck="false" @keydown="onKey" />
+          <input v-else :id="'f-' + f.key" v-model="spec[f.key]" :placeholder="f.placeholder" @keydown="onKey" />
+        </div>
+      </div>
+      <p v-if="runErr" class="note err">run: {{ runErr }}</p>
+
+      <!-- ─────────────── result ─────────────── -->
+      <div v-if="result" class="res" :class="result.status">
+        <!-- entitlement pay-gate / zero-trust grant gate (gateway returns 200 with the typed status) -->
+        <div v-if="result.status === 'entitlement_required' || result.status === 'grant_required'" class="paygate">
+          <div class="pg-head">
+            <span class="lock">🔒</span>
+            <b>{{ result.status === 'grant_required' ? 'Capability grant required' : 'Entitlement required' }}</b>
+            <span class="code402">{{ result.status === 'grant_required' ? 'zero-trust' : '402' }}</span>
+          </div>
+          <p>{{ result.message || `“${result.kind}” on ${result.backend} is a provisioned, pay-gated service — the capability is catalogued but no runtime is provisioned for you yet.` }}</p>
+          <div class="pg-foot">
+            <button class="primary">{{ result.status === 'grant_required' ? 'Request grant' : 'Provision entitlement' }}</button>
+          </div>
+        </div>
+
+        <!-- honest degraded state (e.g. plane not wired) -->
+        <div v-else-if="result.status === 'degraded'" class="degraded">
+          <span class="dwarn">⚠ degraded</span>
+          <span>{{ result.degraded || 'compute plane not wired' }}</span>
+          <span class="dhint">No result is fabricated — wire <code>VITE_STUDIO_API</code> to the Studio BFF to run live.</span>
+        </div>
+
+        <!-- ok / error: outputs + epistemic status + receipt -->
+        <template v-else>
+          <div class="res-head">
+            <span class="rstat" :class="result.status">{{ result.status === 'ok' ? '✓ ok' : '✕ error' }}</span>
+            <span class="epi-chip" :style="epiStyle(result.epistemic_status)" title="epistemic status of THIS result">
+              <i class="dot" :style="{ background: EPISTEMIC_COLORS[result.epistemic_status] }" />{{ result.epistemic_status }}
+            </span>
+            <span class="rback">{{ result.kind }} · {{ result.backend }}</span>
+            <span v-if="deltaCounts" class="gdelta" title="provenance facts written to the project graph (PROV-O)">
+              Δ {{ deltaCounts.n }} nodes · {{ deltaCounts.e }} edges</span>
+            <span v-if="result.memoized" class="memo" title="served from the content-addressed compute memo — identical inputs, identical sealed proof">⚡ memoized</span>
+            <span v-if="result.attestation?.results?.cosign_valid" class="attest"
+                  title="zero-trust AttestationBundle: Ed25519 signature over the in-toto statement verifies (cosign-class)">⛨ attested</span>
+          </div>
+
+          <div v-if="result.error" class="oerr">{{ result.error }}</div>
+
+          <!-- workflow: the DAG execution — each step is its own governed, sealed compute -->
+          <div v-if="wfSteps.length" class="wf">
+            <div class="wf-head">⛓ Workflow steps <span class="wf-n">{{ wfSteps.length }}</span></div>
+            <ol class="wf-list">
+              <li v-for="(s, i) in wfSteps" :key="s.id" class="wf-step" :class="s.status">
+                <span class="wf-idx">{{ i + 1 }}</span>
+                <span class="wf-id">{{ s.id }}</span>
+                <span class="wf-kind">{{ s.kind }} · {{ s.backend }}</span>
+                <span class="epi-chip sm" :style="epiStyle(s.epistemic_status)">
+                  <i class="dot" :style="{ background: EPISTEMIC_COLORS[s.epistemic_status] }" />{{ s.epistemic_status }}
+                </span>
+                <span class="wf-stat" :class="s.status">{{ s.status === 'ok' ? '✓' : '✕' }} {{ s.status }}</span>
+                <span v-if="s.memoized" class="memo sm" title="step served from the memo">⚡</span>
+                <span v-if="s.receipt" class="mono dim wf-rc">⛨ {{ short(s.receipt) }}</span>
+              </li>
+            </ol>
+          </div>
+
+          <div v-if="result.outputs.length && !wfSteps.length" class="out">
+            <template v-for="(o, i) in result.outputs" :key="i">
+              <div v-if="imageMime(o.mime) && typeof o.data === 'string'" class="rich">
+                <img :src="`data:${imageMime(o.mime)};base64,${o.data}`" alt="compute output" />
+              </div>
+              <pre v-else class="stream">{{ o.text ?? (o.data != null ? JSON.stringify(o.data, null, 2) : '') }}</pre>
+            </template>
+          </div>
+          <p v-else-if="!wfSteps.length" class="empty">No outputs.</p>
+
+          <!-- receipt strip — the moat (reuses the notebook receipt-strip idea) -->
+          <div v-if="result.receipt" class="rcpt">
+            <span class="seal">⛨ receipt</span>
+            <span class="mono">{{ short(result.receipt.id) }}</span>
+            <span v-if="result.receipt.signature" class="signed" title="Ed25519-signed by the compute-gateway (in-toto statement)">signed ✓</span>
+            <span v-else class="unsigned" title="no signature on this receipt (no signing key configured)">unsigned</span>
+            <span v-if="result.receipt.inputs_sha" class="mono dim">in {{ short(result.receipt.inputs_sha) }}</span>
+            <span v-if="result.receipt.outputs_sha" class="mono dim">out {{ short(result.receipt.outputs_sha) }}</span>
+            <span v-if="result.receipt.prev" class="mono dim">↩ {{ short(result.receipt.prev) }}</span>
+            <span class="grow" />
+            <span class="replay">replayable</span>
+          </div>
+        </template>
+      </div>
+
+      <!-- session receipt chain — the tamper-evident record of every run -->
+      <div v-if="chain.length" class="chain">
+        <div class="chain-head">⛨ Session receipt chain <span class="cn">{{ chain.length }}</span></div>
+        <div class="crow" v-for="(c, i) in chain" :key="i">
+          <span class="cdot" :style="{ background: EPISTEMIC_COLORS[c.epistemic_status] || 'var(--idle)' }" />
+          <span class="mono cid">{{ c.receipt ? short(c.receipt.id) : '—' }}</span>
+          <span class="ckind">{{ c.kind }} · {{ c.backend }}</span>
+          <span class="epi-chip sm" :style="epiStyle(c.epistemic_status)">{{ c.epistemic_status }}</span>
+          <span v-if="c.receipt?.signature" class="signed sm">signed ✓</span>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.cp { font: 14px/1.5 var(--ui); color: var(--ink); display: flex; flex-direction: column; gap: var(--sp-5); }
+
+/* ── planner ── */
+.planner { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
+.pl-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: var(--sp-3); }
+.pl-head h2 { font-size: 16px; margin: 0; }
+.pl-head .sub { color: var(--muted); font-size: 12.5px; margin: 4px 0 0; max-width: 620px; }
+.pl-head .sub b { color: var(--ink-2); }
+.pl-head .wand { font-size: 26px; color: var(--accent); opacity: .8; line-height: 1; }
+.pl-in { display: flex; gap: 8px; }
+.pl-in input { flex: 1; border: 1px solid var(--hairline); border-radius: var(--r-2); background: var(--surface-2);
+  color: var(--ink); padding: 8px 12px; font-size: 13px; outline: none; }
+.pl-in input:focus { border-color: var(--accent); }
+.pl-out { margin-top: var(--sp-3); border: 1px solid var(--hairline); border-radius: var(--r-2); background: var(--ground); padding: var(--sp-3); }
+.pl-out.nope { border-color: color-mix(in srgb, var(--warn) 35%, var(--hairline)); }
+.pl-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+.pl-meta .strat { font-family: var(--mono); font-size: 10.5px; color: var(--muted); background: var(--sunken); border-radius: var(--r-1); padding: 1px 7px; }
+.pl-meta .rn { font-size: 11px; font-weight: 700; color: var(--fail); }
+.pl-meta .rn.ok { color: var(--ok); }
+.pl-steps { list-style: none; margin: 0 0 8px; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.pl-step { display: flex; align-items: center; gap: 10px; font-size: 11.5px; padding: 6px 10px; border: 1px solid var(--hairline);
+  border-radius: var(--r-2); background: var(--surface); }
+.pl-step .wf-idx { font-family: var(--mono); font-size: 10px; color: var(--faint); width: 14px; }
+.pl-step .wf-id { font-weight: 700; color: var(--ink); }
+.pl-step .wf-kind { font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+.pl-step .lockmini { margin-left: auto; }
+.unmet { display: flex; flex-direction: column; gap: 2px; font-size: 11px; color: var(--warn); margin-bottom: 10px; }
+.run-plan { margin-top: 2px; }
+.pl-out .dwarn { color: var(--warn); font-weight: 700; background: var(--warn-wash); border-radius: var(--r-1); padding: 2px 8px; font-size: 12px; }
+
+/* shared epistemic-warrant chip (coloured off the ramp) */
+.epi-chip { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600;
+  padding: 1px 8px 1px 7px; border-radius: var(--r-1); border: 1px solid transparent; white-space: nowrap; }
+.epi-chip .dot { width: 8px; height: 8px; border-radius: var(--pill); flex: 0 0 auto; }
+.epi-chip.sm { font-size: 10px; padding: 0 6px; }
+
+/* ── registry ── */
+.reg-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: var(--sp-4); }
+.reg-head h2 { font-size: 16px; margin: 0; }
+.reg-head .sub { color: var(--muted); font-size: 12.5px; margin: 4px 0 0; max-width: 640px; }
+.reg-head .sub b { color: var(--ink-2); }
+.reg-head .door { font-size: 30px; color: var(--accent); opacity: .8; line-height: 1; }
+
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: var(--sp-3); }
+.kcard { text-align: left; border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface);
+  padding: var(--sp-3) var(--sp-4); cursor: pointer; display: flex; flex-direction: column; gap: 8px;
+  transition: border-color .12s, box-shadow .12s; color: inherit; font: inherit; }
+.kcard:hover { border-color: var(--hairline-strong); box-shadow: var(--e-1); }
+.kcard.on { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-wash); }
+.kcard.locked { opacity: .82; }
+.krow { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.kname { font-weight: 700; font-size: 14.5px; }
+.ent { font-size: 10.5px; font-weight: 600; border-radius: var(--pill); padding: 1px 8px; color: var(--muted);
+  border: 1px solid var(--hairline); background: var(--sunken); white-space: nowrap; }
+.ent.open { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.kmeta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.stat { font-size: 10.5px; font-weight: 600; border-radius: var(--r-1); padding: 1px 7px; border: 1px solid var(--hairline); }
+.stat.live { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.stat.declared { color: var(--muted); background: var(--sunken); }
+.uc { font-size: 10px; color: var(--epi-derived); border: 1px solid color-mix(in srgb, var(--epi-derived) 35%, transparent);
+  background: var(--epi-derived-wash); border-radius: var(--r-1); padding: 1px 6px; }
+.kback { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; font-size: 11px; }
+.kback .klbl { color: var(--faint); text-transform: uppercase; letter-spacing: .06em; font-size: 9.5px; margin-right: 2px; }
+.bk { font-family: var(--mono); font-size: 10.5px; background: var(--sunken); color: var(--ink-2); border-radius: var(--r-1); padding: 1px 7px; }
+.bk.def { color: var(--accent-ink); background: var(--accent-wash); }
+.kcaps { display: flex; flex-wrap: wrap; gap: 4px; }
+.cap { font-size: 10px; color: var(--muted); background: var(--sunken); border-radius: var(--r-1); padding: 1px 7px; }
+
+/* ── run panel ── */
+.run { border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--surface); padding: var(--sp-4); }
+.run-head { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: var(--sp-3); }
+.run-head h3 { font-size: 14px; margin: 0; }
+.run-head .rk { font-family: var(--mono); color: var(--accent); font-weight: 700; }
+.bsel { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); display: inline-flex; align-items: center; gap: 6px; }
+.bsel select, .field select { padding: 4px 8px; font-size: 12px; border: 1px solid var(--hairline); border-radius: var(--r-2);
+  background: var(--surface); color: var(--ink); text-transform: none; letter-spacing: 0; }
+.run-head .sp { flex: 1; }
+.primary { border: 0; background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 7px 16px; font-size: 13px;
+  font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; gap: 8px; }
+.primary:hover:not(:disabled) { background: var(--accent-2); }
+.primary:disabled { opacity: .5; cursor: default; }
+
+.spec { display: flex; flex-wrap: wrap; gap: var(--sp-3); }
+.field { display: flex; flex-direction: column; gap: 5px; }
+.field.wide { flex: 1 1 100%; }
+.field label { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+.field input, .field .code { border: 1px solid var(--hairline); border-radius: var(--r-2); background: var(--surface-2);
+  color: var(--ink); padding: 8px 10px; font-size: 13px; outline: none; }
+.field input:focus, .field .code:focus, .field select:focus { border-color: var(--accent); }
+.field .code { font: 13px/1.55 var(--mono); resize: vertical; width: 100%; }
+.field input::placeholder, .field .code::placeholder { color: var(--faint); }
+
+/* ── result ── */
+.res { margin-top: var(--sp-4); border: 1px solid var(--hairline); border-radius: var(--r-3); background: var(--ground); padding: var(--sp-3) var(--sp-4); }
+.res.error { border-color: color-mix(in srgb, var(--fail) 45%, var(--hairline)); }
+.res-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 10px; }
+.rstat { font-size: 11px; font-weight: 700; border-radius: var(--pill); padding: 1px 9px; }
+.rstat.ok { color: var(--ok); background: var(--ok-wash); }
+.rstat.error { color: var(--fail); background: var(--fail-wash); }
+.rback { font-family: var(--mono); font-size: 11px; color: var(--muted); }
+.gdelta { font-size: 10.5px; color: var(--epi-attested); background: var(--epi-attested-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 600; }
+.memo { font-size: 10.5px; color: var(--epi-verified); background: var(--epi-verified-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 600; }
+.attest { font-size: 10.5px; color: var(--epi-attested); background: var(--epi-attested-wash);
+  border-radius: var(--r-1); padding: 1px 8px; font-weight: 700; }
+.out { display: flex; flex-direction: column; gap: 8px; }
+.out .stream { margin: 0; font: 12px/1.5 var(--mono); white-space: pre-wrap; word-break: break-word; color: var(--ink-2);
+  background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 8px 10px; }
+.rich img { max-width: 100%; border-radius: var(--r-2); }
+.oerr { color: var(--fail); background: var(--fail-wash); border-radius: var(--r-2); padding: 8px 10px; font: 12px/1.5 var(--mono); }
+.empty { color: var(--faint); font-size: 12px; margin: 0; }
+
+.rcpt { display: flex; align-items: center; gap: 10px; margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--hairline);
+  font-size: 11px; color: var(--muted); flex-wrap: wrap; }
+.rcpt .seal { color: var(--epi-attested); font-weight: 600; }
+.rcpt .mono, .mono { font-family: var(--mono); }
+.rcpt .dim { color: var(--faint); }
+.rcpt .signed, .signed { color: var(--epi-attested); background: var(--epi-attested-wash); border-radius: var(--r-1);
+  padding: 0 6px; font-weight: 600; }
+.rcpt .unsigned { color: var(--warn); background: var(--warn-wash); border-radius: var(--r-1); padding: 0 6px; }
+.rcpt .grow { flex: 1; }
+.rcpt .replay { color: var(--epi-attested); background: var(--epi-attested-wash); border-radius: var(--r-1); padding: 0 6px; font-weight: 600; }
+
+/* workflow step chain */
+.wf { margin: 4px 0 10px; }
+.wf-head { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.wf-head .wf-n { background: var(--epi-derived); color: #fff; border-radius: var(--pill); padding: 0 7px; font-size: 10px; }
+.wf-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.wf-step { display: flex; align-items: center; gap: 10px; font-size: 11.5px; padding: 6px 10px; border: 1px solid var(--hairline);
+  border-left-width: 3px; border-radius: var(--r-2); background: var(--surface); }
+.wf-step.ok { border-left-color: var(--ok); }
+.wf-step.error { border-left-color: var(--fail); }
+.wf-step.degraded { border-left-color: var(--warn); }
+.wf-idx { font-family: var(--mono); font-size: 10px; color: var(--faint); width: 14px; }
+.wf-id { font-weight: 700; color: var(--ink); }
+.wf-kind { font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+.wf-stat { font-size: 10.5px; font-weight: 600; }
+.wf-step.ok .wf-stat { color: var(--ok); }
+.wf-step.error .wf-stat { color: var(--fail); }
+.wf-rc { margin-left: auto; color: var(--epi-attested); }
+
+/* pay-gate 402 */
+.paygate { color: var(--ink); }
+.pg-head { display: flex; align-items: center; gap: 8px; font-size: 14px; }
+.pg-head .lock { font-size: 16px; }
+.pg-head .code402 { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--warn);
+  background: var(--warn-wash); border-radius: var(--r-1); padding: 1px 8px; font-weight: 700; }
+.paygate p { color: var(--muted); font-size: 12.5px; margin: 8px 0 12px; max-width: 560px; }
+.pg-foot { display: flex; align-items: center; gap: 12px; }
+.pg-foot .price { font-weight: 700; color: var(--ink); }
+
+/* degraded */
+.degraded { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 12px; font-size: 12.5px; color: var(--ink-2); }
+.degraded .dwarn { color: var(--warn); font-weight: 700; background: var(--warn-wash); border-radius: var(--r-1); padding: 1px 8px; }
+.degraded .dhint { color: var(--muted); font-size: 11.5px; flex: 1 1 100%; }
+.degraded code { font-family: var(--mono); font-size: 11px; }
+
+/* session chain */
+.chain { margin-top: var(--sp-4); }
+.chain-head { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.chain-head .cn { background: var(--epi-attested); color: #fff; border-radius: var(--pill); padding: 0 7px; font-size: 10px; }
+.crow { display: flex; align-items: center; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--sunken); font-size: 11.5px; }
+.crow:last-child { border-bottom: 0; }
+.crow .cdot { width: 9px; height: 9px; border-radius: var(--pill); flex: 0 0 auto; }
+.crow .cid { color: var(--ink-2); }
+.crow .ckind { color: var(--muted); font-family: var(--mono); font-size: 10.5px; }
+
+/* notes + skeletons */
+.note { font-size: 12px; border-radius: var(--r-2); padding: 8px 12px; margin: 8px 0 0; }
+.note.err { color: var(--fail); background: var(--fail-wash); border: 1px solid color-mix(in srgb, var(--fail) 30%, transparent); }
+.sk { pointer-events: none; }
+.sk-line { height: 10px; background: linear-gradient(90deg, var(--sunken), var(--hairline), var(--sunken));
+  background-size: 200% 100%; border-radius: var(--r-1); margin: 6px 0; animation: sh 1.2s infinite; }
+.w50 { width: 50%; } .w70 { width: 70%; }
+@keyframes sh { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+.spin { width: 12px; height: 12px; border: 2px solid #fff; border-top-color: transparent; border-radius: var(--pill); animation: spn .7s linear infinite; }
+@keyframes spn { to { transform: rotate(360deg); } }
+
+/* a11y */
+.cp :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+@media (prefers-reduced-motion: reduce) {
+  .sk-line { animation: none; } .spin { animation: none; } .kcard { transition: none; }
+}
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioExperiments.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioExperiments.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue";
+import { loadExperiments, logExperiment, EPISTEMIC_COLORS, type Experiments } from "../../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const data = ref<Experiments | null>(null);
+const loading = ref(true);
+const err = ref("");
+
+const showLog = ref(false);
+const fName = ref("");
+const fParams = ref('{"lr": 0.01}');
+const fMetrics = ref('{"acc": 0.9}');
+const token = ref("");
+const logging = ref(false);
+const logMsg = ref("");
+const logErr = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try { data.value = await loadExperiments(props.project); }
+  catch (e) { err.value = e instanceof Error ? e.message : "failed to load"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+function parseJson(s: string): Record<string, unknown> {
+  try { const o = JSON.parse(s); if (o && typeof o === "object") return o as Record<string, unknown>; throw 0; }
+  catch { throw new Error("params/metrics must be valid JSON objects"); }
+}
+
+async function submitLog() {
+  logging.value = true; logMsg.value = ""; logErr.value = "";
+  try {
+    if (!fName.value.trim()) throw new Error("name required");
+    const run = await logExperiment(
+      { project: props.project, name: fName.value.trim(), params: parseJson(fParams.value), metrics: parseJson(fMetrics.value) as Record<string, number>, status: "finished" },
+      token.value,
+    );
+    logMsg.value = `Logged ${run.run_id}`; fName.value = "";
+    await load();
+  } catch (e) { logErr.value = e instanceof Error ? e.message : "log failed"; }
+  finally { logging.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
+function kv(o: Record<string, unknown>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
+</script>
+
+<template>
+  <div class="xp">
+    <div class="xbar">
+      <span class="cnt">{{ data?.count ?? 0 }} runs</span>
+      <div class="spacer" />
+      <button class="run" @click="showLog = !showLog">＋ Log run</button>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload runs">↻</button>
+    </div>
+
+    <div v-if="showLog" class="logbox">
+      <div class="lrow">
+        <input v-model="fName" placeholder="run name" />
+        <input v-model="fParams" class="j mono" placeholder="params JSON" />
+        <input v-model="fMetrics" class="j mono" placeholder="metrics JSON" />
+        <input v-model="token" type="password" class="tok" placeholder="write token" />
+        <button class="primary" @click="submitLog" :disabled="logging">{{ logging ? "…" : "Log" }}</button>
+      </div>
+      <p v-if="logErr" class="lfeedback err">{{ logErr }}</p>
+      <p v-else-if="logMsg" class="lfeedback ok">✓ {{ logMsg }} — persisted as a proof-carrying graph fact</p>
+    </div>
+
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading runs…</p>
+    <p v-else-if="!data?.runs.length" class="msg">No runs yet. Log one — it lands as a fact in the knowledge graph, queryable in the IDE.</p>
+
+    <div v-else class="xscroll">
+      <table class="xgrid">
+        <thead><tr><th>Run</th><th>Status</th><th>Params</th><th>Metrics</th><th>Epistemic</th><th>When</th></tr></thead>
+        <tbody>
+          <tr v-for="r in data.runs" :key="r.run_id">
+            <td class="nm">{{ r.name }}</td>
+            <td><span class="pill" :class="r.status">{{ r.status }}</span></td>
+            <td class="mono">{{ kv(r.params) }}</td>
+            <td class="mono met">{{ kv(r.metrics) }}</td>
+            <td><span class="epi" :style="{ borderColor: color(r.epistemic_mode), color: color(r.epistemic_mode) }">{{ r.epistemic_mode }}</span></td>
+            <td class="when">{{ r.created_at }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-if="data?.runs.length" class="note">Runs are <b>graph facts</b>, not rows in a side DB — query them in the IDE, link them to data/models, and every metric carries its provenance.</p>
+  </div>
+</template>
+
+<style scoped>
+.xp { font: 14px/1.5 var(--ui); color: var(--ink); }
+.xp :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.xbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: 10px; }
+.xbar .cnt { color: var(--muted); font-size: 12px; font-variant-numeric: tabular-nums; } .xbar .spacer { flex: 1; }
+.run { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.mono { font-family: var(--mono); font-size: 12px; }
+.logbox { border: 1px solid var(--hairline-strong); border-radius: var(--r-3); background: var(--sunken); padding: 10px 12px; margin-bottom: 12px; }
+.lrow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+.lrow input { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.lrow input.j { flex: 1; min-width: 140px; } .lrow input.tok { width: 120px; }
+.lrow button.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.lrow button.primary:disabled { opacity: .6; cursor: default; }
+.lfeedback { margin: 8px 0 0; font-size: 12.5px; } .lfeedback.ok { color: var(--ok); } .lfeedback.err { color: var(--fail); }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+.xscroll { overflow-x: auto; border: 1px solid var(--hairline); border-radius: var(--r-3); }
+.xgrid { border-collapse: collapse; width: 100%; font-size: 13px; }
+.xgrid th { text-align: left; padding: 8px 12px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.xgrid td { padding: 8px 12px; border-bottom: 1px solid var(--sunken); white-space: nowrap; }
+.xgrid tr:last-child td { border-bottom: 0; }
+.xgrid .nm { font-weight: 600; } .xgrid .met { color: var(--ok); }
+.pill { font-size: 10.5px; border-radius: var(--pill); padding: 1px 8px; background: var(--hairline); color: var(--muted); }
+.pill.finished { background: var(--ok-wash); color: var(--ok); } .pill.running { background: var(--accent-wash); color: var(--accent); } .pill.failed { background: var(--fail-wash); color: var(--fail); }
+.epi { font-size: 10.5px; border: 1px solid; border-radius: var(--r-1); padding: 1px 8px; }
+.when { color: var(--muted); font-size: 11px; }
+.note { color: var(--muted); font-size: 12.5px; margin-top: 8px; } .note b { color: var(--ink); }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioGovernance.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioGovernance.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+// The Governance cockpit — the Foundry-Workshop answer + the estate's crown jewels, operable in-product:
+// the REAL Ontogenesis ontology (817 classes) you type against, the typed/SHACL-validated ONTOLOGY ACTIONS
+// (Foundry's crown jewel, beaten), and the GAIA world-signals PROMOTION MEMBRANE where a promotion state IS an
+// epistemic status — the same governed-evidence discipline across the knowledge, human, and Earth twins.
+import { ref, onMounted, watch } from "vue";
+import {
+  loadOntology, loadOntologyClass, loadActions, invokeAction, loadWorldsignals, submitWorldsignal,
+  promoteWorldsignal, loadGaiaOntology, loadHdt, loadHdtOntology, submitHdtObservation, promoteHdt, EPISTEMIC_COLORS,
+  type OntologyView, type OntologyClassDetail, type ActionDef, type WorldSignal, type GaiaOntology,
+  type HdtObservation, type HdtOntology,
+} from "../../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const onto = ref<OntologyView | null>(null);
+const actions = ref<ActionDef[]>([]);
+const signals = ref<WorldSignal[]>([]);
+const gaia = ref<GaiaOntology | null>(null);
+const observations = ref<HdtObservation[]>([]);
+const hdt = ref<HdtOntology | null>(null);
+const loading = ref(true);
+const err = ref("");
+const token = ref("");
+const flash = ref("");
+function say(m: string) { flash.value = m; setTimeout(() => (flash.value = ""), 3000); }
+
+async function load() {
+  loading.value = true; err.value = "";
+  try {
+    const [o, a, s, g, ho, hon] = await Promise.all([loadOntology(""), loadActions(props.project), loadWorldsignals(props.project), loadGaiaOntology(), loadHdt(props.project), loadHdtOntology()]);
+    onto.value = o; actions.value = a.actions; signals.value = s.world_signals; gaia.value = g;
+    observations.value = ho.observations; hdt.value = hon;
+  } catch (e) { err.value = e instanceof Error ? e.message : "failed to load governance"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+// ontology browse
+const q = ref(""); const classDetail = ref<OntologyClassDetail | null>(null);
+async function search() { try { onto.value = await loadOntology(q.value); } catch { /* */ } }
+async function openClass(iri: string) { try { classDetail.value = await loadOntologyClass(iri); } catch { /* */ } }
+
+// invoke action
+const invAction = ref(""); const invTarget = ref(""); const invArgs = ref("{}");
+async function doInvoke() {
+  try {
+    const args = JSON.parse(invArgs.value || "{}");
+    const r = await invokeAction({ project: props.project, action: invAction.value, target: invTarget.value, args }, token.value);
+    say(`Invoked ${invAction.value} → ${r.applied.join(", ")} · receipt ${r.receipt.correlation_id}`);
+  } catch (e) { say(e instanceof Error ? e.message : "invoke failed"); }
+}
+
+// GAIA
+const wsFeature = ref(""); const wsType = ref("feature_registry"); const wsActor = ref("human");
+async function doSubmit() {
+  try { const r = await submitWorldsignal({ project: props.project, feature_id: wsFeature.value, signal_type: wsType.value, actor_kind: wsActor.value }, token.value);
+    say(`Signal ${r.signal_id.split(":").pop()} → ${r.promotion_state} (${r.epistemic_mode})`); wsFeature.value = ""; await load(); }
+  catch (e) { say(e instanceof Error ? e.message : "submit failed"); }
+}
+async function doPromote(sig: WorldSignal, to_state: string, actor_kind: string) {
+  try {
+    const r = await promoteWorldsignal({ project: props.project, signal: sig.signal_id, to_state, actor_kind }, token.value);
+    if ("blocked" in r) say(`🔒 ${r.message}`);
+    else { say(`${sig.feature_id} → ${r.to_state} (${r.epistemic_mode})`); await load(); }
+  } catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
+}
+
+// HDT (the human twin)
+const hdtSubject = ref(""); const hdtCode = ref(""); const hdtActor = ref("human");
+async function doHdtSubmit() {
+  try { const r = await submitHdtObservation({ project: props.project, subject: hdtSubject.value, code: hdtCode.value, actor_kind: hdtActor.value }, token.value);
+    say(`Observation → ${r.omega_state} (${r.epistemic_mode})`); hdtCode.value = ""; await load(); }
+  catch (e) { say(e instanceof Error ? e.message : "submit failed"); }
+}
+async function doHdtPromote(o: HdtObservation, to_state: string, actor_kind: string) {
+  try {
+    const r = await promoteHdt({ project: props.project, observation: o.observation_id, to_state, actor_kind }, token.value);
+    if ("blocked" in r) say(`🔒 ${r.message}`);
+    else { say(`${o.code} → ${r.to_state} (${r.epistemic_mode})`); await load(); }
+  } catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
+}
+
+function epi(mode?: string | null): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
+</script>
+
+<template>
+  <div class="gov">
+    <div class="gbar">
+      <span class="cnt">Governance · real ontology · typed actions · the GAIA promotion membrane</span>
+      <div class="spacer" />
+      <input v-model="token" type="password" class="tok" placeholder="write token" />
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload governance">↻</button>
+    </div>
+    <p v-if="flash" class="flash">{{ flash }}</p>
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading governance…</p>
+
+    <div v-else class="grid">
+      <!-- Ontogenesis ontology browser -->
+      <section class="card">
+        <header class="ch"><span class="ci">⬡</span> Ontology<span class="score" v-if="onto">{{ onto.counts.classes }} classes · real</span></header>
+        <div class="orow">
+          <input v-model="q" class="j" placeholder="search Ontogenesis classes…" @keyup.enter="search" />
+          <button class="mini" @click="search">Search</button>
+        </div>
+        <ul class="clist">
+          <li v-for="c in onto?.classes.slice(0, 8)" :key="c.iri" @click="openClass(c.iri)" :class="{ sel: classDetail?.class.iri === c.iri }">
+            <code class="mono">{{ c.iri }}</code><span class="pc">{{ c.property_count }} props</span>
+          </li>
+        </ul>
+        <div v-if="classDetail" class="cdetail">
+          <div class="cd-h"><b>{{ classDetail.class.iri }}</b><span v-if="classDetail.class.subClassOf.length" class="sub">⊑ {{ classDetail.class.subClassOf.join(", ") }}</span></div>
+          <div class="props">
+            <span v-for="p in classDetail.class.inherited_properties.slice(0, 12)" :key="p.iri" class="prop" :class="p.kind">{{ p.iri }}<i v-if="p.range">→{{ p.range }}</i></span>
+          </div>
+        </div>
+        <p class="sub">The real Ontogenesis OWL corpus — actions are <b>typed</b> against these classes and their declared properties.</p>
+      </section>
+
+      <!-- Ontology actions (Foundry Workshop, beaten) -->
+      <section class="card">
+        <header class="ch"><span class="ci">◑</span> Actions<span class="tagline">typed · SHACL-validated · reversible</span></header>
+        <div v-for="a in actions" :key="a.action_id" class="action">
+          <div class="arow"><b>{{ a.name }}</b><code class="mono tt">{{ a.target_type }}</code></div>
+          <div class="eff"><span v-for="(e, i) in a.effects" :key="i" class="e">{{ e.op }} {{ e.property || e.label }}</span></div>
+        </div>
+        <div class="invoke">
+          <div class="irow">
+            <input v-model="invAction" class="j" placeholder="action name" />
+            <input v-model="invTarget" class="j" placeholder="target node id" />
+          </div>
+          <input v-model="invArgs" class="j mono" placeholder='args {"newname":"width"}' />
+          <button class="primary" @click="doInvoke">Invoke</button>
+        </div>
+        <p class="sub">Foundry's crown jewel — but every invocation is proof-carrying, <b>SHACL-validated against the ontology</b>, receipted, and reversible.</p>
+      </section>
+
+      <!-- GAIA promotion membrane -->
+      <section class="card wide" v-if="gaia">
+        <header class="ch"><span class="ci">◍</span> GAIA world-signals — the promotion membrane<span class="tagline">Earth twin</span></header>
+        <div class="membrane">
+          <div v-for="(m, i) in gaia.promotion_epistemic_membrane" :key="m.state" class="mstate" :class="{ canon: m.canonical }">
+            <span class="ms-n">{{ m.state }}</span>
+            <span class="ms-epi" :style="{ color: epi(m.epistemic_human) }">{{ m.epistemic_human }}</span>
+            <span v-if="i < gaia.promotion_epistemic_membrane.length - 1" class="ms-arrow">→</span>
+          </div>
+        </div>
+        <p class="invariant">⚖ {{ gaia.invariant }}</p>
+
+        <div class="submit">
+          <input v-model="wsFeature" class="j" placeholder="feature_id" />
+          <select v-model="wsType" class="j"><option>feature_registry</option><option>weather</option><option>foot_traffic</option></select>
+          <select v-model="wsActor" class="j"><option value="human">human</option><option value="model">model</option></select>
+          <button class="primary" @click="doSubmit">Submit signal</button>
+        </div>
+
+        <table class="wgrid">
+          <thead><tr><th>Feature</th><th>State</th><th>Epistemic</th><th>Evidence</th><th>Promote</th></tr></thead>
+          <tbody>
+            <tr v-for="s in signals" :key="s.signal_id">
+              <td class="nm">{{ s.feature_id }}</td>
+              <td><span class="state" :class="{ canon: s.canonical }">{{ s.promotion_state }}</span></td>
+              <td><span class="epi" :style="{ borderColor: epi(s.epistemic_mode), color: epi(s.epistemic_mode) }">{{ s.epistemic_mode }}</span></td>
+              <td class="ev">{{ s.evidence_count }}</td>
+              <td class="promote">
+                <button class="mini" @click="doPromote(s, 'ReviewRequired', 'human')" v-if="!s.canonical">→ review</button>
+                <button class="mini go" @click="doPromote(s, 'Promoted', 'human')" v-if="!s.canonical">→ promote</button>
+                <button class="mini danger" @click="doPromote(s, 'Promoted', 'model')" v-if="!s.canonical" title="demonstrates the invariant">→ promote as model</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="sub">The promotion state <b>is</b> the epistemic status. Try “promote as model” — GAIA invariant #2 blocks a model from canonizing. One discipline across knowledge, human &amp; Earth twins.</p>
+      </section>
+
+      <!-- HDT — the human twin (closes the triangle) -->
+      <section class="card wide" v-if="hdt">
+        <header class="ch"><span class="ci">◐</span> HDT observations — the OmegaState lattice<span class="tagline">human twin · closes the triangle</span></header>
+        <div class="membrane">
+          <div v-for="(m, i) in hdt.omega_epistemic_lattice" :key="m.state" class="mstate" :class="{ canon: m.canonical }">
+            <span class="ms-n">{{ m.state }}</span>
+            <span class="ms-epi" :style="{ color: epi(m.epistemic_human) }">{{ m.epistemic_human }}</span>
+            <span v-if="i < hdt.omega_epistemic_lattice.length - 1" class="ms-arrow">→</span>
+          </div>
+        </div>
+        <p class="invariant">⚖ {{ hdt.invariant }}</p>
+        <div class="submit">
+          <input v-model="hdtSubject" class="j" placeholder="subject (person id)" />
+          <input v-model="hdtCode" class="j" placeholder="observation code (e.g. LOINC 8867-4)" />
+          <select v-model="hdtActor" class="j"><option value="human">human</option><option value="clinician">clinician</option><option value="model">model</option></select>
+          <button class="primary" @click="doHdtSubmit">Record observation</button>
+        </div>
+        <table class="wgrid">
+          <thead><tr><th>Code</th><th>Subject</th><th>OmegaState</th><th>Epistemic</th><th>Advance</th></tr></thead>
+          <tbody>
+            <tr v-for="o in observations" :key="o.observation_id">
+              <td class="nm">{{ o.code }}</td>
+              <td class="mono">{{ o.subject }}</td>
+              <td><span class="state" :class="{ canon: o.canonical }">{{ o.omega_state }}</span></td>
+              <td><span class="epi" :style="{ borderColor: epi(o.epistemic_mode), color: epi(o.epistemic_mode) }">{{ o.epistemic_mode }}</span></td>
+              <td class="promote">
+                <button class="mini" @click="doHdtPromote(o, 'TRUSTED', 'clinician')" v-if="!o.canonical">→ trusted</button>
+                <button class="mini go" @click="doHdtPromote(o, 'DELIVERED', 'clinician')" v-if="!o.canonical">→ deliver</button>
+                <button class="mini danger" @click="doHdtPromote(o, 'DELIVERED', 'model')" v-if="!o.canonical" title="demonstrates the invariant">→ deliver as model</button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="sub">The <b>third twin</b>. OmegaState = epistemic status, exactly as knowledge &amp; Earth. Only a human/clinician DELIVERS to canonical — “deliver as model” is blocked. <b>All three twins, one discipline.</b></p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.gov { font: 14px/1.5 var(--ui); color: var(--ink); }
+.gov :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.gbar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
+.gbar .cnt { color: var(--muted); font-size: 12px; } .gbar .spacer { flex: 1; }
+.gbar .tok { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; width: 120px; background: var(--surface); color: var(--ink); }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); } .card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--pill); padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--ok); background: var(--ok-wash); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); font-size: 12px; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
+.j { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.mini { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); padding: 3px 9px; font-size: 11.5px; cursor: pointer; }
+.mini.go { border-color: var(--accent); color: var(--accent); } .mini.danger { border-color: var(--warn); color: var(--warn); }
+
+.orow { display: flex; gap: 6px; margin-bottom: 8px; } .orow .j { flex: 1; }
+.clist { list-style: none; margin: 0 0 8px; padding: 0; }
+.clist li { display: flex; align-items: center; gap: var(--sp-2); padding: 3px 6px; border-radius: var(--r-2); cursor: pointer; }
+.clist li:hover, .clist li.sel { background: var(--accent-wash); } .clist .pc { margin-left: auto; font-size: 11px; color: var(--faint); }
+.cdetail { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; }
+.cd-h { display: flex; gap: 8px; align-items: baseline; } .cd-h .sub { font-size: 11px; color: var(--muted); }
+.props { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.prop { font-size: 10.5px; background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; font-family: var(--mono); }
+.prop.object { background: var(--accent-wash); color: var(--accent); } .prop i { font-style: normal; opacity: .6; }
+
+.action { border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 6px 8px; margin-bottom: 6px; }
+.arow { display: flex; align-items: center; gap: var(--sp-2); } .arow .tt { margin-left: auto; background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; }
+.eff { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 4px; } .eff .e { font-size: 10.5px; color: var(--muted); background: var(--sunken); border-radius: var(--r-2); padding: 1px 6px; }
+.invoke { border-top: 1px solid var(--sunken); padding-top: 8px; margin-top: 6px; display: flex; flex-direction: column; gap: 6px; }
+.irow { display: flex; gap: 6px; } .irow .j { flex: 1; } .invoke .j { width: 100%; }
+
+.membrane { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 8px; }
+.mstate { display: flex; align-items: center; gap: 6px; border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 5px 9px; }
+.mstate.canon { border-color: color-mix(in srgb, var(--ok) 40%, transparent); background: var(--ok-wash); }
+.ms-n { font-weight: 600; font-size: 12px; } .ms-epi { font-size: 10.5px; } .ms-arrow { color: var(--faint); margin: 0 2px; }
+.invariant { background: var(--warn-wash); color: var(--warn); border-radius: var(--r-2); padding: 6px 10px; font-size: 12px; margin: 0 0 10px; }
+.submit { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 10px; }
+.wgrid { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.wgrid th { text-align: left; padding: 6px 8px; background: var(--sunken); border-bottom: 1px solid var(--hairline); font-size: 10.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+.wgrid td { padding: 6px 8px; border-bottom: 1px solid var(--sunken); } .wgrid .nm { font-weight: 600; }
+.state { font-size: 10.5px; border-radius: var(--pill); padding: 1px 8px; background: var(--sunken); color: var(--muted); } .state.canon { background: var(--ok-wash); color: var(--ok); }
+.epi { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 1px 7px; } .ev { text-align: center; font-variant-numeric: tabular-nums; }
+.promote { display: flex; gap: 4px; flex-wrap: wrap; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
@@ -1,0 +1,366 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import {
+  loadNotebookAdapters, createNotebookSession, executeCell, loadNotebookReceipts, proposeCell,
+  type NbAdapter, type NbSession, type NbOutput, type NbReceipt,
+} from "../../services/studioApi";
+
+// a tiny inline bar chart (epistemic-coloured) to demonstrate rich output rendering in the preview
+const MINI_SVG = `<svg viewBox="0 0 260 120" width="260" height="120" xmlns="http://www.w3.org/2000/svg">
+${[["attested", 52, "#059669"], ["verified", 41, "#14b8a6"], ["derived", 19, "#8b5cf6"], ["observed", 12, "#4a90e2"], ["hypothesis", 4, "#94a1b2"]]
+  .map((r, i) => `<rect x="76" y="${8 + i * 22}" width="${(r[1] as number) * 3}" height="16" rx="2" fill="${r[2]}"/><text x="70" y="${20 + i * 22}" text-anchor="end" font-size="10" fill="#64707e" font-family="sans-serif">${r[0]}</text>`).join("")}
+</svg>`;
+
+const props = defineProps<{ project: string }>();
+
+interface Cell {
+  id: string; code: string; language: string;
+  outputs: NbOutput[]; status: "idle" | "running" | "ok" | "error" | "degraded";
+  receipt: NbReceipt | null; count: number | null; preview?: boolean;
+  // AI-proposed cells: a hypothesis until the user runs it (its receipt then attests it).
+  proposed?: boolean; rationale?: string; proposedSource?: "model" | "heuristic";
+}
+
+const adapters = ref<Record<string, NbAdapter>>({});
+const adapter = ref("jupyterlab");
+const session = ref<NbSession | null>(null);
+const sessionErr = ref("");
+const cells = ref<Cell[]>([]);
+let seq = 0;
+const uid = () => `c${++seq}`;
+
+// governed preview: illustrative cells with real-looking sealed receipts, clearly marked,
+// so the surface reads world-class before the runtime is wired (never faked live output).
+function seed(): Cell[] {
+  return [
+    { id: uid(), language: "python", status: "ok", count: 1, preview: true,
+      code: "import pandas as pd\ndf = load('apple_2024_breach')   # governed dataset\ndf.shape",
+      outputs: [{ type: "execute_result", text: "(899104, 42)" }],
+      receipt: fakeReceipt("import…shape", "ok") },
+    { id: uid(), language: "python", status: "ok", count: 2, preview: true,
+      code: "# state carries across cells — one persistent kernel per session\ndf['warrant'].value_counts()",
+      outputs: [{ type: "execute_result", html: "<table class='df'><tr><th>warrant</th><th>n</th></tr><tr><td>attested</td><td>41</td></tr><tr><td>verified</td><td>52</td></tr><tr><td>derived</td><td>19</td></tr></table>" }],
+      receipt: fakeReceipt("value_counts", "ok") },
+    { id: uid(), language: "python", status: "ok", count: 3, preview: true,
+      code: "import matplotlib.pyplot as plt\ndf['warrant'].value_counts().plot.barh()   # real plots render inline\nplt.show()",
+      outputs: [{ type: "display_data", svg: MINI_SVG }],
+      receipt: fakeReceipt("plot", "ok") },
+    { id: uid(), language: "python", status: "idle", count: null, code: "", outputs: [], receipt: null },
+  ];
+}
+function fakeReceipt(tag: string, status: string): NbReceipt {
+  return { id: "sha256:" + hash(tag), project: props.project, adapter: adapter.value, language: "python",
+           runtime: "python3", code_sha: "sha256:" + hash("c" + tag), outputs_sha: "sha256:" + hash("o" + tag),
+           status, actor: "you", prev: null, ts: Date.now() / 1000 };
+}
+function hash(s: string): string { let h = 0; for (const c of s) h = (h * 31 + c.charCodeAt(0)) >>> 0; return h.toString(16).padStart(8, "0"); }
+
+const runtime = computed(() => adapters.value[adapter.value]?.kernels?.[0] ?? "python3");
+const wired = computed(() => session.value?.status && session.value.status !== "stub");
+const stub = computed(() => !wired.value);
+
+onMounted(async () => {
+  cells.value = seed();
+  try {
+    const a = await loadNotebookAdapters();
+    adapters.value = a.adapters; adapter.value = a.default;
+    session.value = await createNotebookSession({ project: props.project, adapter: adapter.value, name: "Studio notebook" });
+  } catch (e) { sessionErr.value = e instanceof Error ? e.message : "session failed"; }
+});
+
+async function run(cell: Cell) {
+  if (!cell.code.trim()) return;
+  // running a proposed cell is the act that attests it: the hypothesis earns a receipt.
+  cell.status = "running"; cell.preview = false; cell.proposed = false;
+  try {
+    const r = await executeCell({ project: props.project, code: cell.code, language: cell.language, adapter: adapter.value, session_id: session.value?.id });
+    cell.outputs = r.outputs ?? [];
+    cell.receipt = r.receipt ?? null;
+    cell.status = r.status === "ok" ? "ok" : r.status === "error" ? "error" : "degraded";
+    if (r.degraded) cell.outputs = [{ type: "degraded", text: r.degraded }];
+    cell.count = cell.status === "ok" || cell.status === "error" ? (maxCount() + 1) : cell.count;
+  } catch (e) {
+    cell.status = "error"; cell.outputs = [{ type: "error", ename: "RuntimeError", evalue: e instanceof Error ? e.message : "failed" }];
+  }
+  // append a fresh empty cell if we just ran the last one (Jupyter ergonomics)
+  if (cells.value[cells.value.length - 1].id === cell.id) addCell();
+}
+function maxCount(): number { return cells.value.reduce((m, c) => Math.max(m, c.count ?? 0), 0); }
+async function runAll() { for (const c of cells.value) if (c.code.trim()) await run(c); }
+function addCell() { cells.value.push({ id: uid(), language: "python", status: "idle", count: null, code: "", outputs: [], receipt: null }); }
+function removeCell(id: string) { cells.value = cells.value.filter((c) => c.id !== id); if (!cells.value.length) addCell(); }
+function onKey(e: KeyboardEvent, cell: Cell) {
+  if (e.key === "Enter" && (e.shiftKey || e.ctrlKey || e.metaKey)) { e.preventDefault(); run(cell); }
+}
+function short(id?: string | null) { return id ? id.replace("sha256:", "").slice(0, 8) : ""; }
+const statColor: Record<string, string> = { ok: "var(--ok)", error: "var(--fail)", running: "var(--run)", degraded: "var(--warn)", idle: "var(--idle)" };
+
+// ── attested AI assistant: a model PROPOSES a cell (a hypothesis); running it seals a receipt → attested ──
+const assistPrompt = ref("");
+const assisting = ref(false);
+const assistErr = ref("");
+async function propose() {
+  const prompt = assistPrompt.value.trim();
+  if (!prompt || assisting.value) return;
+  assisting.value = true; assistErr.value = "";
+  try {
+    const p = await proposeCell({ project: props.project, prompt });
+    // insert the proposed cell before a trailing empty scratch cell if there is one, else append.
+    const cell: Cell = {
+      id: uid(), language: "python", status: "idle", count: null, code: p.code, outputs: [], receipt: null,
+      proposed: true, rationale: p.rationale, proposedSource: p.source,
+    };
+    const last = cells.value[cells.value.length - 1];
+    if (last && !last.code.trim() && last.status === "idle" && !last.proposed) {
+      cells.value.splice(cells.value.length - 1, 0, cell);
+    } else {
+      cells.value.push(cell);
+    }
+    assistPrompt.value = "";
+  } catch (e) {
+    assistErr.value = e instanceof Error ? e.message : "proposal failed";
+  } finally {
+    assisting.value = false;
+  }
+}
+
+// ── session provenance: the tamper-evident receipt chain across all cells (the moat) ──
+const chainOpen = ref(false);
+const serverCount = ref<number | null>(null);
+const chain = computed<NbReceipt[]>(() => cells.value.filter((c) => c.receipt).map((c) => c.receipt!));
+async function toggleChain() {
+  chainOpen.value = !chainOpen.value;
+  if (chainOpen.value) { const r = await loadNotebookReceipts(props.project); serverCount.value = r.degraded ? null : (r.count ?? null); }
+}
+</script>
+
+<template>
+  <div class="nb">
+    <!-- runtime toolbar -->
+    <header class="nb-bar">
+      <div class="nb-title">⬢ {{ session?.name || "Notebook" }}<span class="proj">· {{ project }}</span></div>
+      <label class="rt">runtime
+        <select v-model="adapter">
+          <option v-for="(a, k) in adapters" :key="k" :value="k">{{ k }} · {{ a.kernels[0] }}</option>
+        </select>
+      </label>
+      <span class="kstat"><i :style="{ background: wired ? 'var(--ok)' : 'var(--warn)' }" />{{ wired ? runtime + " · ready" : "runtime not wired" }}</span>
+      <div class="sp" />
+      <a v-if="session?.url" class="ghost" :href="session.url" target="_blank" rel="noopener">Open JupyterLab ↗</a>
+      <button class="ghost" @click="addCell">＋ Cell</button>
+      <button class="ghost prov-btn" :class="{ on: chainOpen }" @click="toggleChain" title="Tamper-evident receipt chain">⛨ Provenance<span v-if="chain.length" class="cnt2">{{ chain.length }}</span></button>
+      <button class="primary" @click="runAll">▸ Run all</button>
+    </header>
+
+    <p v-if="stub" class="note">
+      Governed preview — the runtime (lattice-forge) isn’t wired to this build yet. The seeded cells show the
+      shape; live runs execute on a <b>persistent per-session kernel</b> and seal a <b>receipt per cell</b> once
+      <code>VITE_STUDIO_API</code> points at the Studio BFF.
+    </p>
+    <p v-if="sessionErr" class="note err">session: {{ sessionErr }}</p>
+
+    <!-- cells -->
+    <div class="cells">
+      <div v-for="cell in cells" :key="cell.id" class="cell" :class="[cell.status, { proposed: cell.proposed }]">
+        <div class="gutter">
+          <button class="run" :title="'Run (⇧⏎)'" @click="run(cell)"><span v-if="cell.status === 'running'" class="spin" />{{ cell.status === 'running' ? '' : '▸' }}</button>
+          <span class="cnt">{{ cell.count != null ? '[' + cell.count + ']' : '[ ]' }}</span>
+        </div>
+        <div class="body">
+          <!-- AI proposal: an epistemic hypothesis until the user runs it (its receipt then attests it) -->
+          <div v-if="cell.proposed" class="prop">
+            <span class="pbadge">✦ proposed · hypothesis</span>
+            <span class="psrc" :class="cell.proposedSource">
+              {{ cell.proposedSource === 'model' ? 'assistant model' : 'offline heuristic — no model wired' }}
+            </span>
+            <span class="prat">{{ cell.rationale }}</span>
+            <span class="phint">unproven — <b>run it</b> to seal a receipt and attest it ⛨</span>
+          </div>
+          <textarea class="editor" :class="cell.language" v-model="cell.code" spellcheck="false"
+                    :placeholder="'# ' + runtime + ' — ⇧⏎ to run'" rows="2"
+                    @keydown="onKey($event, cell)" @input="(e:any)=>{e.target.style.height='auto';e.target.style.height=e.target.scrollHeight+'px'}" />
+          <!-- outputs -->
+          <div v-if="cell.outputs.length" class="out">
+            <template v-for="(o, i) in cell.outputs" :key="i">
+              <!-- rich: plots (png/svg) and tables/HTML (DataFrame._repr_html_) — real DS output -->
+              <img v-if="o.png" class="rich" :src="'data:image/png;base64,' + o.png" alt="cell output" />
+              <div v-else-if="o.svg" class="rich" v-html="o.svg" />
+              <div v-else-if="o.html" class="rich htmlout" v-html="o.html" />
+              <pre v-else-if="o.type === 'error'" class="oerr">{{ o.ename }}: {{ o.evalue }}</pre>
+              <div v-else-if="o.type === 'degraded'" class="odeg">⚠ {{ o.text }}</div>
+              <pre v-else class="stream">{{ o.text }}</pre>
+            </template>
+          </div>
+          <!-- governed receipt strip — the moat, per cell -->
+          <div v-if="cell.receipt" class="rcpt" :class="{ prev: cell.preview }">
+            <span class="seal">⛨ receipt</span>
+            <span class="mono">{{ short(cell.receipt.id) }}</span>
+            <span class="dot" :style="{ background: statColor[cell.receipt.status] || 'var(--idle)' }" />{{ cell.receipt.status }}
+            <span class="mono dim">code {{ short(cell.receipt.code_sha) }}</span>
+            <span class="mono dim">out {{ short(cell.receipt.outputs_sha) }}</span>
+            <span v-if="cell.receipt.prev" class="mono dim">↩ {{ short(cell.receipt.prev) }}</span>
+            <span v-if="cell.preview" class="tag">preview</span>
+            <span class="grow" />
+            <span class="replay">replayable</span>
+          </div>
+        </div>
+        <button class="x" title="delete cell" @click="removeCell(cell.id)">✕</button>
+      </div>
+    </div>
+
+    <!-- attested AI assistant — Genie-parity, but a proposal is only a HYPOTHESIS until you run it -->
+    <div class="assist">
+      <span class="amark" aria-hidden="true">✦</span>
+      <input class="ainput" v-model="assistPrompt" :disabled="assisting"
+             placeholder="Ask the assistant to draft a cell — e.g. ‘load the breach dataset and plot the warrant distribution’"
+             @keydown.enter="propose" />
+      <button class="apropose" :disabled="assisting || !assistPrompt.trim()" @click="propose">
+        <span v-if="assisting" class="spin" />{{ assisting ? 'Proposing…' : '✦ Propose' }}
+      </button>
+    </div>
+    <p class="ahint">
+      The assistant <b>proposes</b> a cell as an epistemic <b>hypothesis</b> — a model may propose, but only
+      <b>execution</b> (a sealed receipt) makes it real. {{ wired ? 'Backed by the Studio assistant model.' : 'No model wired to this build — proposals come from a deterministic offline heuristic, labelled as such. Never a fabricated model answer.' }}
+    </p>
+    <p v-if="assistErr" class="note err amsg">assistant: {{ assistErr }}</p>
+
+    <!-- session provenance chain — the tamper-evident record Databricks can't produce -->
+    <transition name="slide">
+      <aside v-if="chainOpen" class="prov-drawer">
+        <button class="x2" @click="chainOpen = false" aria-label="Close">✕</button>
+        <div class="pk">Session provenance</div>
+        <h3>Tamper-evident receipt chain</h3>
+        <p class="pcap">Every cell run is sealed and hash-chained to the one before it. Reorder a cell, edit an output, or forge a result and the chain breaks. This is the record a Databricks notebook can’t produce.</p>
+        <div v-if="!chain.length" class="empty2">Run a cell to start the chain.</div>
+        <div v-else class="chainlist">
+          <div v-for="(r, i) in chain" :key="r.id" class="crow">
+            <span class="cdot" :style="{ background: statColor[r.status] || 'var(--idle)' }" />
+            <div class="cinfo">
+              <div class="cid mono">{{ short(r.id) }}<span class="crt">{{ r.runtime }}</span></div>
+              <div class="cmeta"><span class="mono">code {{ short(r.code_sha) }}</span> · <span class="mono">out {{ short(r.outputs_sha) }}</span></div>
+              <div v-if="i > 0" class="clink mono">↩ prev {{ short(r.prev || chain[i - 1].id) }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="pfoot">
+          <span v-if="serverCount != null">✓ server chain: <b>{{ serverCount }}</b> sealed · replayable</span>
+          <span v-else>preview chain — runtime not wired</span>
+        </div>
+      </aside>
+    </transition>
+  </div>
+</template>
+
+<style scoped>
+.nb { font: 14px/1.5 var(--ui); color: var(--ink); position: relative; }
+.prov-btn.on { background: var(--accent-wash); border-color: color-mix(in srgb, var(--accent) 40%, transparent); color: var(--accent-ink); }
+.prov-btn .cnt2 { margin-left: 6px; background: var(--epi-attested); color: #fff; border-radius: 999px; padding: 0 6px; font-size: 11px; }
+
+/* rich outputs — plots (png/svg) + tables (DataFrame HTML) */
+.rich { max-width: 100%; margin: 4px 0; }
+.rich :deep(svg) { max-width: 100%; height: auto; }
+.htmlout { overflow-x: auto; }
+.htmlout :deep(table) { border-collapse: collapse; font: 12px/1.4 var(--mono); }
+.htmlout :deep(th), .htmlout :deep(td) { border: 1px solid var(--hairline); padding: 3px 10px; text-align: right; }
+.htmlout :deep(th) { background: var(--sunken); color: var(--muted); font-weight: 600; }
+
+/* provenance chain drawer */
+.prov-drawer { position: absolute; top: 0; right: 0; width: 320px; max-height: 100%; overflow: auto; background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-3); box-shadow: var(--e-3); padding: 18px 20px; z-index: 20; }
+.prov-drawer .x2 { position: absolute; top: 12px; right: 14px; border: 0; background: none; color: var(--muted); cursor: pointer; font-size: 15px; }
+.prov-drawer .pk { font-size: 10px; text-transform: uppercase; letter-spacing: .09em; color: var(--muted); }
+.prov-drawer h3 { margin: 4px 0 6px; font-size: 15px; }
+.prov-drawer .pcap { font-size: 12px; color: var(--muted); margin: 0 0 14px; }
+.prov-drawer .empty2 { font-size: 12px; color: var(--faint); padding: 20px 0; text-align: center; }
+.chainlist { display: flex; flex-direction: column; gap: 0; }
+.crow { display: flex; gap: 10px; position: relative; padding-bottom: 14px; }
+.crow::before { content: ""; position: absolute; left: 4px; top: 12px; bottom: -2px; width: 2px; background: var(--epi-attested); opacity: .35; }
+.crow:last-child::before { display: none; }
+.crow .cdot { width: 10px; height: 10px; border-radius: 999px; margin-top: 2px; flex: 0 0 auto; z-index: 2; }
+.crow .cid { font-size: 12px; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+.crow .crt { font-size: 10px; color: var(--faint); font-weight: 400; text-transform: none; }
+.crow .cmeta { font-size: 10.5px; color: var(--muted); margin-top: 2px; }
+.crow .clink { font-size: 10px; color: var(--faint); margin-top: 2px; }
+.prov-drawer .pfoot { margin-top: 8px; padding-top: 10px; border-top: 1px solid var(--hairline); font-size: 11px; color: var(--muted); }
+.prov-drawer .pfoot b { color: var(--epi-attested); }
+.slide-enter-active, .slide-leave-active { transition: transform .2s ease, opacity .2s ease; }
+.slide-enter-from, .slide-leave-to { transform: translateX(14px); opacity: 0; }
+.nb-bar { display: flex; align-items: center; gap: 12px; padding: 4px 0 12px; flex-wrap: wrap; }
+.nb-title { font-size: 15px; font-weight: 600; } .nb-title .proj { color: var(--muted); font-weight: 400; margin-left: 6px; font-size: 13px; }
+.rt { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); display: flex; align-items: center; gap: 6px; }
+.rt select { width: auto; padding: 4px 8px; font-size: 12px; text-transform: none; letter-spacing: 0; }
+.kstat { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+.kstat i { width: 8px; height: 8px; border-radius: 999px; }
+.nb-bar .sp { flex: 1; }
+.nb-bar .ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink); border-radius: var(--r-2); padding: 6px 12px; font-size: 13px; cursor: pointer; text-decoration: none; }
+.nb-bar .ghost:hover { background: var(--sunken); }
+.nb-bar .primary { border: 0; background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; font-weight: 600; cursor: pointer; }
+.nb-bar .primary:hover { background: var(--accent-2); }
+
+.note { font-size: 12px; color: var(--warn); background: var(--warn-wash); border: 1px solid color-mix(in srgb, var(--warn) 30%, transparent); border-radius: var(--r-2); padding: 8px 12px; margin: 0 0 14px; }
+.note.err { color: var(--fail); background: var(--fail-wash); border-color: color-mix(in srgb, var(--fail) 30%, transparent); }
+.note code { font-family: var(--mono); font-size: 11px; }
+
+.cells { display: flex; flex-direction: column; gap: 10px; }
+.cell { display: grid; grid-template-columns: 44px 1fr 24px; align-items: start; background: var(--surface); border: 1px solid var(--hairline); border-radius: var(--r-3); position: relative; transition: border-color .15s, box-shadow .15s; }
+.cell.running { border-color: var(--run); box-shadow: 0 0 0 3px var(--run-wash); }
+.cell.error { border-color: color-mix(in srgb, var(--fail) 50%, var(--hairline)); }
+.cell:hover .x { opacity: .6; }
+.gutter { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 10px 0; border-right: 1px solid var(--hairline); height: 100%; }
+.gutter .run { width: 26px; height: 26px; border: 1px solid var(--hairline-strong); background: var(--surface); border-radius: var(--r-2); cursor: pointer; color: var(--accent); font-size: 12px; display: grid; place-items: center; }
+.gutter .run:hover { background: var(--accent-wash); }
+.gutter .cnt { font-family: var(--mono); font-size: 10px; color: var(--faint); }
+.spin { width: 12px; height: 12px; border: 2px solid var(--run); border-top-color: transparent; border-radius: 999px; animation: sp .7s linear infinite; }
+@keyframes sp { to { transform: rotate(360deg); } }
+
+.body { min-width: 0; padding: 8px 12px; }
+.editor { width: 100%; border: 0; background: none; resize: none; outline: none; color: var(--ink);
+  font: 13px/1.55 var(--mono); padding: 4px 0; overflow: hidden; }
+.editor::placeholder { color: var(--faint); }
+.out { border-top: 1px solid var(--hairline); margin-top: 8px; padding-top: 8px; }
+.out pre { margin: 0; font: 12px/1.5 var(--mono); white-space: pre-wrap; word-break: break-word; }
+.out .stream { color: var(--ink-2); }
+.out .oerr { color: var(--fail); background: var(--fail-wash); border-radius: var(--r-1); padding: 6px 8px; }
+.out .odeg { color: var(--warn); font-size: 12px; }
+
+.rcpt { display: flex; align-items: center; gap: 10px; margin-top: 9px; padding-top: 8px; border-top: 1px dashed var(--hairline); font-size: 11px; color: var(--muted); flex-wrap: wrap; }
+.rcpt.prev { opacity: .8; }
+.rcpt .seal { color: var(--epi-attested); font-weight: 600; }
+.rcpt .mono { font-family: var(--mono); }
+.rcpt .dim { color: var(--faint); }
+.rcpt .dot { width: 7px; height: 7px; border-radius: 999px; }
+.rcpt .tag { background: var(--sunken); border-radius: var(--r-1); padding: 0 6px; color: var(--faint); }
+.rcpt .grow { flex: 1; }
+.rcpt .replay { color: var(--epi-attested); background: var(--epi-attested-wash); border-radius: var(--r-1); padding: 0 6px; font-weight: 600; }
+
+.cell .x { position: absolute; top: 8px; right: 6px; border: 0; background: none; color: var(--muted); cursor: pointer; opacity: 0; font-size: 12px; transition: opacity .15s; }
+.cell .x:hover { opacity: 1 !important; color: var(--fail); }
+
+/* proposed cell — a hypothesis until run. Coloured with the hypothesis ink so it reads as unproven. */
+.cell.proposed { border-color: color-mix(in srgb, var(--epi-hypothesis) 55%, var(--hairline)); box-shadow: 0 0 0 3px var(--epi-hypothesis-wash); }
+.cell.proposed .gutter .run { color: var(--epi-hypothesis); border-color: color-mix(in srgb, var(--epi-hypothesis) 45%, transparent); }
+.prop { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 10px; margin-bottom: 8px; font-size: 11px; }
+.prop .pbadge { color: #fff; background: var(--epi-hypothesis); border-radius: var(--r-1); padding: 1px 8px; font-weight: 600; letter-spacing: .02em; }
+.prop .psrc { font-family: var(--mono); font-size: 10.5px; border-radius: var(--r-1); padding: 1px 7px; border: 1px solid var(--hairline); color: var(--muted); }
+.prop .psrc.model { color: var(--epi-verified); border-color: color-mix(in srgb, var(--epi-verified) 40%, transparent); background: var(--epi-verified-wash); }
+.prop .psrc.heuristic { color: var(--warn); border-color: color-mix(in srgb, var(--warn) 35%, transparent); background: var(--warn-wash); }
+.prop .prat { color: var(--muted); flex: 1 1 240px; min-width: 0; }
+.prop .phint { color: var(--epi-hypothesis); font-weight: 500; }
+.prop .phint b { color: var(--epi-attested); }
+
+/* attested AI assistant bar — Genie-parity, proof-carrying */
+.assist { display: flex; align-items: center; gap: 10px; margin-top: 16px; padding: 8px 10px 8px 14px;
+  background: var(--surface); border: 1px solid var(--hairline-strong); border-radius: var(--r-3);
+  box-shadow: 0 0 0 3px var(--epi-hypothesis-wash); }
+.assist .amark { color: var(--epi-hypothesis); font-size: 16px; flex: 0 0 auto; }
+.assist .ainput { flex: 1; border: 0; background: none; outline: none; color: var(--ink); font: 13px/1.5 var(--ui); min-width: 0; }
+.assist .ainput::placeholder { color: var(--faint); }
+.assist .ainput:disabled { color: var(--muted); }
+.assist .apropose { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 7px; border: 0;
+  background: var(--epi-hypothesis); color: #fff; border-radius: var(--r-2); padding: 7px 14px; font-size: 13px; font-weight: 600; cursor: pointer; }
+.assist .apropose:hover:not(:disabled) { background: color-mix(in srgb, var(--epi-hypothesis) 82%, #000); }
+.assist .apropose:disabled { opacity: .55; cursor: default; }
+.assist .apropose .spin { border-color: #fff; border-top-color: transparent; }
+.ahint { font-size: 11px; color: var(--muted); margin: 8px 2px 0; }
+.ahint b { color: var(--ink-2); font-weight: 600; }
+.amsg { margin-top: 10px; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioOps.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioOps.vue
@@ -1,0 +1,249 @@
+<script setup lang="ts">
+// The Operations cockpit — the Foundry-Workshop answer: makes the studio's data plane OPERABLE, not just
+// callable. Pipelines (run), model registry (promote), data catalog, pay-gated compute (submit an execution),
+// and GraphRAG communities — every action proof-carrying and, for compute, entitlement-gated like Databricks/
+// Foundry but sovereign + multi-backend.
+import { ref, onMounted, watch } from "vue";
+import {
+  loadPipelines, runPipeline, loadModels, promoteModel, loadCatalog, loadCompute, execute, loadCommunities,
+  EPISTEMIC_COLORS,
+  type Pipeline, type ModelEntry, type Dataset, type Compute, type Community, type ExecResult,
+} from "../../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+
+const pipelines = ref<Pipeline[]>([]);
+const models = ref<ModelEntry[]>([]);
+const datasets = ref<Dataset[]>([]);
+const compute = ref<Compute | null>(null);
+const communities = ref<Community[]>([]);
+const loading = ref(true);
+const err = ref("");
+const token = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try {
+    const [p, m, c, cp, cm] = await Promise.all([
+      loadPipelines(props.project), loadModels(props.project), loadCatalog(props.project),
+      loadCompute(props.project), loadCommunities(props.project),
+    ]);
+    pipelines.value = p.pipelines; models.value = m.models; datasets.value = c.datasets;
+    compute.value = cp; communities.value = cm.communities;
+  } catch (e) { err.value = e instanceof Error ? e.message : "failed to load operations"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+const STAGES = ["none", "staging", "production", "archived"];
+const busy = ref(""); const flash = ref("");
+function say(msg: string) { flash.value = msg; setTimeout(() => (flash.value = ""), 2600); }
+
+async function doPromote(name: string, version: string, stage: string) {
+  busy.value = `${name}:${version}`;
+  try { const r = await promoteModel({ project: props.project, name, version, stage }, token.value); say(`${name} v${version} → ${r.stage}`); await load(); }
+  catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
+  finally { busy.value = ""; }
+}
+async function doRun(pipeline: string) {
+  busy.value = pipeline;
+  try { const r = await runPipeline({ project: props.project, pipeline }, token.value); say(`Ran ${pipeline} · ${r.status}`); }
+  catch (e) { say(e instanceof Error ? e.message : "run failed"); }
+  finally { busy.value = ""; }
+}
+
+// compute / execute
+const exBackend = ref("mesh-k8s");
+const exKind = ref("notebook-cell");
+const exRef = ref("");
+const exResult = ref<ExecResult | null>(null);
+const exBusy = ref(false);
+async function submitExec() {
+  exBusy.value = true; exResult.value = null;
+  try { exResult.value = await execute({ project: props.project, kind: exKind.value, backend: exBackend.value, ref: exRef.value || undefined }, token.value); }
+  catch (e) { say(e instanceof Error ? e.message : "execute failed"); }
+  finally { exBusy.value = false; }
+}
+
+function color(mode?: string): string { return EPISTEMIC_COLORS[mode || "observed"] || "var(--faint)"; }
+function kv(o: Record<string, number>): string { return Object.entries(o).map(([k, v]) => `${k}=${v}`).join("  "); }
+</script>
+
+<template>
+  <div class="ops">
+    <div class="obar">
+      <span class="cnt">Operations · pipelines · registry · catalog · compute · communities</span>
+      <div class="spacer" />
+      <input v-model="token" type="password" class="tok" placeholder="write token" title="required for run / promote / execute" />
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload operations">↻</button>
+    </div>
+    <p v-if="flash" class="flash">{{ flash }}</p>
+    <p v-if="err" class="msg err">{{ err }}</p>
+    <p v-else-if="loading" class="msg">Loading operations…</p>
+
+    <div v-else class="grid">
+      <!-- Pay-gated compute -->
+      <section class="card wide" v-if="compute">
+        <header class="ch"><span class="ci">⚙</span> Compute<span class="tagline">pay-gated · sovereign · multi-backend</span></header>
+        <div class="backends">
+          <label v-for="b in compute.backends" :key="b.id" class="backend" :class="{ sel: exBackend === b.id, ent: b.entitled }">
+            <input type="radio" name="backend" :value="b.id" v-model="exBackend" />
+            <span class="bn">{{ b.id }}<i class="bk">{{ b.kind }}</i></span>
+            <span class="bnote">{{ b.note }}</span>
+            <span class="bstate" :class="{ on: b.entitled }">{{ b.entitled ? "entitled" : "available" }}</span>
+          </label>
+        </div>
+        <div class="exrow">
+          <select v-model="exKind" class="sel-k">
+            <option>notebook-cell</option><option>pipeline-step</option><option>job</option><option>query</option>
+          </select>
+          <input v-model="exRef" class="ref" placeholder="ref (notebook / pipeline id) — optional" />
+          <button class="primary" @click="submitExec" :disabled="exBusy">{{ exBusy ? "…" : "Submit run" }}</button>
+        </div>
+        <div v-if="exResult" class="exres" :class="{ gated: !exResult.ok }">
+          <template v-if="exResult.ok">
+            ✓ dispatched to <b>{{ exResult.backend }}</b> · receipt <code class="mono">{{ exResult.receipt.correlation_id }}</code>
+            <span class="rep">replayable</span>
+          </template>
+          <template v-else>
+            🔒 <b>entitlement required</b> — {{ exResult.message }}
+          </template>
+        </div>
+        <p class="sub">Same pay-gated model as Databricks/Foundry — <b>capability available, runtime provisioned only when entitled</b> — but the compute is sovereign (your mesh) or bring-your-own, and every run emits a governed, replayable receipt.</p>
+      </section>
+
+      <!-- Model registry -->
+      <section class="card" v-if="models.length">
+        <header class="ch"><span class="ci">◈</span> Model registry<span class="score">{{ models.reduce((n, m) => n + m.versions.length, 0) }} versions</span></header>
+        <div v-for="m in models" :key="m.name" class="model">
+          <div class="mname">{{ m.name }}</div>
+          <div v-for="v in m.versions" :key="v.model_id" class="mver">
+            <span class="vv">v{{ v.version }}</span>
+            <span class="stage" :class="v.stage">{{ v.stage }}</span>
+            <span class="mono met">{{ kv(v.metrics) }}</span>
+            <span v-if="v.run" class="lineage mono" :title="'produced_by → run'">↳ {{ v.run.split(':').pop() }}</span>
+            <select class="promote" :disabled="busy === `${m.name}:${v.version}`"
+                    @change="e => doPromote(m.name, v.version, (e.target as HTMLSelectElement).value)">
+              <option value="" disabled selected>promote…</option>
+              <option v-for="s in STAGES" :key="s" :value="s" :disabled="s === v.stage">{{ s }}</option>
+            </select>
+          </div>
+        </div>
+        <p class="sub">Versions carry their <b>producing run</b> (provenance travels with the model); stage transitions are governed events — beats MLflow.</p>
+      </section>
+
+      <!-- Pipelines -->
+      <section class="card" v-if="pipelines.length">
+        <header class="ch"><span class="ci">⛓</span> Pipelines<span class="score">{{ pipelines.length }}</span></header>
+        <div v-for="p in pipelines" :key="p.pipeline_id" class="pipe">
+          <div class="prow">
+            <span class="pname">{{ p.name }}</span>
+            <button class="run" @click="doRun(p.name)" :disabled="busy === p.name">▷ Run</button>
+          </div>
+          <div class="dag">
+            <template v-for="(s, i) in p.steps" :key="s.id">
+              <span class="step" :title="s.kind">{{ s.id }}</span><span v-if="i < p.steps.length - 1" class="arrow">→</span>
+            </template>
+          </div>
+        </div>
+        <p class="sub">A proof-carrying DAG with a governed run ledger; lineage IS the graph — beats Databricks Workflows / Foundry Pipeline Builder.</p>
+      </section>
+
+      <!-- Data catalog -->
+      <section class="card" v-if="datasets.length">
+        <header class="ch"><span class="ci">▤</span> Data catalog<span class="score">{{ datasets.length }}</span></header>
+        <table class="cat">
+          <tbody>
+            <tr v-for="d in datasets" :key="d.id">
+              <td class="nm">{{ d.name }}</td>
+              <td><span v-if="d.connector" class="pill">{{ d.connector }}</span></td>
+              <td class="mono cols">{{ d.columns.join(", ") }}</td>
+              <td><span class="epi" :style="{ borderColor: color(d.epistemic_mode), color: color(d.epistemic_mode) }">{{ d.epistemic_mode }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="sub">Datasets are proof-carrying graph nodes — provenance + epistemic status native, not a bolt-on catalog.</p>
+      </section>
+
+      <!-- GraphRAG communities -->
+      <section class="card wide" v-if="communities.length">
+        <header class="ch"><span class="ci">◍</span> GraphRAG communities<span class="score">{{ communities.length }} · {{ communities[0] ? 'louvain' : '' }}</span></header>
+        <div class="comms">
+          <div v-for="c in communities" :key="c.community" class="comm">
+            <div class="crow"><b>{{ c.size }}</b> nodes
+              <span class="mb-bar" v-if="c.size">
+                <i v-for="(n, mode) in c.epistemic_distribution" :key="mode" :style="{ width: (n / c.size * 100) + '%', background: color(mode) }" :title="mode + ': ' + n" />
+              </span>
+            </div>
+            <div class="top">{{ c.top_members.map(t => t.label).join(" · ") }}</div>
+          </div>
+        </div>
+        <p class="sub">Communities detected over the <b>proof-carrying</b> graph (deterministic Louvain); each carries its epistemic profile — summaries attach next, frontier-authored.</p>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ops { font: 14px/1.5 var(--ui); color: var(--ink); }
+.ops :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-1); }
+.obar { display: flex; align-items: center; gap: var(--sp-2); margin-bottom: var(--sp-3); }
+.obar .cnt { color: var(--muted); font-size: 12px; } .obar .spacer { flex: 1; }
+.obar .tok { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; width: 130px; background: var(--surface); color: var(--ink); }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 30px; height: 30px; cursor: pointer; }
+.flash { background: var(--ok-wash); color: var(--ok); border-radius: var(--r-2); padding: 7px 12px; font-size: 12.5px; margin: 0 0 12px; }
+.msg { color: var(--muted); } .msg.err { color: var(--fail); }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: var(--sp-3); }
+.card { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--surface); }
+.card.wide { grid-column: 1 / -1; }
+.ch { display: flex; align-items: center; gap: var(--sp-2); font-weight: 600; font-size: 14px; margin-bottom: 10px; }
+.ch .ci { color: var(--accent); } .ch .tagline { margin-left: auto; font-size: 10.5px; color: var(--accent); background: var(--accent-wash); border-radius: var(--pill); padding: 2px 9px; font-weight: 500; }
+.score { margin-left: auto; font-size: 11px; color: var(--muted); background: var(--sunken); border-radius: var(--pill); padding: 2px 9px; font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); font-size: 12px; }
+.sub { color: var(--muted); font-size: 12px; margin: 10px 0 0; } .sub b { color: var(--ink); }
+
+/* compute */
+.backends { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--sp-2); margin-bottom: 10px; }
+.backend { display: grid; grid-template-columns: auto 1fr; grid-template-rows: auto auto; gap: 2px 8px; align-items: center;
+  border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 8px 10px; cursor: pointer; }
+.backend.sel { border-color: var(--accent); background: var(--accent-wash); } .backend.ent { }
+.backend input { grid-row: 1 / 3; } .bn { font-weight: 600; font-size: 13px; } .bn .bk { font-style: normal; font-size: 10px; color: var(--muted); margin-left: 6px; }
+.bnote { grid-column: 2; font-size: 11px; color: var(--muted); } .bstate { grid-column: 2; font-size: 10px; color: var(--warn); } .bstate.on { color: var(--ok); }
+.exrow { display: flex; gap: 6px; margin-bottom: 8px; }
+.exrow .sel-k { border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.exrow .ref { flex: 1; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); padding: 6px 8px; font-size: 13px; background: var(--surface); color: var(--ink); }
+.primary { border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: var(--r-2); padding: 6px 14px; font-size: 13px; cursor: pointer; }
+.primary:disabled { opacity: .6; }
+.exres { font-size: 12.5px; border-radius: var(--r-2); padding: 8px 10px; background: var(--ok-wash); color: var(--ok); }
+.exres.gated { background: var(--warn-wash); color: var(--warn); }
+.exres .rep { margin-left: 6px; font-size: 10px; background: var(--surface); border-radius: var(--r-2); padding: 1px 6px; }
+
+/* models */
+.model { margin-bottom: 8px; } .mname { font-weight: 600; margin-bottom: 3px; }
+.mver { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; padding: 3px 0; flex-wrap: wrap; }
+.vv { font-weight: 700; color: var(--accent); font-variant-numeric: tabular-nums; }
+.stage { font-size: 10px; border-radius: var(--pill); padding: 1px 7px; background: var(--sunken); color: var(--muted); }
+.stage.production { background: var(--ok-wash); color: var(--ok); } .stage.staging { background: var(--accent-wash); color: var(--accent); } .stage.archived { background: var(--sunken); color: var(--faint); }
+.met { color: var(--ok); font-variant-numeric: tabular-nums; } .lineage { color: var(--muted); }
+.promote { margin-left: auto; border: 1px solid var(--hairline-strong); border-radius: var(--r-2); font-size: 11.5px; padding: 2px 6px; background: var(--surface); color: var(--ink); }
+
+/* pipelines */
+.pipe { margin-bottom: 8px; } .prow { display: flex; align-items: center; gap: var(--sp-2); }
+.pname { font-weight: 600; } .run { margin-left: auto; border: 1px solid var(--accent); background: var(--surface); color: var(--accent); border-radius: var(--r-2); padding: 3px 10px; font-size: 12px; cursor: pointer; }
+.dag { display: flex; align-items: center; gap: 5px; flex-wrap: wrap; margin-top: 5px; }
+.step { font-size: 11.5px; background: var(--sunken); border-radius: var(--r-2); padding: 2px 9px; } .arrow { color: var(--faint); }
+
+/* catalog */
+.cat { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.cat td { padding: 5px 8px; border-bottom: 1px solid var(--sunken); } .cat tr:last-child td { border-bottom: 0; }
+.cat .nm { font-weight: 600; } .cat .cols { color: var(--muted); } .pill { font-size: 10px; background: var(--hairline); border-radius: var(--r-2); padding: 1px 7px; color: var(--muted); }
+.epi { font-size: 10px; border: 1px solid; border-radius: var(--r-1); padding: 1px 7px; }
+
+/* communities */
+.comms { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--sp-3); }
+.comm { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: 8px 10px; }
+.crow { display: flex; align-items: center; gap: var(--sp-2); font-size: 12.5px; } .crow b { font-size: 16px; font-variant-numeric: tabular-nums; }
+.mb-bar { display: flex; height: 7px; flex: 1; border-radius: var(--r-1); overflow: hidden; background: var(--sunken); } .mb-bar i { display: block; height: 100%; }
+.top { font-size: 11.5px; color: var(--muted); margin-top: 5px; }
+</style>

--- a/socioprophet-web/client-vue/src/pages/studio/api.ts
+++ b/socioprophet-web/client-vue/src/pages/studio/api.ts
@@ -1,0 +1,72 @@
+/**
+ * api.ts — the Prophet Studio client for the platform's real services.
+ *
+ * Every call goes to a same-origin `/svc/<service>/…` path that nginx (prod) or the Vite dev server proxies
+ * to the in-cluster service — so no CORS, no hard-coded hosts. Each service base is overridable at runtime
+ * via window.__PROPHET_API__ for bespoke ingress topologies. Errors are surfaced, never swallowed.
+ */
+type ApiMap = { hellgraph: string; reason: string; er: string; studio: string }
+const DEFAULTS: ApiMap = { hellgraph: '/svc/hellgraph', reason: '/svc/reason', er: '/svc/er', studio: '/svc/studio' }
+const CFG: ApiMap = { ...DEFAULTS, ...((globalThis as any).__PROPHET_API__ ?? {}) }
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message) }
+}
+
+async function call<T>(base: string, path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(base + path, {
+    ...init,
+    headers: { ...(init?.body ? { 'content-type': 'application/json' } : {}), ...(init?.headers ?? {}) },
+  })
+  const text = await res.text()
+  let body: any = text
+  try { body = text ? JSON.parse(text) : null } catch { /* keep raw text (e.g. turtle/html) */ }
+  if (!res.ok) throw new ApiError(res.status, (body && body.error) || text || `HTTP ${res.status}`)
+  return body as T
+}
+
+// ── hellgraph-service ────────────────────────────────────────────────────────────
+export const graph = {
+  stats: () => call<{ nodes: number; edges: number }>(CFG.hellgraph, '/api/graph/stats'),
+  subgraph: (label = '', limit = 400) =>
+    call<{ count: number; edges: number; nodes: any[]; edgeList: any[] }>(CFG.hellgraph, `/api/graph/subgraph?label=${encodeURIComponent(label)}&limit=${limit}`),
+  addNode: (id: string, labels: string[], properties: Record<string, unknown> = {}) =>
+    call(CFG.hellgraph, '/api/graph/node', { method: 'POST', body: JSON.stringify({ id, labels, properties }) }),
+  addEdge: (label: string, from: string, to: string, properties: Record<string, unknown> = {}) =>
+    call(CFG.hellgraph, '/api/graph/edge', { method: 'POST', body: JSON.stringify({ label, from, to, properties }) }),
+  sparql: (query: string) => call<any>(CFG.hellgraph, '/api/graph/sparql', { method: 'POST', body: JSON.stringify({ query }) }),
+  cypher: (query: string) => call<any>(CFG.hellgraph, '/api/graph/cypher', { method: 'POST', body: JSON.stringify({ query }) }),
+  gremlin: (query: string) => call<any>(CFG.hellgraph, '/api/graph/gremlin', { method: 'POST', body: JSON.stringify({ query }) }),
+  analytics: (metric: 'pagerank' | 'components', limit = 25) =>
+    call<any>(CFG.hellgraph, `/api/graph/analytics?metric=${metric}&limit=${limit}`),
+  resource: (uri: string) => call<any>(CFG.hellgraph, `/api/graph/resource?uri=${encodeURIComponent(uri)}`),
+  ground: (q: string, hops = 1) => call<any>(CFG.hellgraph, `/api/graph/ground?q=${encodeURIComponent(q)}&hops=${hops}`),
+  ask: (question: string) => call<any>(CFG.hellgraph, '/api/graph/ask', { method: 'POST', body: JSON.stringify({ question }) }),
+}
+
+// ── owl-reasoner ─────────────────────────────────────────────────────────────────
+export const reasoner = {
+  reason: (turtle: string, inference = 'rdfs', explain = true, shapes?: string) =>
+    call<any>(CFG.reason, '/reason', { method: 'POST', body: JSON.stringify({ turtle, inference, explain, shapes }) }),
+  ontologyDoc: (turtle: string) => call<any>(CFG.reason, '/ontology/doc', { method: 'POST', body: JSON.stringify({ turtle, format: 'json' }) }),
+  ontologyGraph: (turtle: string) => call<any>(CFG.reason, '/ontology/graph', { method: 'POST', body: JSON.stringify({ turtle }) }),
+  virtualize: (rows: any[], mapping: any) => call<any>(CFG.reason, '/virtualize', { method: 'POST', body: JSON.stringify({ rows, mapping }) }),
+}
+
+// ── entity-resolution ────────────────────────────────────────────────────────────
+export const er = {
+  resolve: (records: any[]) => call<any>(CFG.er, '/resolve', { method: 'POST', body: JSON.stringify({ records }) }),
+}
+
+export interface Health { name: string; ok: boolean; detail?: string }
+export async function health(): Promise<Health[]> {
+  const probes: [string, string, string][] = [
+    ['hellgraph', CFG.hellgraph, '/healthz'],
+    ['owl-reasoner', CFG.reason, '/healthz'],
+    ['entity-resolution', CFG.er, '/healthz'],
+    ['lattice-studio', CFG.studio, '/healthz'],
+  ]
+  return Promise.all(probes.map(async ([name, base, p]) => {
+    try { await call(base, p); return { name, ok: true } } catch (e: any) { return { name, ok: false, detail: e?.message } }
+  }))
+}

--- a/socioprophet-web/client-vue/src/pages/studio/studio-tokens.css
+++ b/socioprophet-web/client-vue/src/pages/studio/studio-tokens.css
@@ -1,0 +1,87 @@
+/* Prophet Studio design tokens (Layer 0), SCOPED to the Studio subtree so the migrated
+   notebook/compute surfaces keep their intended look inside the dark cockpit shell without
+   clobbering the cockpit's own global tokens. Dark values (cockpit is always dark).
+   Epistemic ramp = the one saturated dimension (the moat, made visible). */
+.studio-scope {
+  --ground:#0b0f15; --sunken:#080b10; --surface:#141b24; --surface-2:#18202a;
+  --hairline:#232c38; --hairline-strong:#33404f;
+  --ink:#e8eef5; --ink-2:#b4c0cd; --muted:#8a97a5; --faint:#5d6a78;
+  --bar:#080b10; --bar-ink:#e8eef5; --bar-muted:#8a97a5; --bar-line:#1c242f;
+  --accent:#5b95f9; --accent-2:#3f83f8; --accent-wash:#16233b; --accent-ink:#bcd4ff;
+
+  --epi-hypothesis:#8592a3; --epi-observed:#5b95f9; --epi-derived:#a082f8;
+  --epi-verified:#2dd4bf; --epi-attested:#34d399; --epi-simulated:#e0975a; --epi-unknown:#4a5568;
+  --epi-hypothesis-wash:#1a2029; --epi-observed-wash:#14243c; --epi-derived-wash:#211a3a;
+  --epi-verified-wash:#0e2c2b; --epi-attested-wash:#0e2a22;
+
+  --ok:#3fb950; --warn:#d29922; --fail:#e5534b; --run:#5b95f9; --idle:#6b7684;
+  --ok-wash:#0f2417; --warn-wash:#241d0a; --fail-wash:#2a1315; --run-wash:#14243c;
+
+  --sp-1:4px; --sp-2:8px; --sp-3:12px; --sp-4:16px; --sp-5:24px; --sp-6:32px;
+  --r-1:3px; --r-2:5px; --r-3:8px; --pill:999px;
+  --e-1:0 1px 2px rgba(0,0,0,.4); --e-2:0 4px 14px rgba(0,0,0,.5); --e-3:0 12px 40px rgba(0,0,0,.6);
+  --canvas-dot:#1a212b;
+  --ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+/* ---- shared primitive utilities (scoped) ---------------------------------- */
+.studio-scope .epi-stripe { position:relative; }
+.studio-scope .epi-stripe::before {
+  content:""; position:absolute; left:0; top:0; bottom:0; width:3px;
+  background:var(--epi, var(--epi-unknown)); border-radius:var(--r-1) 0 0 var(--r-1);
+}
+.studio-scope .epi-dot { display:inline-block; width:8px; height:8px; border-radius:var(--pill);
+  background:var(--epi, var(--epi-unknown)); flex:0 0 auto; }
+.studio-scope .epi-chip { display:inline-flex; align-items:center; gap:6px; font-size:11px; font-weight:600;
+  letter-spacing:.01em; padding:1px 8px 1px 7px; border-radius:var(--r-1);
+  color:var(--epi, var(--epi-unknown)); background:var(--epi-wash, transparent);
+  border:1px solid color-mix(in srgb, var(--epi, var(--epi-unknown)) 40%, transparent); }
+.studio-scope .stat-chip { display:inline-flex; align-items:center; gap:5px; font-size:11px; font-weight:600;
+  padding:1px 8px; border-radius:var(--pill); color:#fff; background:var(--stat, var(--idle)); }
+.studio-scope .stat-chip.soft { color:var(--stat, var(--idle)); background:var(--stat-wash, var(--sunken)); }
+.studio-scope .tnum { font-variant-numeric: tabular-nums; }
+.studio-scope .mono { font-family: var(--mono); }
+
+/* ---- Prophet Studio KE-surface tokens + utilities (scoped) ----------------
+   The migrated Graph Explorer / Query / Analytics / GraphRAG / Resource / Reasoner /
+   Entity-Resolution / Ontology views use this vocabulary (--panel, .card, .btn, .tbl…). */
+.studio-scope {
+  --bg:#0b0e14; --panel:#121722; --panel-2:#161c28; --border:#232b3a; --border-2:#2e3849;
+  --text:#e6edf3; --warn:#f0b849; --bad:#ff6b6b; --good:#43d17a;
+  --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.studio-scope .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 1rem 1.1rem; }
+.studio-scope .card + .card { margin-top: 1rem; }
+.studio-scope .card h3 { margin: 0 0 .3rem; font-size: .92rem; font-weight: 600; }
+.studio-scope .card .desc { color: var(--muted); font-size: .82rem; margin: 0 0 .8rem; }
+.studio-scope .grid { display: grid; gap: 1rem; }
+.studio-scope .grid.cols-2 { grid-template-columns: 1fr 1fr; }
+.studio-scope .grid.cols-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 900px) { .studio-scope .grid.cols-2, .studio-scope .grid.cols-3 { grid-template-columns: 1fr; } }
+.studio-scope label.fld { display:block; color:var(--muted); font-size:.74rem; text-transform:uppercase; letter-spacing:.05em; margin:0 0 .3rem; }
+.studio-scope textarea, .studio-scope input[type=text], .studio-scope select {
+  width:100%; background:var(--bg); color:var(--text); border:1px solid var(--border-2); border-radius:8px;
+  padding:.55rem .65rem; font-family:var(--mono); font-size:.82rem; resize:vertical; }
+.studio-scope textarea:focus, .studio-scope input:focus, .studio-scope select:focus { outline:none; border-color:var(--accent); }
+.studio-scope button.btn { background:var(--accent); color:#04122e; border:0; border-radius:8px; padding:.5rem .9rem; font-weight:600; cursor:pointer; font-size:.84rem; }
+.studio-scope button.btn:hover { filter:brightness(1.08); }
+.studio-scope button.btn.ghost { background:transparent; color:var(--text); border:1px solid var(--border-2); }
+.studio-scope button.btn:disabled { opacity:.5; cursor:default; }
+.studio-scope .row { display:flex; gap:.5rem; align-items:center; flex-wrap:wrap; }
+.studio-scope table.tbl { width:100%; border-collapse:collapse; font-size:.82rem; }
+.studio-scope table.tbl th { text-align:left; color:var(--muted); font-weight:500; border-bottom:1px solid var(--border-2); padding:.4rem .5rem; position:sticky; top:0; background:var(--panel); }
+.studio-scope table.tbl td { border-bottom:1px solid var(--border); padding:.4rem .5rem; font-family:var(--mono); vertical-align:top; }
+.studio-scope .scroll { overflow:auto; max-height:52vh; border:1px solid var(--border); border-radius:8px; }
+.studio-scope .pill { display:inline-block; padding:.1rem .5rem; border-radius:999px; font-size:.7rem; border:1px solid var(--border-2); color:var(--muted); }
+.studio-scope .pill.good { color:var(--good); border-color:#1e4d34; background:#0f2a1c; }
+.studio-scope .pill.bad { color:var(--bad); border-color:#4d1e1e; background:#2a0f0f; }
+.studio-scope .pill.accent { color:var(--accent); border-color:#23406e; background:#0f1c33; }
+.studio-scope .kpi { font-size:1.6rem; font-weight:700; letter-spacing:-.02em; }
+.studio-scope .kpi-l { color:var(--muted); font-size:.74rem; text-transform:uppercase; letter-spacing:.05em; }
+.studio-scope code, .studio-scope .mono { font-family:var(--mono); }
+.studio-scope pre.out { background:var(--bg); border:1px solid var(--border); border-radius:8px; padding:.7rem; overflow:auto; font-size:.78rem; max-height:40vh; }
+.studio-scope .err { color:var(--bad); font-size:.82rem; }
+.studio-scope .muted { color:var(--muted); }
+.studio-scope a.link { color:var(--accent); cursor:pointer; text-decoration:none; }
+.studio-scope a.link:hover { text-decoration:underline; }

--- a/socioprophet-web/client-vue/src/services/algoApi.ts
+++ b/socioprophet-web/client-vue/src/services/algoApi.ts
@@ -1,0 +1,33 @@
+// Real Algorithmic Trading backend — algo-engine (prophet-platform/apps/algo-engine).
+// Backtests run over real historical daily bars (Yahoo); paper execution is a real ledger
+// marked to the latest close. Same-origin `/svc/algo` proxy → :8085 in dev.
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_ALGO_BASE ?? '/svc/algo';
+
+export interface StrategyDef { id: string; label: string; blurb: string; params: Record<string, any> }
+export interface Metrics { total_return: number; cagr: number; sharpe: number; max_drawdown: number; win_rate: number; vol: number }
+export interface Fill { symbol: string; side: 'BUY' | 'SELL'; weight_delta: number; price: number }
+export interface Backtest {
+  ok: boolean; error?: string; strategy: string; universe: string[]; as_of: string;
+  metrics: Metrics; trades: number; gross_exposure: number;
+  equity_curve: number[]; dates: string[]; fills: Fill[];
+  provenance: { data_source: string; bars_per_name: number; not_investment_advice: boolean };
+}
+export interface NlSpec { strategy: string; universe: string[]; params: Record<string, any>; name: string; rationale: string }
+export interface Position { symbol: string; qty: number; price: number; market_value: number }
+export interface Order { symbol: string; side: string; qty: number; price: number; ts: string }
+export interface PaperState { cash: number; positions: Position[]; market_value: number; equity: number; unrealized_pnl: number; orders: Order[] }
+
+async function get<T>(p: string): Promise<T> {
+  const r = await fetch(`${BASE}${p}`); if (!r.ok) throw new Error(`${p} ${r.status}`); return r.json();
+}
+async function post<T>(p: string, body: unknown): Promise<T> {
+  const r = await fetch(`${BASE}${p}`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+  if (!r.ok) throw new Error(`${p} ${r.status}`); return r.json();
+}
+
+export const listStrategies = () => get<{ strategies: StrategyDef[] }>('/strategies');
+export const runBacktest = (b: { strategy: string; universe: string[]; lookback_days?: number; params?: Record<string, any> }) => post<Backtest>('/backtest', b);
+export const strategyFromNl = (text: string) => post<NlSpec>('/strategy/from-nl', { text });
+export const paperState = () => get<PaperState>('/paper/state');
+export const placeOrder = (o: { symbol: string; side: 'BUY' | 'SELL'; qty: number; price?: number }) => post<PaperState & { fill: Order }>('/paper/order', o);
+export const resetPaper = () => post<PaperState>('/paper/reset', {});

--- a/socioprophet-web/client-vue/src/services/hellgraphApi.ts
+++ b/socioprophet-web/client-vue/src/services/hellgraphApi.ts
@@ -1,0 +1,24 @@
+// Canonical knowledge-graph client — hellgraph-service, the shared HTTP HellGraph engine
+// (prophet-platform/apps/hellgraph-service). This is the ONE backend the cockpit's Knowledge
+// Graph and the Prophet Studio Graph Explorer both read, so the graph is unified across surfaces.
+//
+// Base is the same-origin `/svc/hellgraph` proxy (see vite.config.ts) → :8090 in dev.
+// Endpoints mirror the agent-machine surface contract, so SurfaceResult/GraphHealth are reused.
+import type { SurfaceResult, GraphHealth } from './agentMachineApi';
+
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_HELLGRAPH_BASE ?? '/svc/hellgraph';
+
+export const graphSurface = async (view = 'all', limit = 34, root = ''): Promise<SurfaceResult> => {
+  const q = new URLSearchParams({ view, limit: String(limit) });
+  if (root) q.set('root', root);
+  const res = await fetch(`${BASE}/api/graph/surface?${q.toString()}`);
+  if (!res.ok) throw new Error(`graph surface ${res.status}`);
+  return res.json();
+};
+
+export async function graphHealth(): Promise<GraphHealth> {
+  const res = await fetch(`${BASE}/api/graph/stats`);
+  if (!res.ok) throw new Error(`graph stats ${res.status}`);
+  const d = (await res.json()) as { nodes: number; edges: number };
+  return { ok: true, nodes: d.nodes, edges: d.edges };
+}

--- a/socioprophet-web/client-vue/src/services/ieApi.ts
+++ b/socioprophet-web/client-vue/src/services/ieApi.ts
@@ -1,0 +1,47 @@
+// Real NLP / Information-Extraction backend — ie-engine (prophet-platform/apps/ie-engine).
+// Entities = live spaCy NER; relations = dependency parse; claims = assert/hedge; extraction can be
+// pushed into the canonical HellGraph. Same-origin `/svc/ie` proxy → :8086 in dev.
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_IE_BASE ?? '/svc/ie';
+
+export interface Entity { text: string; type: string; spacy_label?: string; mentions?: number; count?: number }
+export interface Relation { from: string; relation: string; to: string }
+export interface Claim { type: 'ASSERT' | 'HEDGE'; text: string; verifiable: boolean }
+export interface Extraction {
+  entities: Entity[]; relations: Relation[]; claims: Claim[]; topics: Entity[];
+  sentiment: { label: string; score: number }; counts: Record<string, number>;
+  provenance: { model: string; extractor: string; real: boolean };
+}
+export interface GraphWrite extends Extraction { ok: boolean; nodes_written: number; edges_written: number; graph: string }
+
+async function post<T>(p: string, body: unknown): Promise<T> {
+  const r = await fetch(`${BASE}${p}`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+  if (!r.ok) throw new Error(`${p} ${r.status}`); return r.json();
+}
+export const extract = (text: string) => post<Extraction>('/extract', { text });
+export const toGraph = (text: string) => post<GraphWrite>('/to-graph', { text });
+export const vectorize = (texts: string[]) => post<{ similarity: number[][]; method: string }>('/vectorize', { texts });
+
+export interface Term { term: string; type: string; count: number; definition: string }
+export const glossary = (text: string) => post<{ terms: Term[]; count: number }>('/glossary', { text });
+
+// Sibling suite backends, same-origin proxies (see vite.config.ts).
+async function postAt<T>(base: string, p: string, body: unknown): Promise<T> {
+  const r = await fetch(`${base}${p}`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+  if (!r.ok) throw new Error(`${p} ${r.status}`); return r.json();
+}
+// owl-reasoner — type-system / ontology entailment
+export const reason = (turtle: string, inference = 'rdfs') =>
+  postAt<{ input_triples: number; entailed_triples: number; entailments: any[] }>('/svc/reason', '/reason', { turtle, inference });
+// entity-resolution — resolve mentions → golden records
+export const resolve = (records: { id: string; name: string }[]) =>
+  postAt<{ golden_records: any[]; decision_ledger: any[]; entities: any[] }>('/svc/er', '/resolve', { records });
+
+// holmes — verify claims against real HellGraph evidence (deduction engine)
+export interface Verdict { claim: string; verdict: 'supported' | 'weakly-supported' | 'unverified' | 'unreachable'; matched_terms?: string[]; evidence_count: number }
+export const verifyClaims = (claims: string[]) =>
+  postAt<{ results: Verdict[] }>('/svc/holmes', '/verify', { claims });
+
+// synapseiq — language intelligence: KKO (Peircean) type classification of entity types
+export interface Kko { type: string; kko: 'Particulars' | 'Generals' | 'Possibilities' }
+export const kkoClassify = (types: string[]) =>
+  postAt<{ results: Kko[] }>('/svc/synapse', '/kko-class', { types });

--- a/socioprophet-web/client-vue/src/services/sherlockApi.ts
+++ b/socioprophet-web/client-vue/src/services/sherlockApi.ts
@@ -1,0 +1,19 @@
+// Sherlock — sovereign Discovery search (sherlock-engine, Tantivy/Rust, no JVM). Same-origin
+// `/svc/sherlock` proxy → :8093 in dev. Ontology-driven full-text with BM25 + highlighted snippets;
+// results can be verified against HellGraph evidence via Holmes (see ieApi.verifyClaims).
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_SHERLOCK_BASE ?? '/svc/sherlock';
+
+export interface Hit { id: string; title: string; doctype: string; category: string; region: string; score: number; bm25: number; snippet: string }
+export interface SearchResult { query: string; engine: string; total: number; hits: Hit[]; error?: string }
+export interface Facets { doctype: Record<string, number>; category: Record<string, number>; region: Record<string, number> }
+
+export async function search(q: string, limit = 10): Promise<SearchResult> {
+  const r = await fetch(`${BASE}/search?q=${encodeURIComponent(q)}&limit=${limit}`);
+  if (!r.ok) throw new Error(`search ${r.status}`);
+  return r.json();
+}
+export async function facets(): Promise<Facets> {
+  const r = await fetch(`${BASE}/facets`);
+  if (!r.ok) throw new Error(`facets ${r.status}`);
+  return r.json();
+}

--- a/socioprophet-web/client-vue/src/services/studioApi.ts
+++ b/socioprophet-web/client-vue/src/services/studioApi.ts
@@ -1,0 +1,947 @@
+// studioApi — client for the Lattice Studio product surface (notebooks + data catalog + model catalog + tuning +
+// reproducible experiments), the integrated Watson-Studio-class plane. Calls the studio BFF, which fronts the
+// deployed Tier-9 fabric (lattice-studio notebooks, prophet-core-catalog, model-zoo-api, tritfabric/Ray,
+// governance-ledger). VITE_STUDIO_API unset → STUB mode so the surface renders standalone until the BFF is wired.
+// Everything is PROJECT-SCOPED: a projectId (Noetica proj- collection) threads through so notebooks/data/models/
+// experiments live in the same knowledge scope an agent team already retrieves.
+
+const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_API;
+
+export type StudioSection =
+  | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
+  | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation" // Knowledge engineering
+  | "operations" | "compute"                                                    // Operations cockpit (WS#45–48/#31) + Universal Compute Plane
+  | "governance"                                                                // Governance: ontology · actions · GAIA
+  | "commons";                                                                  // Commons (WS#36–39)
+
+export interface Notebook {
+  id: string; name: string; runtime: string; kernel: string;
+  status: "idle" | "running" | "stopped"; updatedAt: string;
+  cells: number; collaborators: string[]; lastCell?: string;
+}
+export interface DataAsset {
+  id: string; name: string; kind: "table" | "dataset" | "stream"; catalog: string; governed: boolean;
+  rows?: number; columns?: number; schema?: { name: string; type: string }[]; lineage?: string[];
+}
+export interface ModelCard {
+  id: string; name: string; task: string; stage: "candidate" | "staged" | "promoted";
+  metrics?: { name: string; value: number; unit?: string }[]; base?: string; lineage?: string[]; servable?: boolean;
+}
+export interface TuningRun {
+  id: string; name: string; method: "lora" | "sae" | "circuit-probe" | "full"; backend: string;
+  status: "queued" | "running" | "done" | "failed"; progress?: number; metric?: { name: string; value: number };
+  target?: string;
+}
+export interface Experiment {
+  id: string; title: string; reproducible: boolean; provenance: string; createdAt: string;
+  steps?: { label: string; hash: string }[]; rerunnable?: boolean;
+}
+
+// ── Knowledge engineering — extraction → ontology → graph → retrieval → generation ──
+export interface ExtractionSource {
+  id: string; name: string; engine: "holmes" | "sherlock" | "doc-ingest"; kind: string;
+  status: "idle" | "running" | "done"; extracted?: number; target: string; // → graph
+}
+export interface OntologyItem {
+  id: string; name: string; kind: "class" | "relation" | "axiom" | "alignment"; engine: "ontogenesis";
+  count?: number; aligned?: boolean;
+}
+export interface GraphStat { id: string; label: string; value: number | string; hint?: string }
+export interface RetrievalIndex {
+  id: string; name: string; method: "fiber" | "graph-rag" | "topic" | "vector" | "lexical";
+  engine: "fibered-retrieval" | "slash-topics" | "hellgraph" | "noetica"; scope: string; ready: boolean;
+}
+export interface GenerationRun {
+  id: string; name: string; engine: "new-hope"; kind: "synthesis" | "generation-tuning" | "distillation";
+  status: "queued" | "running" | "done" | "failed"; grounded?: boolean; output?: string;
+}
+
+// The MOAT header — the proof-carrying identity of the whole workspace, computed live on every load.
+export interface Moat {
+  epistemic_distribution: Record<string, number>; fact_count: number; provenance_coverage: number;
+  verified_compute: boolean; receipts_recent: number; governed_writes: boolean; read_auth: boolean;
+}
+export interface StudioBundle {
+  notebooks: Notebook[]; data: DataAsset[]; models: ModelCard[]; tuning: TuningRun[]; experiments: Experiment[];
+  extraction: ExtractionSource[]; ontology: OntologyItem[]; graph: GraphStat[]; retrieval: RetrievalIndex[]; generation: GenerationRun[];
+  moat?: Moat; stub?: boolean;
+}
+
+// graph/query are custom-rendered sections with no list payload in the bundle → defensive index.
+export const SECTION_COUNT = (b: StudioBundle | null, s: StudioSection): number => (b ? ((b as unknown as Record<string, unknown[]>)[s]?.length ?? 0) : 0);
+
+const now = () => new Date().toISOString();
+const STUB: StudioBundle = {
+  moat: { epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, fact_count: 5,
+          provenance_coverage: 0.8, verified_compute: true, receipts_recent: 3, governed_writes: true, read_auth: false },
+  notebooks: [
+    { id: "nb-1", name: "Exploratory analysis", runtime: "prophet-python-ml", kernel: "python3", status: "idle", updatedAt: now(), cells: 24, collaborators: ["you", "analyst-agent"], lastCell: "df.groupby('cohort').agg(...)" },
+    { id: "nb-2", name: "LoRA fine-tune", runtime: "prophet-ray-ml", kernel: "ray", status: "running", updatedAt: now(), cells: 11, collaborators: ["you"], lastCell: "trainer.fit(ray_dataset)" },
+    { id: "nb-3", name: "SAE feature atlas", runtime: "prophet-ray-ml", kernel: "ray", status: "idle", updatedAt: now(), cells: 38, collaborators: ["you", "researcher-agent"], lastCell: "atlas.plot_features(layer=12)" },
+  ],
+  data: [
+    { id: "da-1", name: "customer_events", kind: "table", catalog: "prophet-core-catalog", governed: true, rows: 1_240_000, columns: 18, schema: [{ name: "event_id", type: "uuid" }, { name: "ts", type: "timestamp" }, { name: "cohort", type: "string" }], lineage: ["ingest→dbt→catalog"] },
+    { id: "da-2", name: "corpus_v3", kind: "dataset", catalog: "prophet-core-catalog", governed: true, rows: 890_000, lineage: ["scrape→dedupe→redact→catalog"] },
+    { id: "da-3", name: "telemetry_stream", kind: "stream", catalog: "prophet-core-catalog", governed: false },
+  ],
+  models: [
+    { id: "m-1", name: "prophet-7b-lora", task: "chat", stage: "staged", base: "prophet-7b", servable: true, metrics: [{ name: "MMLU", value: 64.2 }, { name: "win-rate", value: 0.58 }], lineage: ["prophet-7b→lora(nb-2)→zoo"] },
+    { id: "m-2", name: "sae-residual-l12", task: "interpretability", stage: "candidate", base: "prophet-7b", metrics: [{ name: "L0", value: 41 }, { name: "recon", value: 0.92 }], lineage: ["prophet-7b→sae(t-1)"] },
+    { id: "m-3", name: "prophet-7b", task: "chat", stage: "promoted", servable: true, metrics: [{ name: "MMLU", value: 61.0 }] },
+  ],
+  tuning: [
+    { id: "t-1", name: "SAE on residual stream L12", method: "sae", backend: "tritfabric/ray", status: "running", progress: 0.62, metric: { name: "recon", value: 0.92 }, target: "prophet-7b" },
+    { id: "t-2", name: "Circuit probe — induction heads", method: "circuit-probe", backend: "tritfabric/ray", status: "queued", target: "prophet-7b" },
+    { id: "t-3", name: "LoRA — support tone", method: "lora", backend: "tritfabric/ray", status: "done", progress: 1, metric: { name: "loss", value: 0.31 }, target: "prophet-7b" },
+  ],
+  experiments: [
+    { id: "e-1", title: "LoRA vs full fine-tune", reproducible: true, provenance: "in-toto + conda-lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:9a1…" }, { label: "data", hash: "sha256:c4f…" }, { label: "code", hash: "sha256:2e8…" }] },
+    { id: "e-2", title: "SAE sparsity sweep", reproducible: true, provenance: "in-toto + flake.lock", createdAt: now(), rerunnable: true, steps: [{ label: "runtime", hash: "sha256:77b…" }, { label: "params", hash: "sha256:1d3…" }] },
+  ],
+  extraction: [
+    { id: "x-1", name: "Entity & relation extraction — corpus_v3", engine: "holmes", kind: "entities+relations", status: "running", extracted: 48210, target: "project graph" },
+    { id: "x-2", name: "Federated retrieval → facts", engine: "sherlock", kind: "federated search", status: "idle", target: "project graph" },
+    { id: "x-3", name: "Doc ingest — governed", engine: "doc-ingest", kind: "chunks+claims", status: "done", extracted: 12904, target: "proj- collection" },
+  ],
+  ontology: [
+    { id: "o-1", name: "Domain ontology", kind: "class", engine: "ontogenesis", count: 342, aligned: true },
+    { id: "o-2", name: "Relations", kind: "relation", engine: "ontogenesis", count: 118, aligned: true },
+    { id: "o-3", name: "KKO ⇄ project alignment", kind: "alignment", engine: "ontogenesis", aligned: true },
+  ],
+  graph: [
+    { id: "g-1", label: "Entities", value: 61240, hint: "canonical entities in the project graph" },
+    { id: "g-2", label: "Relations", value: 148900 },
+    { id: "g-3", label: "Documents grounded", value: 12904 },
+    { id: "g-4", label: "Engine", value: "HellGraph", hint: "gremlin / sparql over :8090" },
+  ],
+  retrieval: [
+    { id: "r-1", name: "Fibered retrieval (PageIndex ⊕ HellGraph)", method: "fiber", engine: "fibered-retrieval", scope: "project", ready: true },
+    { id: "r-2", name: "Graph-RAG", method: "graph-rag", engine: "hellgraph", scope: "project", ready: true },
+    { id: "r-3", name: "Topic index", method: "topic", engine: "slash-topics", scope: "project", ready: true },
+    { id: "r-4", name: "Semantic + lexical", method: "vector", engine: "noetica", scope: "chat + project", ready: true },
+  ],
+  generation: [
+    { id: "gn-1", name: "Synthesize training set from graph", engine: "new-hope", kind: "synthesis", status: "running", grounded: true, output: "→ annotation set" },
+    { id: "gn-2", name: "Generation-tuning — grounded rewrite", engine: "new-hope", kind: "generation-tuning", status: "queued", grounded: true },
+  ],
+  stub: true,
+};
+
+// ── KE-2: the project sub-graph with PROVENANCE per node (the differentiator) ──
+export interface GraphNode { id: string; name: string; epistemic_mode: string; source?: string; extractor?: string; labels: string[] }
+export interface GraphEdge { id: string; source: string; target: string; label: string; weight?: number }
+export interface GraphView {
+  project: string; projectCollection: string;
+  nodes: GraphNode[]; edges?: GraphEdge[]; count: number; edge_count?: number;
+  epistemic_distribution: Record<string, number>;
+  degraded?: string | null; stub?: boolean;
+}
+
+// Epistemic-mode → colour (the ladder hypothesis→…→attested). This colouring IS the feature: Bloom shows topology,
+// we show epistemic status per node.
+// Resolve from the token ramp so the graph, membrane, and chips share one ink.
+// (Falls back to literals when read outside the DOM, e.g. SSR/tests.)
+function epiVar(name: string, fallback: string): string {
+  if (typeof getComputedStyle === "function" && typeof document !== "undefined") {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    if (v) return v;
+  }
+  return fallback;
+}
+export const EPISTEMIC_COLORS: Record<string, string> = {
+  get hypothesis() { return epiVar("--epi-hypothesis", "#94a1b2"); },
+  get observed()   { return epiVar("--epi-observed",   "#4a90e2"); },
+  get derived()    { return epiVar("--epi-derived",    "#8b5cf6"); },
+  get verified()   { return epiVar("--epi-verified",   "#14b8a6"); },
+  get attested()   { return epiVar("--epi-attested",   "#059669"); },
+  get simulated()  { return epiVar("--epi-simulated",  "#d98324"); },
+  get unknown()    { return epiVar("--epi-unknown",    "#b6bec9"); },
+};
+
+const STUB_GRAPH: GraphView = {
+  project: "demo", projectCollection: "proj-demo",
+  nodes: [
+    { id: "proj-demo:ent:hellgraph", name: "HellGraph", epistemic_mode: "verified", source: "doc:spec", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:neo4j", name: "Neo4j", epistemic_mode: "observed", source: "doc:demo", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:anzo", name: "Anzo", epistemic_mode: "observed", source: "doc:demo", extractor: "lattice-studio/deterministic-v0", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:sae", name: "SAE feature", epistemic_mode: "derived", source: "notebook:nb-3", extractor: "superconscious", labels: ["proj-demo", "Entity"] },
+    { id: "proj-demo:ent:claim", name: "Contradiction claim", epistemic_mode: "hypothesis", source: "holmes", extractor: "holmes", labels: ["proj-demo", "Entity"] },
+  ],
+  edges: [
+    { id: "e1", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:neo4j", label: "COMPARED_WITH", weight: 3 },
+    { id: "e2", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:anzo", label: "COMPARED_WITH", weight: 2 },
+    { id: "e3", source: "proj-demo:ent:neo4j", target: "proj-demo:ent:anzo", label: "CO_OCCURS", weight: 1 },
+    { id: "e4", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:sae", label: "GROUNDS", weight: 2 },
+    { id: "e5", source: "proj-demo:ent:sae", target: "proj-demo:ent:claim", label: "SUPPORTS", weight: 1 },
+    { id: "e6", source: "proj-demo:ent:hellgraph", target: "proj-demo:ent:claim", label: "GROUNDS", weight: 1 },
+  ],
+  count: 5, edge_count: 6, epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, stub: true,
+};
+
+export async function loadGraph(project: string): Promise<GraphView> {
+  if (!BASE) return STUB_GRAPH;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/graph?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`graph load failed: ${res.status}`);
+  return (await res.json()) as GraphView;
+}
+
+// ── WRITE workbench: hand-author facts into the project graph (KE-1). Fail-closed behind the Studio write
+// token (Bearer) — the same gate /extract uses, so a manual fact is as governed + proof-carrying as an
+// extracted one. The token is held in-session only (never persisted). ──
+export const EPISTEMIC_ORDER = ["attested", "verified", "observed", "derived", "hypothesis", "simulated"] as const;
+
+export interface AddNodeInput { project: string; name: string; epistemic_mode?: string; labels?: string[]; source?: string }
+export interface AddEdgeInput { project: string; from_name: string; to_name: string; label?: string; epistemic_mode?: string; source?: string }
+
+function writeHeaders(token: string): HeadersInit {
+  return { "content-type": "application/json", accept: "application/json", authorization: `Bearer ${token}` };
+}
+
+function writeError(prefix: string, status: number): Error {
+  const hint = status === 401 ? " — bad write token" : status === 503 ? " — writes disabled (STUDIO_WRITE_TOKEN unset)" : status === 502 ? " — graph write failed" : "";
+  return new Error(`${prefix}: ${status}${hint}`);
+}
+
+export async function addNode(input: AddNodeInput, token: string): Promise<{ id: string; written: boolean }> {
+  if (!BASE) throw new Error("Studio backend not connected (set VITE_STUDIO_API)");
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/node`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("add node failed", res.status);
+  return (await res.json()) as { id: string; written: boolean };
+}
+
+export async function addEdge(input: AddEdgeInput, token: string): Promise<{ from: string; to: string; written: boolean }> {
+  if (!BASE) throw new Error("Studio backend not connected (set VITE_STUDIO_API)");
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/edge`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("add edge failed", res.status);
+  return (await res.json()) as { from: string; to: string; written: boolean };
+}
+
+// ── KE-5 "How derived?": the proof-carrying lineage of one fact — provenance + the facts it was
+// derived/co-observed with, each carrying its own epistemic status. What Bloom/Stardog can't show. ──
+export interface Derivation { relation: string; direction: "in" | "out"; weight: number; with: { id: string; name: string; epistemic_mode: string; source?: string | null } }
+export interface Provenance {
+  id: string; found: boolean; name?: string; epistemic_mode?: string; source?: string | null;
+  extractor?: string | null; kko_type?: string; labels?: string[];
+  derivations: Derivation[]; derivation_count: number; summary?: string; degraded?: string | null;
+}
+
+const STUB_PROVENANCE = (id: string, nodes: GraphNode[], edges: GraphEdge[]): Provenance => {
+  const node = nodes.find((n) => n.id === id);
+  if (!node) return { id, found: false, derivations: [], derivation_count: 0 };
+  const byId = Object.fromEntries(nodes.map((n) => [n.id, n]));
+  const derivations: Derivation[] = edges.filter((e) => e.source === id || e.target === id).map((e) => {
+    const out = e.source === id; const o = byId[out ? e.target : e.source];
+    return { relation: e.label, direction: out ? "out" : "in", weight: e.weight ?? 1,
+             with: { id: o?.id ?? "", name: o?.name ?? "", epistemic_mode: o?.epistemic_mode ?? "unknown", source: o?.source } };
+  });
+  return { id, found: true, name: node.name, epistemic_mode: node.epistemic_mode, source: node.source,
+           extractor: node.extractor, kko_type: "Particulars", labels: node.labels,
+           derivations, derivation_count: derivations.length,
+           summary: `‘${node.name}’ is held as ${node.epistemic_mode}, connected to ${derivations.length} related fact(s).` };
+};
+
+export async function getProvenance(project: string, id: string, stubGraph?: GraphView): Promise<Provenance> {
+  if (!BASE) return STUB_PROVENANCE(id, stubGraph?.nodes ?? STUB_GRAPH.nodes, stubGraph?.edges ?? STUB_GRAPH.edges ?? []);
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/provenance?project=${encodeURIComponent(project)}&id=${encodeURIComponent(id)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`provenance failed: ${res.status}`);
+  return (await res.json()) as Provenance;
+}
+
+// ── WS#29: verified-compute RECEIPTS from the evidence fabric — the replayable proof-of-work behind Studio. ──
+export interface Receipt { service: string; correlation_id: string; received_at?: string | null; verdict?: string | null; kind?: string | null; bundle_ref?: string | null }
+export interface Receipts { receipts: Receipt[]; count: number; services: Record<string, boolean>; services_reachable: number; detail_endpoint: string }
+
+const STUB_RECEIPTS: Receipts = {
+  receipts: [
+    { service: "hellgraph-service", correlation_id: "hg-9f2a", received_at: "just now", verdict: "ok", kind: "graph-write", bundle_ref: "/v1/receipts/hellgraph-service/hg-9f2a" },
+    { service: "owl-reasoner", correlation_id: "owl-71c", received_at: "2m ago", verdict: "sound", kind: "reason", bundle_ref: "/v1/receipts/owl-reasoner/owl-71c" },
+    { service: "entity-resolution", correlation_id: "er-33b", received_at: "6m ago", verdict: "merged", kind: "resolve", bundle_ref: "/v1/receipts/entity-resolution/er-33b" },
+  ],
+  count: 3, services: { "hellgraph-service": true, "owl-reasoner": true, "entity-resolution": true }, services_reachable: 3,
+  detail_endpoint: "/v1/receipts/{service}/{correlation_id}",
+};
+
+export async function loadReceipts(limit = 12): Promise<Receipts> {
+  if (!BASE) return STUB_RECEIPTS;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/receipts?limit=${limit}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`receipts failed: ${res.status}`);
+  return (await res.json()) as Receipts;
+}
+
+// ── WS#30: the proof-carrying query IDE (SPARQL/Cypher/Gremlin). Results carry replay proof + per-fact epistemic. ──
+export type QueryLang = "sparql" | "cypher" | "gremlin";
+export interface QueryProof { query_hash?: string | null; evaluated_at_seq?: number | null; replayable: boolean }
+export interface QueryResult {
+  project: string; lang: QueryLang; columns: string[]; rows: Record<string, unknown>[]; row_count: number;
+  epistemic: Record<string, string>; proof: QueryProof; raw?: unknown;
+}
+
+const STUB_QUERY = (lang: QueryLang): QueryResult => ({
+  project: "demo", lang,
+  columns: ["entity", "epistemic"],
+  rows: [
+    { entity: "proj-demo:ent:hellgraph", epistemic: "verified" },
+    { entity: "proj-demo:ent:neo4j", epistemic: "observed" },
+    { entity: "proj-demo:ent:anzo", epistemic: "observed" },
+  ],
+  row_count: 3,
+  epistemic: { "proj-demo:ent:hellgraph": "verified", "proj-demo:ent:neo4j": "observed", "proj-demo:ent:anzo": "observed" },
+  proof: { query_hash: "qh-demo-8f2a", evaluated_at_seq: 128, replayable: true },
+});
+
+export async function runQuery(project: string, lang: QueryLang, query: string, params?: Record<string, string>): Promise<QueryResult> {
+  if (!BASE) return STUB_QUERY(lang);
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/query`, {
+    method: "POST", headers: { "content-type": "application/json", accept: "application/json" },
+    body: JSON.stringify({ project, lang, query, params }),
+  });
+  if (!res.ok) {
+    let detail = `${res.status}`;
+    try { const j = await res.json(); detail = (j as { detail?: string }).detail ?? detail; } catch { /* */ }
+    throw new Error(`query failed: ${detail}`);
+  }
+  return (await res.json()) as QueryResult;
+}
+
+// ── WS#32: experiment tracking — runs are first-class proof-carrying graph facts (params/metrics + epistemic). ──
+export interface ExperimentRun {
+  run_id: string; name: string; status: string; params: Record<string, unknown>; metrics: Record<string, number>;
+  created_at?: string | null; epistemic_mode?: string; extractor?: string | null; source?: string | null;
+}
+export interface Experiments { project: string; runs: ExperimentRun[]; count: number; degraded?: string | null }
+
+const STUB_EXPERIMENTS: Experiments = {
+  project: "demo", count: 2,
+  runs: [
+    { run_id: "proj-demo:run:8f2a", name: "sweep-lr", status: "finished", params: { lr: 0.01, batch: 64 }, metrics: { acc: 0.912, loss: 0.28 }, created_at: "2m ago", epistemic_mode: "observed", extractor: "studio/experiment-v0" },
+    { run_id: "proj-demo:run:71c9", name: "baseline", status: "finished", params: { lr: 0.001 }, metrics: { acc: 0.874 }, created_at: "1h ago", epistemic_mode: "observed", extractor: "studio/experiment-v0" },
+  ],
+};
+
+export async function loadExperiments(project: string): Promise<Experiments> {
+  if (!BASE) return STUB_EXPERIMENTS;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/experiments?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`experiments failed: ${res.status}`);
+  return (await res.json()) as Experiments;
+}
+
+export async function logExperiment(
+  input: { project: string; name: string; params?: Record<string, unknown>; metrics?: Record<string, number>; status?: string },
+  token: string,
+): Promise<ExperimentRun> {
+  if (!BASE) throw new Error("Studio backend not connected (set VITE_STUDIO_API)");
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/experiments`, {
+    method: "POST", headers: writeHeaders(token), body: JSON.stringify(input),
+  });
+  if (!res.ok) throw writeError("log experiment failed", res.status);
+  return (await res.json()) as ExperimentRun;
+}
+
+// ── WS#35: sovereign persistent IDs + citation — DataCite-compatible, resolves to a proof-carrying record. ──
+export interface Citation {
+  pid: string; doi: string; resolve: string; content_hash: string; created_at?: string;
+  citation: string; bibtex: string; datacite: unknown; proof_carrying: boolean;
+}
+
+const STUB_CITATION = (kind: string, ref: string): Citation => {
+  const h = "8f2ad4c1b9e0";
+  const pid = `sp:proj-demo/${kind}/${h.slice(0, 12)}`;
+  const doi = `10.82044/proj-demo.${kind}.${h.slice(0, 8)}`;
+  return {
+    pid, doi, resolve: `https://studio.socioprophet.ai/resolve?pid=${pid}`, content_hash: h, created_at: "just now",
+    citation: `SocioProphet Knowledge Commons (2026). ${kind} · ${ref || "proj-demo"}. SocioProphet Knowledge Commons. ${pid} (DOI: ${doi}).`,
+    bibtex: `@misc{${h.slice(0, 8)},\n  author = {SocioProphet Knowledge Commons},\n  title = {${kind} · ${ref || "proj-demo"}},\n  year = {2026},\n  note = {${pid}},\n  doi = {${doi}}\n}`,
+    datacite: { id: doi, type: "dois" }, proof_carrying: true,
+  };
+};
+
+export async function mintCitation(
+  input: { project: string; kind: string; ref?: string; title?: string; creators?: string[] },
+  token: string,
+): Promise<Citation> {
+  if (!BASE) return STUB_CITATION(input.kind, input.ref ?? "");
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/cite`, {
+    method: "POST", headers: writeHeaders(token), body: JSON.stringify(input),
+  });
+  if (!res.ok) throw writeError("cite failed", res.status);
+  return (await res.json()) as Citation;
+}
+
+// ── WS#36–39: the proof-carrying knowledge COMMONS — preservation, FAIR, scholarly/agent hooks, curation. ──
+export interface SnapshotVersion { snapshot_id: string; version: number; content_hash: string; sealed_at?: string | null; parent?: string | null; note?: string | null; epistemic_mode?: string }
+export interface Versions { project: string; target: string; versions: SnapshotVersion[]; count: number; degraded?: string | null }
+
+export interface Fair {
+  project: string; target: string; title: string; pid?: string | null; doi?: string | null;
+  version?: number | null; content_hash?: string | null;
+  fair: { findable: boolean; accessible: boolean; interoperable: boolean; reusable: boolean; score: number };
+  fair_plus: { epistemic: boolean; provenance_chain: boolean; hash_sealed: boolean };
+  hint?: string | null;
+}
+
+export interface OrcidContributor { name: string; orcid: string; orcid_url: string }
+export interface AgentVerb { name: string; endpoint: string | null; verifiable: boolean }
+export interface Ecosystem {
+  project: string; target: string;
+  scholarly: { doi?: string | null; doi_url?: string | null; orcid_contributors: OrcidContributor[]; openaire: { harvestable: boolean; datacite_doi?: string | null; metadata: string } };
+  agent_manifest: { "@type": string; identifier?: string | null; proof_carrying: boolean; epistemic_status: boolean; sovereign: boolean; access: AgentVerb[]; consume_note: string };
+}
+
+export interface Commons {
+  project: string; collection: string;
+  scale: { facts: number; citations: number; preserved_versions: number; endorsements: number; contributors: number };
+  epistemic_distribution: Record<string, number>; epistemic_quality_index?: number | null; degraded?: string | null;
+}
+
+export interface Endorsement { target: string; endorser: string; note?: string | null; at?: string | null }
+export interface Curation { project: string; target?: string | null; endorsements: Endorsement[]; count: number; curation_score: number; epistemic_weighted: boolean; degraded?: string | null }
+
+const STUB_COMMONS: Commons = {
+  project: "demo", collection: "proj-demo",
+  scale: { facts: 128, citations: 3, preserved_versions: 4, endorsements: 7, contributors: 2 },
+  epistemic_distribution: { attested: 18, verified: 41, observed: 63, hypothesis: 6 }, epistemic_quality_index: 0.71,
+};
+const STUB_FAIR: Fair = {
+  project: "demo", target: "proj-demo", title: "demo — knowledge graph", pid: "sp:proj-demo/graph/8f2ad4c1b9e0",
+  doi: "10.82044/proj-demo.graph.8f2ad4c1", version: 4, content_hash: "8f2ad4c1b9e0",
+  fair: { findable: true, accessible: true, interoperable: true, reusable: true, score: 1.0 },
+  fair_plus: { epistemic: true, provenance_chain: true, hash_sealed: true }, hint: null,
+};
+const STUB_ECOSYSTEM: Ecosystem = {
+  project: "demo", target: "proj-demo",
+  scholarly: { doi: "10.82044/proj-demo.graph.8f2ad4c1", doi_url: "https://doi.org/10.82044/proj-demo.graph.8f2ad4c1",
+    orcid_contributors: [{ name: "M. Heller", orcid: "0000-0002-1825-0097", orcid_url: "https://orcid.org/0000-0002-1825-0097" }],
+    openaire: { harvestable: true, datacite_doi: "10.82044/proj-demo.graph.8f2ad4c1", metadata: "/api/studio/fair?project=demo" } },
+  agent_manifest: { "@type": "AgentCapabilityManifest", identifier: "sp:proj-demo/graph/8f2ad4c1b9e0", proof_carrying: true, epistemic_status: true, sovereign: true,
+    access: [
+      { name: "resolve", endpoint: "/api/studio/resolve?pid=sp:proj-demo/graph/8f2ad4c1b9e0", verifiable: true },
+      { name: "query", endpoint: "/api/studio/query", verifiable: true },
+      { name: "provenance", endpoint: "/api/studio/provenance", verifiable: true },
+      { name: "receipts", endpoint: "/api/studio/receipts", verifiable: true },
+      { name: "rdf", endpoint: "/api/studio/graph.ttl?project=demo", verifiable: true },
+      { name: "fair", endpoint: "/api/studio/fair?project=demo", verifiable: true },
+    ], consume_note: "every result carries a queryHash + epistemic status; verify via the receipts/provenance verbs" },
+};
+const STUB_VERSIONS: Versions = {
+  project: "demo", target: "proj-demo", count: 2,
+  versions: [
+    { snapshot_id: "proj-demo:snap:8f2ad4c1b9e0", version: 2, content_hash: "8f2ad4c1b9e0", sealed_at: "2m ago", parent: "proj-demo:snap:71c9", note: "post-review", epistemic_mode: "attested" },
+    { snapshot_id: "proj-demo:snap:71c9", version: 1, content_hash: "71c9aa02", sealed_at: "1h ago", parent: null, note: "initial", epistemic_mode: "attested" },
+  ],
+};
+const STUB_CURATION: Curation = {
+  project: "demo", target: null, epistemic_weighted: true, count: 2, curation_score: 1.6,
+  endorsements: [
+    { target: "proj-demo:ent:hellgraph", endorser: "0000-0002-1825-0097", note: "verified independently", at: "5m ago" },
+    { target: "proj-demo:ent:provenance", endorser: "curator:noetica", note: null, at: "1h ago" },
+  ],
+};
+
+async function _read<T>(path: string, stub: T): Promise<T> {
+  if (!BASE) return stub;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}${path}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export const loadCommons = (project: string) => _read(`/api/studio/commons?project=${encodeURIComponent(project)}`, STUB_COMMONS);
+export const loadFair = (project: string) => _read(`/api/studio/fair?project=${encodeURIComponent(project)}`, STUB_FAIR);
+export const loadEcosystem = (project: string) => _read(`/api/studio/ecosystem?project=${encodeURIComponent(project)}`, STUB_ECOSYSTEM);
+export const loadVersions = (project: string) => _read(`/api/studio/versions?project=${encodeURIComponent(project)}`, STUB_VERSIONS);
+export const loadCuration = (project: string, target?: string) =>
+  _read(`/api/studio/curation?project=${encodeURIComponent(project)}${target ? `&target=${encodeURIComponent(target)}` : ""}`, STUB_CURATION);
+
+export async function endorse(
+  input: { project: string; target: string; endorser: string; note?: string; revoke?: boolean },
+  token: string,
+): Promise<{ endorsement_id: string; target: string; endorser: string; revoked: boolean; proof_carrying: boolean }> {
+  if (!BASE) return { endorsement_id: `stub:endorse:${input.target}`, target: input.target, endorser: input.endorser, revoked: !!input.revoke, proof_carrying: true };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/endorse`, {
+    method: "POST", headers: writeHeaders(token), body: JSON.stringify(input),
+  });
+  if (!res.ok) throw writeError("endorse failed", res.status);
+  return await res.json();
+}
+
+// ── Operations panel (Databricks/Foundry-parity): pipelines · model registry · catalog · compute · communities ──
+export interface PipelineStepDef { id: string; kind: string; inputs?: string[]; outputs?: string[] }
+export interface Pipeline { pipeline_id: string; name: string; steps: PipelineStepDef[]; step_count: number }
+export interface ModelVersion { model_id: string; version: string; stage: string; metrics: Record<string, number>; run?: string | null }
+export interface ModelEntry { name: string; versions: ModelVersion[] }
+export interface Dataset { id: string; name: string; labels: string[]; connector?: string | null; epistemic_mode: string; columns: string[] }
+export interface ComputeBackend { id: string; kind: string; note: string; entitled: boolean; default?: boolean }
+export interface Compute { backends: ComputeBackend[]; entitled_any: boolean; model: string }
+export interface Community { community: string; size: number; top_members: { id: string; label: string; degree: number }[]; epistemic_distribution: Record<string, number> }
+export interface ExecReceipt { correlation_id: string; backend: string; replayable: boolean; bundle_ref: string; payload_sha256: string }
+export type ExecResult =
+  | { ok: true; execution_id: string; backend: string; status: string; receipt: ExecReceipt }
+  | { ok: false; entitlement_required: true; backend: string; message: string };
+
+const STUB_PIPELINES: { pipelines: Pipeline[]; count: number } = {
+  count: 1,
+  pipelines: [{ pipeline_id: "proj-demo:pipeline:etl_train", name: "ETL → train", step_count: 3,
+    steps: [{ id: "load", kind: "extract", outputs: ["raw"] }, { id: "clean", kind: "transform", inputs: ["raw"], outputs: ["tidy"] }, { id: "fit", kind: "train", inputs: ["tidy"] }] }],
+};
+const STUB_MODELS: { models: ModelEntry[]; count: number } = {
+  count: 2,
+  models: [{ name: "classifier", versions: [
+    { model_id: "proj-demo:model:classifier:2", version: "2", stage: "production", metrics: { acc: 0.93 }, run: "proj-demo:run:abc" },
+    { model_id: "proj-demo:model:classifier:1", version: "1", stage: "archived", metrics: { acc: 0.88 }, run: "proj-demo:run:aa0" }] }],
+};
+const STUB_CATALOG: { datasets: Dataset[]; count: number } = {
+  count: 2,
+  datasets: [
+    { id: "proj-demo:ingest:people", name: "people", labels: ["Person", "Ingested"], connector: "csv", epistemic_mode: "observed", columns: ["id", "name", "age"] },
+    { id: "proj-demo:ingest:orders", name: "orders", labels: ["Order", "Ingested"], connector: "postgres", epistemic_mode: "observed", columns: ["order_id", "total"] }],
+};
+const STUB_COMPUTE: Compute = {
+  entitled_any: false,
+  model: "pay-gated full service — capability available, runtime provisioned only when entitled",
+  backends: [
+    { id: "mesh-k8s", kind: "sovereign", default: true, note: "self-hosted sandbox on the paid mesh (kind / k3s / k8s / DinD)", entitled: false },
+    { id: "spark", kind: "sovereign", note: "a small Spark namespace on the mesh", entitled: false },
+    { id: "databricks", kind: "external", note: "connect to your own Databricks workspace", entitled: false }],
+};
+const STUB_COMMUNITIES: { communities: Community[]; count: number; inter_community_edges: number; algorithm: string } = {
+  count: 2, inter_community_edges: 3, algorithm: "louvain-modularity (deterministic, single-level)",
+  communities: [
+    { community: "proj-demo:community:a1b2", size: 7, epistemic_distribution: { verified: 3, observed: 4 }, top_members: [{ id: "proj-demo:ent:hellgraph", label: "HellGraph", degree: 6 }, { id: "proj-demo:ent:provenance", label: "provenance", degree: 4 }] },
+    { community: "proj-demo:community:c3d4", size: 4, epistemic_distribution: { observed: 4 }, top_members: [{ id: "proj-demo:ent:foundry", label: "Foundry", degree: 3 }] }],
+};
+
+export const loadPipelines = (project: string) => _read(`/api/studio/pipelines?project=${encodeURIComponent(project)}`, STUB_PIPELINES);
+export const loadModels = (project: string) => _read(`/api/studio/models?project=${encodeURIComponent(project)}`, STUB_MODELS);
+export const loadCatalog = (project: string) => _read(`/api/studio/catalog?project=${encodeURIComponent(project)}`, STUB_CATALOG);
+export const loadCompute = (project: string) => _read(`/api/studio/compute?project=${encodeURIComponent(project)}`, STUB_COMPUTE);
+export const loadCommunities = (project: string) => _read(`/api/studio/communities?project=${encodeURIComponent(project)}`, STUB_COMMUNITIES);
+
+export async function runPipeline(input: { project: string; pipeline: string; status?: string }, token: string): Promise<{ run_id: string; status: string }> {
+  if (!BASE) return { run_id: `stub:run:${input.pipeline}`, status: input.status ?? "finished" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/pipeline/run`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("pipeline run failed", res.status);
+  return await res.json();
+}
+
+export async function promoteModel(input: { project: string; name: string; version: string; stage: string }, token: string): Promise<{ model_id: string; stage: string; from_stage: string }> {
+  if (!BASE) return { model_id: `stub:model:${input.name}:${input.version}`, stage: input.stage, from_stage: "staging" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/model/promote`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("promote failed", res.status);
+  return await res.json();
+}
+
+export async function execute(
+  input: { project: string; kind: string; backend: string; ref?: string; code?: string },
+  token: string,
+): Promise<ExecResult> {
+  if (!BASE) return { ok: false, entitlement_required: true, backend: input.backend, message: "compute is a paid, provisioned service — provision an entitlement to run (dev stub)" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/execute`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (res.status === 402) {
+    const d = (await res.json().catch(() => ({}))) as { detail?: { message?: string } };
+    return { ok: false, entitlement_required: true, backend: input.backend, message: d.detail?.message ?? "compute entitlement required" };
+  }
+  if (!res.ok) throw writeError("execute failed", res.status);
+  return { ok: true, ...(await res.json()) };
+}
+
+// ── Notebook runtime (lattice-forge, via the BFF) — governed, adapter-based, receipt-per-cell ──
+export interface NbAdapter { role: string; capabilities: string[]; kernels: string[]; mode: string }
+export interface NbSession {
+  id: string; project: string; adapter: string; role: string; mode: string;
+  kernel: string; name: string; status: string; url?: string | null;
+}
+export interface NbOutput { type: string; name?: string; text?: string; ename?: string; evalue?: string; mime?: string[]; png?: string; svg?: string; html?: string }
+export interface NbReceipt {
+  id: string; project: string; adapter: string; language: string; runtime: string;
+  code_sha: string; outputs_sha: string; status: string; actor: string; prev?: string | null; ts: number;
+}
+export interface NbExecResult {
+  status: string; outputs: NbOutput[]; error?: string | null; degraded?: string | null;
+  receipt?: NbReceipt | null; adapter?: string; runtime?: string;
+}
+
+const NB_ADAPTERS_STUB: { default: string; adapters: Record<string, NbAdapter> } = {
+  default: "jupyterlab",
+  adapters: {
+    jupyterlab: { role: "scientific-notebook", capabilities: ["python", "r", "julia", "terminal"], kernels: ["python3", "ir", "julia"], mode: "session" },
+    zeppelin:   { role: "collaborative-analytics", capabilities: ["spark", "sql", "scala", "python"], kernels: ["spark", "python3"], mode: "session" },
+    observable: { role: "reactive-visualization", capabilities: ["javascript", "sql", "markdown"], kernels: ["javascript"], mode: "reactive" },
+    quarto:     { role: "publishing", capabilities: ["python", "r", "markdown", "slides"], kernels: ["python3"], mode: "headless" },
+  },
+};
+
+function nbBase(): string | null { return BASE ? BASE.replace(/\/$/, "") : null; }
+
+export async function loadNotebookAdapters(): Promise<{ default: string; adapters: Record<string, NbAdapter> }> {
+  const b = nbBase(); if (!b) return NB_ADAPTERS_STUB;
+  const r = await fetch(`${b}/api/studio/notebook/adapters`).catch(() => null);
+  if (!r || !r.ok) return NB_ADAPTERS_STUB;
+  const d = await r.json(); return d.adapters ? d : NB_ADAPTERS_STUB;
+}
+
+export async function createNotebookSession(input: { project: string; adapter?: string; name?: string }): Promise<NbSession> {
+  const b = nbBase();
+  if (!b) return { id: "stub-" + Math.random().toString(16).slice(2, 8), project: input.project, adapter: input.adapter || "jupyterlab",
+                   role: "scientific-notebook", mode: "session", kernel: "python3", name: input.name || "Notebook session", status: "stub", url: null };
+  const r = await fetch(`${b}/api/studio/notebook/session`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) });
+  if (!r.ok) throw new Error(`session failed (HTTP ${r.status})`);
+  return r.json();
+}
+
+export async function loadNotebookSessions(project: string): Promise<{ project: string; sessions: NbSession[]; degraded?: string }> {
+  const b = nbBase(); if (!b) return { project, sessions: [] };
+  const r = await fetch(`${b}/api/studio/notebook/sessions?project=${encodeURIComponent(project)}`).catch(() => null);
+  if (!r || !r.ok) return { project, sessions: [], degraded: "runtime unreachable" };
+  return r.json();
+}
+
+export async function executeCell(input: { project: string; code: string; language?: string; adapter?: string; session_id?: string }): Promise<NbExecResult> {
+  const b = nbBase();
+  // honest stub: no BASE → we do NOT fake compute; the surface shows "runtime not wired".
+  if (!b) return { status: "degraded", outputs: [], error: null, degraded: "notebook runtime not wired (dev preview)", receipt: null };
+  const r = await fetch(`${b}/api/studio/notebook/execute`, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(input) });
+  if (!r.ok) throw new Error(`execute failed (HTTP ${r.status})`);
+  return r.json();
+}
+
+export async function loadNotebookReceipts(project: string): Promise<{ project: string; count: number; receipts: NbReceipt[]; degraded?: string }> {
+  const b = nbBase(); if (!b) return { project, count: 0, receipts: [] };
+  const r = await fetch(`${b}/api/studio/notebook/receipts?project=${encodeURIComponent(project)}`).catch(() => null);
+  if (!r || !r.ok) return { project, count: 0, receipts: [], degraded: "runtime unreachable" };
+  return r.json();
+}
+
+// ── Attested AI assistant — the moat applied to AI (Genie-parity, but proof-carrying) ──
+// A model (or, offline, a deterministic heuristic) PROPOSES a cell. That proposal is epistemically a
+// HYPOTHESIS — unproven — until the user RUNS it, at which point its sealed receipt attests it. We never
+// pretend a heuristic is a model: source is labelled honestly so the surface can say "offline heuristic".
+export interface NbProposal { code: string; rationale: string; source: "model" | "heuristic"; epistemic: "hypothesis" }
+
+// Deterministic keyword scaffold — the honest offline fallback. Maps a natural-language prompt to a
+// starter cell + a short rationale explaining the mapping. Never dressed up as a model answer.
+function heuristicProposal(prompt: string): NbProposal {
+  const p = prompt.trim();
+  const low = p.toLowerCase();
+  const has = (...ws: string[]) => ws.some((w) => low.includes(w));
+  let code: string;
+  let rationale: string;
+  if (has("plot", "chart", "distribution", "bar", "histogram")) {
+    code = "import matplotlib.pyplot as plt\ndf['<column>'].value_counts().plot.barh()\nplt.show()";
+    rationale = "‘plot/chart’ → a matplotlib bar of a column’s value counts. Set <column> and run to attest it.";
+  } else if (has("load", "dataset", "data")) {
+    // pull a plausible dataset name out of the prompt (quoted, or the longest word-ish token)
+    const quoted = p.match(/['"`]([^'"`]+)['"`]/)?.[1];
+    const guess = quoted || (p.match(/[A-Za-z][A-Za-z0-9_]{3,}/g) || [])
+      .filter((w) => !["load", "dataset", "data", "the", "please", "into", "from"].includes(w.toLowerCase()))
+      .sort((a, b) => b.length - a.length)[0] || "my_dataset";
+    code = `df = load('${guess}')   # governed dataset\ndf.head()`;
+    rationale = `‘load/data’ → a governed load() scaffold; guessed dataset ‘${guess}’ from your prompt. Run to seal a receipt.`;
+  } else if (has("count", "value")) {
+    code = "df['<column>'].value_counts()";
+    rationale = "‘count/value’ → value_counts() on a column. Set <column> and run to attest it.";
+  } else if (has("shape", "rows", "columns", "size")) {
+    code = "df.shape";
+    rationale = "‘shape/rows’ → df.shape (rows, columns). Run to attest it.";
+  } else if (has("head", "preview", "peek", "first")) {
+    code = "df.head()";
+    rationale = "‘head/preview’ → df.head() to inspect the first rows. Run to attest it.";
+  } else if (has("describe", "summary", "summarize", "stats", "statistics")) {
+    code = "df.describe()";
+    rationale = "‘describe/summary’ → df.describe() for summary statistics. Run to attest it.";
+  } else {
+    const echo = p.replace(/\n/g, " ").slice(0, 120) || "your request";
+    code = `# ${echo}\n# offline scaffold — no runtime wired to author this. Edit, then run to seal a receipt.\n`;
+    rationale = "No keyword matched, so this is a commented scaffold echoing your request — nothing was inferred.";
+  }
+  return { code, rationale, source: "heuristic", epistemic: "hypothesis" };
+}
+
+export async function proposeCell(input: { project: string; prompt: string; context?: string }): Promise<NbProposal> {
+  const b = nbBase();
+  // Offline → deterministic heuristic, labelled honestly (never a fabricated "model" answer).
+  if (!b) return heuristicProposal(input.prompt);
+  try {
+    const r = await fetch(`${b}/api/studio/notebook/assist`, {
+      method: "POST", headers: { "Content-Type": "application/json", accept: "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!r.ok) return heuristicProposal(input.prompt);
+    const d = (await r.json()) as { code?: string; rationale?: string };
+    if (!d || typeof d.code !== "string") return heuristicProposal(input.prompt);
+    return { code: d.code, rationale: d.rationale || "Proposed by the Studio assistant model.", source: "model", epistemic: "hypothesis" };
+  } catch {
+    return heuristicProposal(input.prompt);
+  }
+}
+
+// ── Governance panel: the real ontology (Ontogenesis) · typed actions (Foundry-Workshop) · GAIA world-signals ──
+export interface OntologyClassLite { iri: string; label?: string; subClassOf: string[]; property_count: number }
+export interface OntologyProperty { iri: string; label?: string; kind: string; range?: string | null }
+export interface OntologyView { base_iri: string; counts: Record<string, unknown>; classes: OntologyClassLite[]; total_matched: number }
+export interface OntologyClassDetail { class: { iri: string; label?: string; subClassOf: string[]; inherited_properties: OntologyProperty[] }; base_iri: string }
+
+export interface ActionEffectDef { op: string; property?: string; label?: string; value?: unknown; value_from?: string }
+export interface ActionDef { action_id: string; name: string; target_type: string; description?: string | null; params: { name: string; type?: string }[]; effects: ActionEffectDef[] }
+
+export interface WorldSignal { signal_id: string; feature_id: string; signal_type: string; promotion_state: string; epistemic_mode?: string | null; canonical: boolean; evidence_count: number; confidence?: number | null; submitted_at?: string | null }
+export interface GaiaMembrane { state: string; epistemic_human: string; epistemic_model: string; canonical: boolean }
+export interface GaiaOntology { promotion_states: string[]; promotion_epistemic_membrane: GaiaMembrane[]; invariant: string; three_twins: Record<string, string> }
+
+const STUB_ONTOLOGY: OntologyView = {
+  base_iri: "https://socioprophet.dev/ont/ontogenesis#", counts: { classes: 817, object_properties: 621, datatype_properties: 590 }, total_matched: 12,
+  classes: [
+    { iri: "upper:Entity", label: "Entity", subClassOf: [], property_count: 3 },
+    { iri: "upper:Agent", label: "Agent", subClassOf: ["upper:Entity"], property_count: 4 },
+    { iri: "upper:Evidence", label: "Evidence", subClassOf: ["upper:InformationArtifact"], property_count: 2 },
+    { iri: "upper:Policy", label: "Policy", subClassOf: ["upper:InformationArtifact"], property_count: 2 }],
+};
+const STUB_ACTIONS: { actions: ActionDef[]; count: number } = {
+  count: 1,
+  actions: [{ action_id: "proj-demo:action:rename_attr", name: "Rename attr", target_type: "ACSETAttr", description: "typed against the real ontology",
+    params: [{ name: "newname" }], effects: [{ op: "set_property", property: "acsetAttrName", value_from: "newname" }] }],
+};
+const STUB_WORLDSIGNALS: { world_signals: WorldSignal[]; count: number } = {
+  count: 2,
+  world_signals: [
+    { signal_id: "proj-demo:worldsignal:ft-42", feature_id: "foot-traffic-poi-42", signal_type: "feature_registry", promotion_state: "Promoted", epistemic_mode: "attested", canonical: true, evidence_count: 3, confidence: 0.91, submitted_at: "2h ago" },
+    { signal_id: "proj-demo:worldsignal:wx", feature_id: "weather-nowcast", signal_type: "weather", promotion_state: "EvidenceOnly", epistemic_mode: "derived", canonical: false, evidence_count: 0, confidence: 0.4, submitted_at: "5m ago" }],
+};
+const STUB_GAIA: GaiaOntology = {
+  promotion_states: ["EvidenceOnly", "ReviewRequired", "Rejected", "Promoted"],
+  invariant: "GAIA-2: a model may propose but only a human/policy actor may Promote to canonical (attested)",
+  three_twins: { knowledge: "HellGraph fact · observed→attested", human: "HDT Observation → OmegaState", earth: "GAIA WorldSignal → PromotionState" },
+  promotion_epistemic_membrane: [
+    { state: "EvidenceOnly", epistemic_human: "observed", epistemic_model: "derived", canonical: false },
+    { state: "ReviewRequired", epistemic_human: "observed", epistemic_model: "derived", canonical: false },
+    { state: "Rejected", epistemic_human: "simulated", epistemic_model: "simulated", canonical: false },
+    { state: "Promoted", epistemic_human: "attested", epistemic_model: "attested", canonical: true }],
+};
+
+export const loadOntology = (search: string) => _read<OntologyView>(`/api/studio/ontology${search ? `?search=${encodeURIComponent(search)}` : ""}`, STUB_ONTOLOGY);
+export const loadOntologyClass = (cls: string) => _read<OntologyClassDetail>(`/api/studio/ontology?cls=${encodeURIComponent(cls)}`, { class: { iri: cls, subClassOf: [], inherited_properties: [] }, base_iri: "" });
+export const loadActions = (project: string) => _read(`/api/studio/actions?project=${encodeURIComponent(project)}`, STUB_ACTIONS);
+export const loadWorldsignals = (project: string) => _read(`/api/studio/worldsignals?project=${encodeURIComponent(project)}`, STUB_WORLDSIGNALS);
+export const loadGaiaOntology = () => _read(`/api/studio/gaia/ontology`, STUB_GAIA);
+
+// ── HDT — the human twin (closes the triangle) ──
+export interface HdtObservation { observation_id: string; subject: string; code: string; omega_state: string; epistemic_mode?: string | null; canonical: boolean; recorded_at?: string | null }
+export interface OmegaStep { state: string; epistemic_human: string; epistemic_model: string; canonical: boolean }
+export interface HdtOntology { omega_states: string[]; omega_epistemic_lattice: OmegaStep[]; kfs_triad: Record<string, string>; invariant: string; three_twins_closed: Record<string, string> }
+
+const STUB_HDT: { observations: HdtObservation[]; count: number } = {
+  count: 2,
+  observations: [
+    { observation_id: "proj-demo:hdtobs:hr", subject: "person:kim", code: "8867-4", omega_state: "DELIVERED", epistemic_mode: "attested", canonical: true, recorded_at: "1h ago" },
+    { observation_id: "proj-demo:hdtobs:bp", subject: "person:kim", code: "85354-9", omega_state: "SEEDED", epistemic_mode: "observed", canonical: false, recorded_at: "3m ago" }],
+};
+const STUB_HDT_ONT: HdtOntology = {
+  omega_states: ["ABSENT", "SEEDED", "NORMALIZED", "LINKED", "TRUSTED", "ACTIONABLE", "DELIVERED"],
+  kfs_triad: { CBD: "Cognition", CGT: "Values", NHY: "Action" },
+  invariant: "a model may advance an observation but only a human/clinician/policy actor may DELIVER to canonical human-actionable truth",
+  three_twins_closed: { knowledge: "HellGraph · observed→attested", human: "HDT · ABSENT→DELIVERED", earth: "GAIA · EvidenceOnly→Promoted" },
+  omega_epistemic_lattice: [
+    { state: "ABSENT", epistemic_human: "observed", epistemic_model: "hypothesis", canonical: false },
+    { state: "SEEDED", epistemic_human: "observed", epistemic_model: "hypothesis", canonical: false },
+    { state: "NORMALIZED", epistemic_human: "observed", epistemic_model: "derived", canonical: false },
+    { state: "LINKED", epistemic_human: "observed", epistemic_model: "derived", canonical: false },
+    { state: "TRUSTED", epistemic_human: "verified", epistemic_model: "verified", canonical: false },
+    { state: "ACTIONABLE", epistemic_human: "verified", epistemic_model: "verified", canonical: false },
+    { state: "DELIVERED", epistemic_human: "attested", epistemic_model: "attested", canonical: true }],
+};
+
+export const loadHdt = (project: string) => _read(`/api/studio/hdt?project=${encodeURIComponent(project)}`, STUB_HDT);
+export const loadHdtOntology = () => _read(`/api/studio/hdt/ontology`, STUB_HDT_ONT);
+
+export async function submitHdtObservation(input: { project: string; subject: string; code: string; value?: string; actor_kind?: string }, token: string): Promise<{ observation_id: string; omega_state: string; epistemic_mode: string }> {
+  if (!BASE) return { observation_id: `stub:${input.code}`, omega_state: "SEEDED", epistemic_mode: input.actor_kind === "model" ? "hypothesis" : "observed" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/hdt/observation`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("submit failed", res.status);
+  return await res.json();
+}
+
+export async function promoteHdt(input: { project: string; observation: string; to_state: string; actor_kind?: string }, token: string): Promise<{ to_state: string; epistemic_mode: string; canonical: boolean } | { blocked: true; message: string }> {
+  if (!BASE) return input.actor_kind === "model" && input.to_state === "DELIVERED" ? { blocked: true, message: "HDT invariant — only a human/clinician/policy may DELIVER to canonical" } : { to_state: input.to_state, epistemic_mode: input.to_state === "DELIVERED" ? "attested" : "observed", canonical: input.to_state === "DELIVERED" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/hdt/promote`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (res.status === 403 || res.status === 422) {
+    const d = (await res.json().catch(() => ({}))) as { detail?: { message?: string } | string };
+    return { blocked: true, message: typeof d.detail === "object" ? (d.detail.message ?? "blocked") : (d.detail ?? "blocked") };
+  }
+  if (!res.ok) throw writeError("promote failed", res.status);
+  return await res.json();
+}
+
+export async function invokeAction(input: { project: string; action: string; target: string; args: Record<string, unknown> }, token: string): Promise<{ invocation_id: string; applied: string[]; receipt: { correlation_id: string } }> {
+  if (!BASE) return { invocation_id: "stub:inv", applied: ["set acsetAttrName"], receipt: { correlation_id: "act-stub" } };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/action/invoke`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) {
+    let msg = `${res.status}`;
+    try { const j = await res.json(); msg = typeof j.detail === "object" ? JSON.stringify(j.detail.violations ?? j.detail) : (j.detail ?? msg); } catch { /* */ }
+    throw new Error(`invoke failed: ${msg}`);
+  }
+  return await res.json();
+}
+
+export async function submitWorldsignal(input: { project: string; feature_id: string; signal_type: string; confidence?: number; evidence_refs?: string[]; actor_kind?: string }, token: string): Promise<{ signal_id: string; promotion_state: string; epistemic_mode: string }> {
+  if (!BASE) return { signal_id: `stub:${input.feature_id}`, promotion_state: "EvidenceOnly", epistemic_mode: input.actor_kind === "model" ? "derived" : "observed" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/worldsignal`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (!res.ok) throw writeError("submit failed", res.status);
+  return await res.json();
+}
+
+export async function promoteWorldsignal(input: { project: string; signal: string; to_state: string; actor_kind?: string; policy_id?: string }, token: string): Promise<{ to_state: string; epistemic_mode: string; canonical: boolean } | { blocked: true; message: string }> {
+  if (!BASE) return input.actor_kind === "model" && input.to_state === "Promoted" ? { blocked: true, message: "GAIA invariant #2 — a model may not Promote to canonical" } : { to_state: input.to_state, epistemic_mode: input.to_state === "Promoted" ? "attested" : "observed", canonical: input.to_state === "Promoted" };
+  if (!token) throw new Error("write token required");
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/worldsignal/promote`, { method: "POST", headers: writeHeaders(token), body: JSON.stringify(input) });
+  if (res.status === 403 || res.status === 422) {
+    const d = (await res.json().catch(() => ({}))) as { detail?: { message?: string } | string };
+    return { blocked: true, message: typeof d.detail === "object" ? (d.detail.message ?? "blocked") : (d.detail ?? "blocked") };
+  }
+  if (!res.ok) throw writeError("promote failed", res.status);
+  return await res.json();
+}
+
+// ── Universal Compute Plane — the compute-gateway: one governed door for ALL compute ──
+// A single catalog of compute KINDS (notebook, graph-query, spark, inference, …), each declaring its
+// backends, capabilities, a DEFAULT epistemic warrant, whether it executes user code, a live/declared
+// status and whether the caller is entitled. Every run returns a proof-carrying receipt (optionally
+// signed) + an epistemic status. The Studio BFF proxies to the gateway; unset BASE → honest STUB.
+export interface ComputeKind {
+  kind: string;
+  backends: string[];
+  default: string;              // default backend
+  capabilities: string[];
+  epistemic: string;            // default epistemic warrant for this kind's results (ramp mode)
+  executes_user_code: boolean;
+  status: "live" | "declared";  // live = runnable now; declared = catalogued, not yet provisioned
+  entitled: boolean;
+}
+export interface ComputeOutput { type: string; text?: string; data?: unknown; mime?: string | string[] }
+export interface ComputeReceipt {
+  id: string; kind: string; backend: string; epistemic_status: string;
+  inputs_sha?: string; outputs_sha?: string; prev?: string | null; ts?: number;
+  signature?: string | null; public_key?: string | null;   // Ed25519 over the in-toto statement
+  [k: string]: unknown;
+}
+// Zero-trust conformance (compute-gateway ⇄ OUR mcp-a2a-zero-trust kernel).
+export interface ComputeGrantCheck { operation?: string; grant_id?: string; result?: { valid?: boolean; reason?: string } }
+export interface ComputeAttestation { results?: { tpm_valid?: boolean; cosign_valid?: boolean; fido2_valid?: boolean } }
+export interface ComputeResultLite {
+  status: "ok" | "error" | "degraded" | "entitlement_required" | "grant_required";
+  kind: string; backend: string; epistemic_status: string;
+  outputs: ComputeOutput[];
+  receipt?: ComputeReceipt | null;
+  // the gateway returns the provenance subgraph itself (arrays), not counts.
+  graph_delta?: { nodes?: unknown[]; edges?: unknown[]; written?: boolean } | null;
+  degraded?: string | null;
+  error?: string | null;
+  entitlement_required?: boolean;
+  message?: string | null;              // gateway's pay-gate / grant message (top-level)
+  grant_check?: ComputeGrantCheck | null;
+  attestation?: ComputeAttestation | null;
+  memoized?: boolean;                   // served from the content-addressed compute memo
+}
+
+// STUB catalog — MIRRORS the real compute-gateway registry (backends + warrants) so the offline preview
+// never misrepresents the live plane. notebook/graph/spark are live; inference is declared (adapter wired,
+// endpoint unverified) and left un-entitled so the pay-gate card is demonstrable standalone.
+const STUB_COMPUTE_REGISTRY: { kinds: ComputeKind[] } = {
+  kinds: [
+    { kind: "notebook", backends: ["forge"], default: "forge",
+      capabilities: ["python", "r", "julia", "stateful-kernel"], epistemic: "derived",
+      executes_user_code: true, status: "live", entitled: true },
+    { kind: "graph-query", backends: ["hellgraph"], default: "hellgraph",
+      capabilities: ["label-query", "subgraph"], epistemic: "observed",
+      executes_user_code: false, status: "live", entitled: true },
+    { kind: "graph-stats", backends: ["hellgraph"], default: "hellgraph",
+      capabilities: ["counts", "analytics"], epistemic: "observed",
+      executes_user_code: false, status: "live", entitled: true },
+    { kind: "spark", backends: ["spark-runner"], default: "spark-runner",
+      capabilities: ["sql", "dataframe"], epistemic: "derived",
+      executes_user_code: true, status: "live", entitled: true },
+    { kind: "inference", backends: ["model-server"], default: "model-server",
+      capabilities: ["chat", "embed"], epistemic: "derived",
+      executes_user_code: false, status: "declared", entitled: false },
+    { kind: "workflow", backends: ["gateway"], default: "gateway",
+      capabilities: ["dag", "compose", "fan-in", "memoized-steps"], epistemic: "derived",
+      executes_user_code: false, status: "live", entitled: true },
+  ],
+};
+
+export async function loadComputeRegistry(project: string): Promise<{ kinds: ComputeKind[] }> {
+  const b = nbBase();
+  if (!b) return STUB_COMPUTE_REGISTRY;
+  const r = await fetch(`${b}/api/studio/compute/registry?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } }).catch(() => null);
+  if (!r || !r.ok) return STUB_COMPUTE_REGISTRY;
+  const d = await r.json();
+  return Array.isArray(d?.kinds) ? d : STUB_COMPUTE_REGISTRY;
+}
+
+export async function runCompute(input: { kind: string; spec: Record<string, unknown>; project: string; backend?: string }): Promise<ComputeResultLite> {
+  const b = nbBase();
+  // honest stub: no BASE → we do NOT fake a real result; the surface shows the compute plane isn't wired.
+  if (!b) return {
+    status: "degraded", kind: input.kind, backend: input.backend ?? "—",
+    epistemic_status: "hypothesis", outputs: [], receipt: null,
+    graph_delta: { nodes: [], edges: [] },
+    degraded: "compute plane not wired (dev preview)",
+  };
+  const r = await fetch(`${b}/api/studio/compute/run`, {
+    method: "POST", headers: { "Content-Type": "application/json", accept: "application/json" },
+    body: JSON.stringify(input),
+  });
+  // the gateway returns 200 with status:"entitlement_required"|"grant_required" for a soft gate; a 402 is
+  // also honoured for parity with a hard pay-gate. Either way the body carries the typed result.
+  if (r.status === 402) return (await r.json()) as ComputeResultLite;
+  if (!r.ok) throw new Error(`compute run failed (HTTP ${r.status})`);
+  return (await r.json()) as ComputeResultLite;
+}
+
+// ── Planner — the capability registry as an agent ACTION SPACE (layer 6) ──
+// Desired capabilities → a governed workflow PLAN (preview, free): observed reads fan
+// out, then derivations fan in. The surface hands `plan` straight to runCompute to
+// execute it under full governance. Deterministic (strategy=capability-dag).
+export interface ComputePlanStep {
+  id: string; kind: string; backend: string; satisfies: string;
+  epistemic: string; executes_user_code?: boolean; status?: string; entitled: boolean;
+}
+export interface ComputePlan {
+  strategy: string; intent?: string | null;
+  plan?: { kind: string; project: string; spec: { steps: unknown[] } } | null;
+  steps: ComputePlanStep[];
+  warrant_preview?: string;
+  unmet_capabilities?: string[];
+  unmet_entitlements?: string[];
+  runnable?: boolean;
+  degraded?: string;
+}
+
+export async function planCompute(input: { capabilities: string[]; project: string; intent?: string }): Promise<ComputePlan> {
+  const b = nbBase();
+  if (!b) return { strategy: "stub", steps: [], plan: null, runnable: false,
+    degraded: "planner not wired (dev preview)" };
+  const r = await fetch(`${b}/api/studio/compute/plan`, {
+    method: "POST", headers: { "Content-Type": "application/json", accept: "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!r.ok) throw new Error(`plan failed (HTTP ${r.status})`);
+  return (await r.json()) as ComputePlan;
+}
+
+export async function loadStudio(projectId?: string): Promise<StudioBundle> {
+  if (!BASE) return STUB;
+  const q = projectId ? `?project=${encodeURIComponent(projectId)}` : "";
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio${q}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`studio load failed: ${res.status}`);
+  return (await res.json()) as StudioBundle;
+}

--- a/socioprophet-web/client-vue/vite.config.ts
+++ b/socioprophet-web/client-vue/vite.config.ts
@@ -28,6 +28,55 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, ''),
         },
+        // Canonical knowledge graph — hellgraph-service (the shared HTTP HellGraph engine).
+        // Both this cockpit's Knowledge Graph and the Prophet Studio Graph Explorer read it,
+        // so "the graph" is one across every surface. Strip the /svc/hellgraph prefix.
+        '/svc/hellgraph': {
+          target: env.VITE_HELLGRAPH_BASE || 'http://localhost:8090',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/hellgraph/, ''),
+        },
+        // owl-reasoner (RDFS/OWL entailment) + entity-resolution — the Studio Reason & Resolve bench.
+        '/svc/reason': {
+          target: env.VITE_REASON_BASE || 'http://localhost:8081',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/reason/, ''),
+        },
+        '/svc/er': {
+          target: env.VITE_ER_BASE || 'http://localhost:8082',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/er/, ''),
+        },
+        // algo-engine — REAL backtest + paper-execution for the Algorithmic Trading surface.
+        '/svc/algo': {
+          target: env.VITE_ALGO_BASE || 'http://localhost:8085',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/algo/, ''),
+        },
+        // ie-engine — REAL NLP / information-extraction (spaCy) for the NLP & IE surface.
+        '/svc/ie': {
+          target: env.VITE_IE_BASE || 'http://localhost:8086',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/ie/, ''),
+        },
+        // holmes — REAL claim verification over HellGraph evidence (Go service).
+        '/svc/holmes': {
+          target: env.VITE_HOLMES_BASE || 'http://localhost:8091',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/holmes/, ''),
+        },
+        // synapseiq-bridge — language intelligence: normalization + KKO type classification.
+        '/svc/synapse': {
+          target: env.VITE_SYNAPSE_BASE || 'http://localhost:8092',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/synapse/, ''),
+        },
+        // sherlock-engine — Tantivy (Rust, no-JVM) ontology-driven Discovery search.
+        '/svc/sherlock': {
+          target: env.VITE_SHERLOCK_BASE || 'http://localhost:8093',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/sherlock/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',


### PR DESCRIPTION
Consolidates the analyst cockpit into one shell and turns fixture capability boards into functional surfaces backed by real sovereign services.

**Unification**
- A single **Studio** workspace (`/studio`): Notebooks + Compute Plane (from app-vue) and the knowledge-engineering bench — Graph Explorer, Query, Analytics, GraphRAG, Resource Browser, Reasoner, Entity Resolution, Ontology, Experiments/Ops/Governance/Commons (from Prophet Studio) — behind `/svc/*` proxies, one design system.
- **Graph unified**: `KnowledgeGraph.vue` reads the canonical `hellgraph-service` (`/svc/hellgraph/api/graph/surface`) — same backend the Studio Graph Explorer uses.

**Fixture → real** (each backed by a new service):
- **Algo Trading** — real backtests over live data, plain-English strategy authoring, paper execution + P&L (`algo-engine`).
- **NLP & IE** — spaCy extraction + glossary + vectors + type-system + resolve, with **Holmes** claim-verification and **SynapseIQ** KKO typing (`ie-engine` + `/svc/holmes` + `/svc/synapse`).
- **Discovery** — sovereign **Tantivy** hybrid search + facets + Holmes verify (`/svc/sherlock`).

**Also**: `vite.config` `/svc/*` proxy family; GYG `CausalValuation` dark-token palette fix; nav wiring (Studio group, Discovery under Knowledge, Economic-Prophet → GYG).

Backends land in prophet-platform#868; tools in holmes#15, synapseiq#10, sherlock-search#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)