### PR TITLE
integ: BearBrowser explicit local-event handoff adapter (from fi-bearbrowser-explicit-local-adapter)

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyBearBrowserExplicitLocalEventHandoff,
   bearBrowserHandoffBoundaryNotice,
   bearBrowserReaderHandoffFixture,
   isBearBrowserReaderHandoffFixture,
   mapBearBrowserHandoffToFeedItem,
   resolveBearBrowserLocalEventHandoff,
 } from '../features/feed-intelligence/bearbrowserHandoff';
+import { feedIntelligenceState } from '../features/feed-intelligence/state';
 
 describe('BearBrowser handoff fixture mapping', () => {
   it('maps a local handoff fixture into a quarantined local-only FeedItem', () => {
@@ -66,8 +68,72 @@ describe('BearBrowser handoff fixture mapping', () => {
     expect(resolution.item?.claims).toContain('capture-is-not-publication');
   });
 
+  it('keeps explicit local-event adapter disabled without mutating item state', () => {
+    const resolution = applyBearBrowserExplicitLocalEventHandoff({
+      enabled: false,
+      existingItems: feedIntelligenceState.items,
+      payload: bearBrowserReaderHandoffFixture,
+    });
+
+    expect(resolution.status).toBe('disabled');
+    expect(resolution.item).toBeUndefined();
+    expect(resolution.items).toEqual(feedIntelligenceState.items);
+  });
+
+  it('keeps missing explicit local payload failure-safe', () => {
+    const resolution = applyBearBrowserExplicitLocalEventHandoff({
+      enabled: true,
+      existingItems: feedIntelligenceState.items,
+    });
+
+    expect(resolution.status).toBe('missing');
+    expect(resolution.item).toBeUndefined();
+    expect(resolution.items).toEqual(feedIntelligenceState.items);
+  });
+
+  it('keeps invalid explicit local payload failure-safe', () => {
+    const resolution = applyBearBrowserExplicitLocalEventHandoff({
+      enabled: true,
+      existingItems: feedIntelligenceState.items,
+      payload: { sourceUrl: 'local://bad', storagePolicyRequest: 'hostedPublic' },
+    });
+
+    expect(resolution.status).toBe('invalid');
+    expect(resolution.item).toBeUndefined();
+    expect(resolution.items).toEqual(feedIntelligenceState.items);
+  });
+
+  it('maps an accepted explicit local payload as a local-only quarantined reader item', () => {
+    const existingItems = feedIntelligenceState.items.filter((item) => item.id !== 'item-bearbrowser-handoff-fixture-001');
+
+    const resolution = applyBearBrowserExplicitLocalEventHandoff({
+      enabled: true,
+      existingItems,
+      payload: bearBrowserReaderHandoffFixture,
+    });
+
+    expect(resolution.status).toBe('accepted');
+    expect(resolution.item.storagePolicy).toBe('localOnly');
+    expect(resolution.item.membraneDecision).toBe('quarantine');
+    expect(resolution.item.claims).toContain('capture-is-not-publication');
+    expect(resolution.items).toContainEqual(resolution.item);
+  });
+
+  it('upserts accepted explicit local payloads without duplicating reader items', () => {
+    const resolution = applyBearBrowserExplicitLocalEventHandoff({
+      enabled: true,
+      existingItems: feedIntelligenceState.items,
+      payload: bearBrowserReaderHandoffFixture,
+    });
+
+    const handoffItems = resolution.items.filter((item) => item.id === 'item-bearbrowser-handoff-fixture-001');
+
+    expect(resolution.status).toBe('accepted');
+    expect(handoffItems).toHaveLength(1);
+  });
+
   it('states disabled live side effects explicitly', () => {
-    expect(bearBrowserHandoffBoundaryNotice()).toContain('local-event only');
+    expect(bearBrowserHandoffBoundaryNotice()).toContain('explicit-local-event only');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('no native browser bridge');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('memory writeback');
     expect(bearBrowserHandoffBoundaryNotice()).toContain('graph traversal');

--- a/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/BearBrowserHandoffFixture.test.ts
@@ -113,9 +113,9 @@ describe('BearBrowser handoff fixture mapping', () => {
     });
 
     expect(resolution.status).toBe('accepted');
-    expect(resolution.item.storagePolicy).toBe('localOnly');
-    expect(resolution.item.membraneDecision).toBe('quarantine');
-    expect(resolution.item.claims).toContain('capture-is-not-publication');
+    expect(resolution.item?.storagePolicy).toBe('localOnly');
+    expect(resolution.item?.membraneDecision).toBe('quarantine');
+    expect(resolution.item?.claims).toContain('capture-is-not-publication');
     expect(resolution.items).toContainEqual(resolution.item);
   });
 

--- a/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
+++ b/socioprophet-web/client-vue/src/features/feed-intelligence/bearbrowserHandoff.ts
@@ -31,6 +31,24 @@ export type BearBrowserLocalEventResolution =
       reason: string;
     };
 
+export type BearBrowserExplicitLocalEventAdapterState = BearBrowserLocalEventAdapterState & {
+  existingItems: FeedItem[];
+};
+
+export type BearBrowserExplicitLocalEventAdapterResolution =
+  | {
+      status: 'disabled' | 'missing' | 'invalid';
+      item?: undefined;
+      items: FeedItem[];
+      reason: string;
+    }
+  | {
+      status: 'accepted';
+      item: FeedItem;
+      items: FeedItem[];
+      reason: string;
+    };
+
 export const bearBrowserReaderHandoffFixture: BearBrowserReaderHandoffFixture = {
   sourceUrl: 'https://example.local/sourceos/bearbrowser-capture-demo',
   canonicalUrl: 'local://bearbrowser/captures/feed-intelligence-demo-001',
@@ -100,6 +118,31 @@ export function resolveBearBrowserLocalEventHandoff(
   };
 }
 
+export function applyBearBrowserExplicitLocalEventHandoff(
+  state: BearBrowserExplicitLocalEventAdapterState,
+): BearBrowserExplicitLocalEventAdapterResolution {
+  const resolution = resolveBearBrowserLocalEventHandoff({
+    enabled: state.enabled,
+    payload: state.payload,
+  });
+
+  if (resolution.status !== 'accepted') {
+    return {
+      status: resolution.status,
+      items: [...state.existingItems],
+      reason: resolution.reason,
+    };
+  }
+
+  return {
+    status: 'accepted',
+    item: resolution.item,
+    items: upsertFeedItem(state.existingItems, resolution.item),
+    reason:
+      'Explicit local BearBrowser handoff payload accepted and mapped in memory as a local-only quarantined reader item.',
+  };
+}
+
 export function isBearBrowserReaderHandoffFixture(
   value: unknown,
 ): value is BearBrowserReaderHandoffFixture {
@@ -118,10 +161,14 @@ export function isBearBrowserReaderHandoffFixture(
   );
 }
 
+function upsertFeedItem(items: FeedItem[], item: FeedItem): FeedItem[] {
+  return [...items.filter((existingItem) => existingItem.id !== item.id), item];
+}
+
 function isBearBrowserProfileClass(value: unknown): value is BearBrowserProfileClass {
   return value === 'human' || value === 'agent' || value === 'terminal';
 }
 
 export function bearBrowserHandoffBoundaryNotice(): string {
-  return 'BearBrowser handoff is local-event only; no native browser bridge, network fetch, publication, memory writeback, or graph traversal is active.';
+  return 'BearBrowser handoff is explicit-local-event only; no native browser bridge, network fetch, publication, memory writeback, or graph traversal is active.';
 }


### PR DESCRIPTION
Integrates the genuinely-additive feature from `fi-bearbrowser-explicit-local-adapter` that main lacked, rather than dropping the branch as 'behind'.

**What:** `applyBearBrowserExplicitLocalEventHandoff` — an explicit-local-event adapter layered on main's existing `resolveBearBrowserLocalEventHandoff`, upserting an accepted handoff into an in-memory feed list with local-only quarantine semantics.

**Why integrate (not drop):** per the compare-and-integrate doctrine — the branch is 196 commits behind main, but this specific feature builds *on top of* main's current code and is real value main didn't have.

**Method:** cherry-picked the branch's 3 commits onto current master — **clean, zero conflicts** (main already has the base functions). Test lands in the canonical `src/__tests__/` location.

**Verified:** `vitest run src/__tests__/BearBrowserHandoffFixture.test.ts` → **12 passed** (main's originals + the new explicit-adapter cases). 2 files, +115 lines.