### PR TITLE
cockpit: make Notebooks + Studio findable (un-bury from operator gating)

### DIFF
--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -299,7 +299,15 @@ export const DRAWER_SECTIONS: DrawerSection[] = [
     id: 'working',
     label: 'Working surfaces',
     defaultOpen: true,
-    items: [...OPERATOR_SHORTCUTS, { label: 'Feed', to: '/feed' }],
+    // Studio + Notebooks surfaced here (always-visible, top of drawer) so they're findable
+    // without hunting through the operator-gated Studio group. Notebooks is the flagship
+    // workbench — it shouldn't be three clicks and an Operator-mode toggle away.
+    items: [
+      { label: 'Studio', to: '/studio' },
+      { label: 'Notebooks', to: '/studio?section=notebooks' },
+      ...OPERATOR_SHORTCUTS,
+      { label: 'Feed', to: '/feed' },
+    ],
   },
   {
     id: 'knowledge',
@@ -312,7 +320,13 @@ export const DRAWER_SECTIONS: DrawerSection[] = [
       { label: 'Noetica Chat', to: '/noetica' },
     ],
   },
-  ...AGENT_COCKPIT.map((g) => ({ id: _slug(g.label), label: g.label, defaultOpen: false, operator: true, items: g.items })),
+  // The Studio group (Notebooks, Compute, Graph Explorer, …) is a core user surface, so it's
+  // shown by default and NOT operator-gated. The rest (Infrastructure, Models & Pipelines,
+  // Workstation, SourceOS, Marketplace) stay Operator-mode sections.
+  ...AGENT_COCKPIT.map((g) => {
+    const isStudio = g.label === 'Studio';
+    return { id: _slug(g.label), label: g.label, defaultOpen: isStudio, operator: !isStudio, items: g.items };
+  }),
 ];
 
 // Flat, de-duplicated surface index for the ⌘K command palette — every reachable

--- a/socioprophet-web/client-vue/src/pages/studio/Analytics.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/Analytics.vue
@@ -28,7 +28,7 @@ function fmt(e: unknown) { return e instanceof ApiError ? `${e.status}: ${e.mess
         <div><div class="kpi">{{ pr.edges }}</div><div class="kpi-l">edges</div></div>
       </div>
       <div class="scroll"><table class="tbl"><thead><tr><th>#</th><th>node</th><th>score</th></tr></thead>
-        <tbody><tr v-for="(t,i) in pr.top" :key="t.id"><td>{{ i+1 }}</td><td style="word-break:break-all">{{ t.id }}</td><td>{{ t.score }}</td></tr></tbody></table></div>
+        <tbody><tr v-for="(t,i) in pr.top" :key="t.id"><td>{{ Number(i)+1 }}</td><td style="word-break:break-all">{{ t.id }}</td><td>{{ t.score }}</td></tr></tbody></table></div>
     </div>
     <div class="card" v-if="cc">
       <div class="row" style="justify-content:space-between"><h3>Connected components</h3><span class="pill accent">{{ cc.backend }}</span></div>


### PR DESCRIPTION
**Symptom (owner report):** "I can't find my notebooks." The Studio group — Notebooks, Compute, Graph Explorer, Query Console, Reasoner, ER, Ontology, etc. — was an **Operator-mode-gated** drawer section, **collapsed by default**. So without knowing to flip Operator mode *and* expand the right accordion, Notebooks was effectively hidden.

**Fix (cockpitNav.ts only):**
- Surface **Studio** + **Notebooks** directly in the always-open *Working surfaces* section (top of the drawer).
- Make the **Studio** drawer group **default-open** and **not** operator-gated. The other operator groups (Infrastructure, Models & Pipelines, Workstation, SourceOS, Marketplace) stay Operator-mode-gated as before.

**Verified** headless against the running dev server: opening the drawer now shows Notebooks immediately (no Operator toggle, no hunting); clicking it loads the Studio workbench at `/studio?section=notebooks`.

Note: this is the *findability* fix. Notebooks still needs its backend (`VITE_STUDIO_API` / agent-machine) wired to show live data on a deployed site — tracked separately.