### PR TITLE
marketing: add Sign in button to socioprophet.com → the cockpit

### DIFF
--- a/marketing/public/index.html
+++ b/marketing/public/index.html
@@ -132,6 +132,7 @@
             <a href="/organizations/">Organizations</a>
             <a href="/documentation/" onclick='spTrack("cta_docs_click",{href:this.getAttribute("href")})'>Documentation</a>
             <a href="https://vue.socioprophet.com" onclick='spTrack("cta_portal_click",{href:this.getAttribute("href")})'>Portal</a>
+            <a href="https://app.socioprophet.com" class="btn-dark" onclick='spTrack("cta_signin_click",{href:this.getAttribute("href")})'>Sign in</a>
           </nav>
         </div>
       </div>


### PR DESCRIPTION
socioprophet.com had Commons/Organizations/Documentation/Portal but **no Sign in / way into the app**. Adds a prominent **Sign in** (existing `btn-dark` style) in the nav → `https://app.socioprophet.com` (the login + cockpit domain), with the site's `spTrack` CTA analytics.

The entry piece of **socioprophet.com → login → cockpit** (Option 1: app.socioprophet.com becomes the GKE cockpit). Deploys via the Firebase `marketing` target. Lights up fully once app.socioprophet.com serves the operating GKE cockpit (DNS repoint + managed cert + Firebase-config injection — tracked).