### PR TITLE
feat(cockpit+studio): federation card + Documents section — the backend made visible

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioDocuments.vue
+++ b/socioprophet-web/app-vue/src/components/StudioDocuments.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+// The DOCUMENT view of the project graph (BFF /api/studio/documents): what a Noetica user
+// published — or the pipeline ingested — and how much linked knowledge each document yielded.
+// Documents, not a node soup; every row traces to its doc_sha and extractor. Hand-authored
+// facts are counted separately (undocumented_nodes) — still real, just not doc-scoped.
+import { ref, onMounted, watch } from "vue";
+import { loadDocuments, type DocumentsView } from "../services/studioApi";
+
+const props = defineProps<{ project: string }>();
+const view = ref<DocumentsView | null>(null);
+const loading = ref(true);
+const err = ref("");
+
+async function load() {
+  loading.value = true; err.value = "";
+  try { view.value = await loadDocuments(props.project); }
+  catch (e) { err.value = e instanceof Error ? e.message : "failed to load documents"; }
+  finally { loading.value = false; }
+}
+onMounted(load);
+watch(() => props.project, load);
+
+const short = (sha: string) => sha.slice(0, 12);
+</script>
+
+<template>
+  <div class="docs">
+    <div class="dbar">
+      <span class="cnt" v-if="view">{{ view.count }} document{{ view.count === 1 ? "" : "s" }}
+        · {{ view.undocumented_nodes }} hand-authored fact{{ view.undocumented_nodes === 1 ? "" : "s" }} outside any document</span>
+      <div class="spacer" />
+      <span v-if="view?.stub" class="stub">stub — set VITE_STUDIO_API</span>
+      <button class="ghost" @click="load" :disabled="loading" title="reload" aria-label="Reload documents">↻</button>
+    </div>
+
+    <div v-if="err" class="err">{{ err }}</div>
+    <div v-else-if="loading" class="muted">Loading…</div>
+    <div v-else-if="view && view.documents.length === 0" class="muted">
+      No documents yet — drop one through the ingestion pipeline (or a federated Noetica user's
+      knowledge will appear here once their machine is admitted).
+    </div>
+
+    <table v-else-if="view" class="dtable">
+      <thead>
+        <tr><th>Document</th><th class="num">Entities</th><th class="num">Edges</th><th>Sample</th><th>Extractor</th></tr>
+      </thead>
+      <tbody>
+        <tr v-for="d in view.documents" :key="d.doc_sha">
+          <td>
+            <div class="fname">{{ d.filename || "(unnamed)" }}</div>
+            <code class="sha" :title="d.doc_sha">{{ short(d.doc_sha) }}</code>
+          </td>
+          <td class="num">{{ d.entities }}</td>
+          <td class="num">{{ d.edges }}</td>
+          <td><span class="chip" v-for="s in d.sample.slice(0, 4)" :key="s">{{ s }}</span></td>
+          <td class="muted small">{{ d.extractor || "—" }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="foot" v-if="view && view.documents.length">
+      Every fact from these documents carries its doc_sha in provenance — the graph explorer's
+      provenance panel traces any node back to the exact document that produced it.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.docs { display: flex; flex-direction: column; gap: 12px; }
+.dbar { display: flex; align-items: center; gap: 10px; }
+.cnt { font-size: 12px; color: var(--text-2, #6a6f73); }
+.spacer { flex: 1; }
+.stub { font-size: 11px; color: var(--text-3, #8d9196); }
+.ghost { background: none; border: 1px solid var(--border-1, #e0e0e0); border-radius: 6px; padding: 2px 8px; cursor: pointer; color: var(--text-2, #6a6f73); }
+.err { color: #b3261e; font-size: 12px; }
+.muted { color: var(--text-3, #8d9196); font-size: 12px; }
+.small { font-size: 11px; }
+.dtable { width: 100%; border-collapse: collapse; font-size: 12.5px; }
+.dtable th { text-align: left; font-weight: 600; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--text-3, #8d9196); padding: 6px 10px; border-bottom: 1px solid var(--border-1, #e0e0e0); }
+.dtable td { padding: 8px 10px; border-bottom: 1px solid var(--border-2, #f0f0f0); vertical-align: top; }
+.dtable .num { text-align: right; font-variant-numeric: tabular-nums; }
+.fname { font-weight: 600; color: var(--text-1, #21272a); }
+.sha { font-size: 10.5px; color: var(--text-3, #8d9196); }
+.chip { display: inline-block; margin: 0 4px 4px 0; padding: 1px 7px; border: 1px solid var(--border-1, #e0e0e0); border-radius: 999px; font-size: 11px; color: var(--text-2, #6a6f73); }
+.foot { font-size: 11.5px; color: var(--text-3, #8d9196); max-width: 62ch; }
+</style>

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -9,7 +9,7 @@ const BASE = (import.meta as { env?: Record<string, string> }).env?.VITE_STUDIO_
 
 export type StudioSection =
   | "notebooks" | "data" | "models" | "tuning" | "experiments"                 // Workbench
-  | "extraction" | "ontology" | "graph" | "query" | "retrieval" | "generation" // Knowledge engineering
+  | "extraction" | "ontology" | "graph" | "documents" | "query" | "retrieval" | "generation" // Knowledge engineering
   | "operations" | "compute"                                                    // Operations cockpit (WS#45–48/#31) + Universal Compute Plane
   | "governance"                                                                // Governance: ontology · actions · GAIA
   | "commons";                                                                  // Commons (WS#36–39)
@@ -177,6 +177,34 @@ const STUB_GRAPH: GraphView = {
   ],
   count: 5, edge_count: 6, epistemic_distribution: { verified: 1, observed: 2, derived: 1, hypothesis: 1 }, stub: true,
 };
+
+// ── documents view: what was ingested and how much linked knowledge each doc yielded ──
+export interface StudioDocument {
+  doc_sha: string; filename?: string; file_sha?: string; source?: string; extractor?: string;
+  entities: number; edges: number; sample: string[];
+}
+export interface DocumentsView {
+  project: string; documents: StudioDocument[]; count: number;
+  undocumented_nodes: number; degraded?: string | null; stub?: boolean;
+}
+
+const STUB_DOCUMENTS: DocumentsView = {
+  project: "demo",
+  documents: [
+    { doc_sha: "d3adb33fcafe0001", filename: "gyg-fy26-pack.pdf", extractor: "lattice-studio/ie-pipeline-v1",
+      entities: 12, edges: 7, sample: ["Guzman & Gomez", "Sydney", "Steven Marks"] },
+    { doc_sha: "0ddba11deadf0002", filename: "cmg-q1-earnings.htm", extractor: "lattice-studio/ie-pipeline-v1",
+      entities: 9, edges: 4, sample: ["Chipotle", "Total revenue"] },
+  ],
+  count: 2, undocumented_nodes: 3, stub: true,
+};
+
+export async function loadDocuments(project: string): Promise<DocumentsView> {
+  if (!BASE) return STUB_DOCUMENTS;
+  const res = await fetch(`${BASE.replace(/\/$/, "")}/api/studio/documents?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`documents load failed: ${res.status}`);
+  return (await res.json()) as DocumentsView;
+}
 
 export async function loadGraph(project: string): Promise<GraphView> {
   if (!BASE) return STUB_GRAPH;

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { loadStudio, loadReceipts, mintCitation, SECTION_COUNT, EPISTEMIC_COLORS, type StudioBundle, type StudioSection, type Receipts, type Citation } from "../services/studioApi";
 import StudioGraph from "../components/StudioGraph.vue";
+import StudioDocuments from "../components/StudioDocuments.vue";
 import StudioQuery from "../components/StudioQuery.vue";
 import StudioExperiments from "../components/StudioExperiments.vue";
 import StudioCommons from "../components/StudioCommons.vue";
@@ -59,6 +60,7 @@ const sections: { id: StudioSection; label: string; icon: string; group: string;
   { id: "extraction",  label: "Extraction",    icon: "⛏", group: "Knowledge engineering", blurb: "Pull knowledge into the project graph — Holmes entities/relations, Sherlock federated search, governed ingest." },
   { id: "ontology",    label: "Ontology",      icon: "⬡", group: "Knowledge engineering", blurb: "The schema & alignment layer — Ontogenesis classes, relations, KKO alignment." },
   { id: "graph",       label: "Graph",         icon: "⧉", group: "Knowledge engineering", blurb: "The project knowledge graph — HellGraph, gremlin/sparql, grounded to your docs." },
+  { id: "documents",   label: "Documents",     icon: "▤", group: "Knowledge engineering", blurb: "What was ingested — every document and the linked knowledge it yielded, doc_sha provenance per fact." },
   { id: "query",       label: "Query",         icon: "⌗", group: "Knowledge engineering", blurb: "SPARQL / Cypher / Gremlin over the live kernel — results you can replay (proof-carrying) and whose facts carry epistemic status." },
   { id: "retrieval",   label: "Retrieval",     icon: "◎", group: "Knowledge engineering", blurb: "Fibered retrieval (PageIndex ⊕ HellGraph) · Graph-RAG · topic & semantic indexes." },
   { id: "generation",  label: "Generation",    icon: "✦", group: "Knowledge engineering", blurb: "Grounded generation & generation-tuning — New-Hope synthesis over the graph." },
@@ -96,6 +98,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
   tuning:      [{ label: "Register model", hint: "→ model zoo" }, { label: "Logs", hint: "job status" }, { label: "Cancel", hint: "cancel job" }],
   experiments: [{ label: "Re-run", hint: "reproduce end-to-end" }, { label: "Provenance", hint: "in-toto chain" }, { label: "Publish", hint: "publication artifact" }],
   extraction:  [{ label: "Run extraction", hint: "Holmes/Sherlock → project graph" }, { label: "View in graph", hint: "open the graph" }, { label: "Share to team", hint: "in the project collection" }],
+  documents:   [{ label: "View in graph", hint: "the doc's subgraph in the explorer" }, { label: "Provenance", hint: "every fact carries its doc_sha" }],
   ontology:    [{ label: "Edit ontology", hint: "Ontogenesis" }, { label: "Align", hint: "map to KKO / project" }, { label: "Apply to graph", hint: "re-type entities" }],
   graph:       [{ label: "Open graph", hint: "HellGraph gremlin/sparql" }, { label: "Query", hint: "graph-RAG" }, { label: "Export", hint: "sub-graph" }],
   query:       [{ label: "Run", hint: "SPARQL/Cypher/Gremlin over the kernel" }, { label: "Replay", hint: "re-evaluate by query hash" }, { label: "Export", hint: "results + proof" }],
@@ -217,6 +220,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
         <StudioCompute v-else-if="section === 'compute'" :project="project" />
         <!-- Graph section = the provenance-first explorer (KE-2) -->
         <StudioGraph v-else-if="section === 'graph'" :project="project" />
+        <StudioDocuments v-else-if="section === 'documents'" :project="project" />
         <!-- Query section = the proof-carrying query IDE (WS#30) -->
         <StudioQuery v-else-if="section === 'query'" :project="project" />
         <!-- Experiments = runs as proof-carrying graph facts (WS#32) -->

--- a/socioprophet-web/client-vue/src/pages/KnowledgeGraph.vue
+++ b/socioprophet-web/client-vue/src/pages/KnowledgeGraph.vue
@@ -18,6 +18,26 @@
       <span v-if="root" class="rooted">rooted at <b>{{ rootLabel }}</b></span>
     </div>
 
+    <!-- Org federation — membership state of the shared graph (super-peer, opt-in). Admins hand
+         the BASE KEY to users; users' machine keys are admitted operator-side ('admit' scope). -->
+    <div v-if="fed" class="fedcard" :class="{ off: !fed.enabled }">
+      <template v-if="fed.enabled">
+        <span class="feddot on" aria-hidden="true" />
+        <span class="fedtext"><b>Org federation live</b>
+          <template v-if="fed.health"> — {{ fed.health.writers }} writer{{ fed.health.writers === 1 ? '' : 's' }} · {{ fed.health.nodes }} federated nodes</template>
+          <template v-if="fed.authEnforced === false"> · <b class="warn">auth OFF (dev)</b></template>
+        </span>
+        <span v-if="fed.baseKey" class="fedkey">
+          join key <code :title="fed.baseKey">{{ fed.baseKey.slice(0, 12) }}…</code>
+          <button class="copy" @click="copyBaseKey">{{ copied ? 'copied' : 'copy' }}</button>
+        </span>
+      </template>
+      <template v-else>
+        <span class="feddot" aria-hidden="true" />
+        <span class="fedtext">Org federation off — activation runbook in deploy/values/hellgraph-service.yaml</span>
+      </template>
+    </div>
+
     <p v-if="error" class="error">{{ error }} — run the Agent Machine (dev:app) with the HellGraph sidecar.</p>
     <p v-else-if="!data" class="muted">Loading subgraph…</p>
     <p v-else-if="data.nodes.length === 0" class="muted">No nodes in this view yet — ingest interactions to populate the graph.</p>
@@ -44,7 +64,7 @@ import { ref, computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 // Reads the CANONICAL hellgraph-service (shared with the Prophet Studio Graph Explorer) — one graph
 // across every surface. Types still come from agentMachineApi (the surface contract is mirrored).
-import { graphSurface, graphHealth } from '../services/hellgraphApi';
+import { graphSurface, graphHealth, federationState, type FederationState } from '../services/hellgraphApi';
 import type { SurfaceResult, GraphHealth } from '../services/agentMachineApi';
 import { navScopeForPath } from '../config/cockpitNav';
 
@@ -57,6 +77,12 @@ const view = ref<(typeof views)[number]>('all');
 const root = ref('');
 const data = ref<SurfaceResult | null>(null);
 const health = ref<GraphHealth | null>(null);
+const fed = ref<FederationState | null>(null);
+const copied = ref(false);
+function copyBaseKey() {
+  if (!fed.value?.baseKey) return;
+  void navigator.clipboard?.writeText(fed.value.baseKey).then(() => { copied.value = true; setTimeout(() => { copied.value = false; }, 1500); });
+}
 const error = ref('');
 
 const W = 720, H = 460;
@@ -73,6 +99,7 @@ onMounted(async () => {
   const r = typeof route.query.root === 'string' ? route.query.root : '';
   if (r) root.value = r;
   void load();
+  federationState().then((f) => { fed.value = f; }).catch(() => { fed.value = null; });  // card hides when unreachable
   try { health.value = await graphHealth(); } catch { /* health is best-effort */ }
 });
 
@@ -135,4 +162,15 @@ h1 { margin: 0; font-size: 1.25rem; } .head p { margin: 0.25rem 0 0; color: rgba
 .node text { fill: rgba(255, 255, 255, 0.72); font-size: 8.5px; pointer-events: none; } .node.featured text { fill: #fff; font-weight: 600; }
 .legend { display: flex; flex-wrap: wrap; gap: 0.75rem; padding: 0.5rem 0.9rem; border-top: 1px solid rgba(255, 255, 255, 0.08); }
 .lg { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.68rem; color: rgba(255, 255, 255, 0.6); text-transform: capitalize; } .lg i { width: 9px; height: 9px; border-radius: 50%; }
+
+/* org federation card — quiet strip; state carried by the dot + one line of text */
+.fedcard { display: flex; align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid var(--border-subtle-01, #e0e0e0); border-radius: 8px; font-size: 12.5px; }
+.fedcard.off { color: var(--text-helper, #8d9196); }
+.feddot { width: 8px; height: 8px; border-radius: 999px; background: var(--border-strong-01, #c6c6c6); flex: none; }
+.feddot.on { background: #24a148; }
+.fedtext { min-width: 0; }
+.fedtext .warn { color: #b28600; }
+.fedkey { margin-left: auto; display: flex; align-items: center; gap: 6px; color: var(--text-secondary, #525252); }
+.fedkey code { font-size: 11px; }
+.copy { border: 1px solid var(--border-subtle-01, #e0e0e0); background: none; border-radius: 6px; padding: 1px 8px; font-size: 11px; cursor: pointer; color: inherit; }
 </style>

--- a/socioprophet-web/client-vue/src/services/hellgraphApi.ts
+++ b/socioprophet-web/client-vue/src/services/hellgraphApi.ts
@@ -23,3 +23,22 @@ export async function graphHealth(): Promise<GraphHealth> {
   const d = (await res.json()) as { nodes: number; edges: number };
   return { ok: true, nodes: d.nodes, edges: d.edges };
 }
+
+// ── Org federation (the super-peer hosted by hellgraph-service; opt-in) ──────────────────
+// status is open; ADMIT is operator-side (HMAC-minted token with the 'admit' scope). The
+// cockpit's job is visibility: is federation on, what's the base key users join by, and
+// how much of the org graph the federation index carries.
+export interface FederationState {
+  enabled: boolean;
+  authEnforced?: boolean;
+  baseKey?: string;
+  writerKey?: string;
+  health?: { nodes: number; edges: number; writers: number; cut: Record<string, number> };
+  degraded?: string;
+}
+
+export async function federationState(): Promise<FederationState> {
+  const res = await fetch(`${BASE}/api/federation/status`);
+  if (!res.ok) throw new Error(`federation status ${res.status}`);
+  return (await res.json()) as FederationState;
+}


### PR DESCRIPTION
## What
The two Vue surfaces that make today's federation + ingestion backend visible to an org admin:

**Knowledge Graph page (client-vue, canonical cockpit)** — an org-federation strip: live dot, writers + federated-node counts, the **join key with one-tap copy** (what an admin hands a Noetica user for the one-time opt-in), an explicit **auth OFF (dev)** warning when the super-peer runs ungoverned, and an honest off-state pointing at the activation runbook. Hides when the service is unreachable.

**Prophet Studio (app-vue)** — a **Documents** section under Knowledge engineering, on `/api/studio/documents` (prophet-platform #964): every ingested document with entity/edge counts, sample entities, extractor tag and short `doc_sha`; hand-authored facts counted separately; stub mode consistent with every other section.

Backend counterparts: platform #966 (super-peer) · Noetica #543 (participant + opt-in UI) · platform #964 (documents BFF).

## Verification
`vue-tsc --noEmit` clean on both apps; stub modes render standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)