### PR TITLE
cockpit: causal-graph adapter + read-only view — closes epistemic-kernel trio

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/CausalGraphFixtureShape.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/CausalGraphFixtureShape.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Fixture-chain parity for the causal-graph cockpit types.
+ *
+ * The client-side types mirror sourceos-spec's v0.1 CausalHypothesis /
+ * CausalEdge. When either canonical schema bumps, these tests are the guard
+ * that catches the mirror drifting out of step: every required field the
+ * shipped v0.1 contract names is asserted present on the demo fixture.
+ *
+ * Also exercises the read-model invariants the cockpit refuses to render
+ * past: unwarranted edge, missing warrant lookup, endpoint not in the
+ * hypothesis set, self-loop.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  assertWellFormed,
+  contributionSummary,
+  demoAutoPartsSnapshot,
+  severityBadge,
+  warrantsForEdge,
+  warrantsForHypothesis,
+} from '../features/causal-graph/state';
+import type { CausalEdge, CausalHypothesis } from '../features/causal-graph/types';
+
+// Required fields per sourceos-spec CausalHypothesis.json v0.1 (subset the
+// cockpit renders — NOT the ingest-only fields like kkoTypeRef or entityClusterRef).
+const HYPOTHESIS_REQUIRED = [
+  'id', 'type', 'specVersion', 'graphRef', 'label', 'hypothesis', 'topics',
+  'claimStatus', 'warrantRefs',
+] as const;
+
+const EDGE_REQUIRED = [
+  'id', 'type', 'specVersion', 'graphRef', 'fromRef', 'toRef', 'sign', 'warrantRefs',
+] as const;
+
+describe('CausalGraphSnapshot mirrors the shipped v0.1 contracts', () => {
+  it('every fixture hypothesis carries every required v0.1 field', () => {
+    for (const h of demoAutoPartsSnapshot.hypotheses) {
+      for (const key of HYPOTHESIS_REQUIRED) {
+        expect(h, `${h.id} missing ${key}`).toHaveProperty(key);
+      }
+      expect(h.type).toBe('CausalHypothesis');
+      expect(h.specVersion).toBe('0.1.0');
+      expect(h.graphRef).toBe(demoAutoPartsSnapshot.graphRef);
+    }
+  });
+
+  it('every fixture edge carries every required v0.1 field, non-empty warrants, and valid sign', () => {
+    for (const e of demoAutoPartsSnapshot.edges) {
+      for (const key of EDGE_REQUIRED) {
+        expect(e, `${e.id} missing ${key}`).toHaveProperty(key);
+      }
+      expect(e.type).toBe('CausalEdge');
+      expect(e.specVersion).toBe('0.1.0');
+      expect(['positive', 'negative']).toContain(e.sign);
+      expect(e.warrantRefs.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('cockpit read-model invariants', () => {
+  it('demo snapshot passes assertWellFormed', () => {
+    expect(() => assertWellFormed(demoAutoPartsSnapshot)).not.toThrow();
+  });
+
+  it('refuses to render an edge with no warrantRefs', () => {
+    const broken = structuredClone(demoAutoPartsSnapshot);
+    broken.edges[0]!.warrantRefs = [];
+    expect(() => assertWellFormed(broken)).toThrow(/no warrantRefs/);
+  });
+
+  it('refuses to render an edge whose warrant is not in the lookup', () => {
+    const broken = structuredClone(demoAutoPartsSnapshot);
+    broken.edges[0]!.warrantRefs = ['urn:srcos:evidence:missing'];
+    expect(() => assertWellFormed(broken)).toThrow(/not present in snapshot.warrants/);
+  });
+
+  it('refuses to render an edge whose endpoint is not declared', () => {
+    const broken = structuredClone(demoAutoPartsSnapshot);
+    broken.edges[0]!.toRef = 'urn:srcos:causal-hypothesis:ghost';
+    expect(() => assertWellFormed(broken)).toThrow(/not in this snapshot/);
+  });
+
+  it('refuses to render a self-loop', () => {
+    const broken = structuredClone(demoAutoPartsSnapshot);
+    broken.edges[0]!.toRef = broken.edges[0]!.fromRef;
+    expect(() => assertWellFormed(broken)).toThrow(/self-loop/);
+  });
+});
+
+describe('warrant drill-down surfaces every referenced evidence atom', () => {
+  it('warrantsForEdge returns a WarrantSummary per referenced warrant', () => {
+    for (const edge of demoAutoPartsSnapshot.edges) {
+      const found = warrantsForEdge(demoAutoPartsSnapshot, edge);
+      expect(found.length).toBe(edge.warrantRefs.length);
+      for (const w of found) {
+        expect(w.excerpt.length).toBeGreaterThan(0);
+        expect(w.sourceDocRef.startsWith('urn:srcos:doc:')).toBe(true);
+      }
+    }
+  });
+
+  it('warrantsForHypothesis returns warrants for an evidenced claim and empty for proposed', () => {
+    const evidenced = demoAutoPartsSnapshot.hypotheses.find((h) => h.claimStatus === 'evidenced');
+    expect(evidenced).toBeDefined();
+    expect(warrantsForHypothesis(demoAutoPartsSnapshot, evidenced!).length).toBeGreaterThan(0);
+
+    const proposed = demoAutoPartsSnapshot.hypotheses.find((h) => h.claimStatus === 'proposed');
+    expect(proposed).toBeDefined();
+    expect(warrantsForHypothesis(demoAutoPartsSnapshot, proposed!)).toEqual([]);
+  });
+});
+
+describe('display projections', () => {
+  it('severityBadge tone tracks claim status distinctly', () => {
+    const tones = (['proposed', 'evidenced', 'scored'] as const).map((s) =>
+      severityBadge({ claimStatus: s } as CausalHypothesis).tone,
+    );
+    expect(new Set(tones).size).toBe(3);
+  });
+
+  it('contributionSummary reports direction, magnitude, lag, and confidence when present', () => {
+    const edge: CausalEdge = {
+      id: 'e', type: 'CausalEdge', specVersion: '0.1.0', graphRef: 'g',
+      fromRef: 'a', toRef: 'b', sign: 'negative', weight: 0.5, lagDays: 30,
+      confidence: 0.75, warrantRefs: ['w'],
+    };
+    const s = contributionSummary(edge);
+    expect(s).toContain('lowers');
+    expect(s).toContain('50%');
+    expect(s).toContain('30-day');
+    expect(s).toContain('75%');
+  });
+
+  it('contributionSummary omits optional fields when absent', () => {
+    const edge: CausalEdge = {
+      id: 'e', type: 'CausalEdge', specVersion: '0.1.0', graphRef: 'g',
+      fromRef: 'a', toRef: 'b', sign: 'positive', warrantRefs: ['w'],
+    };
+    const s = contributionSummary(edge);
+    expect(s).toBe('raises');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/CausalGraphView.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/CausalGraphView.smoke.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Smoke test for the CausalGraphView page.
+ *
+ * The view mounts, calls assertWellFormed at construction, and renders one
+ * hypothesis row per hypothesis and one edge row per edge. Toggling an edge
+ * opens the warrant drill-down so the "every surface shows its warrant"
+ * principle is visible not just declared.
+ */
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import CausalGraphView from '../pages/CausalGraphView.vue';
+import { demoAutoPartsSnapshot } from '../features/causal-graph/state';
+
+describe('CausalGraphView', () => {
+  it('renders one row per hypothesis and one per edge from the demo snapshot', () => {
+    const w = mount(CausalGraphView);
+    expect(w.findAll('.hypothesis').length).toBe(demoAutoPartsSnapshot.hypotheses.length);
+    expect(w.findAll('.edge').length).toBe(demoAutoPartsSnapshot.edges.length);
+  });
+
+  it('surfaces the source-document warrant when an edge is clicked', async () => {
+    const w = mount(CausalGraphView);
+    // No drill-down visible before click.
+    expect(w.find('.edge .drill-down').exists()).toBe(false);
+
+    await w.find('.edge .row').trigger('click');
+
+    const drilled = w.find('.edge .drill-down');
+    expect(drilled.exists()).toBe(true);
+    // The auto-parts fixture references a document — the surface must show it.
+    expect(drilled.text()).toContain('urn:srcos:doc:');
+  });
+
+  it('shows a distinct severity badge per claim status', () => {
+    const w = mount(CausalGraphView);
+    const tones = w.findAll('.badge').map((b) => b.attributes('data-tone'));
+    // The demo has both evidenced and proposed hypotheses.
+    expect(new Set(tones).size).toBeGreaterThan(1);
+  });
+});

--- a/socioprophet-web/client-vue/src/features/causal-graph/state.ts
+++ b/socioprophet-web/client-vue/src/features/causal-graph/state.ts
@@ -1,0 +1,202 @@
+/**
+ * Cockpit read-model helpers for CausalGraphSnapshot.
+ *
+ * Three query functions the render layer needs:
+ *   - warrantsForEdge / warrantsForHypothesis: the "every surface shows its
+ *     warrant" primitive (W11). Renders on hover, click, drill-down.
+ *   - severityBadge: what claim status a hypothesis reports today, in the
+ *     five-axis claim verdict vocabulary (proposed / evidenced / scored).
+ *   - contributionSummary: a first-cut narrative for an edge — sign,
+ *     magnitude, lag, confidence — kept as pure text so the render layer
+ *     can drop it in without formatting concerns. The cockpit does NOT
+ *     compute propagation itself; that is the engine's job (economic-prophet
+ *     `causal_graph.propagate`). This module is display, not maths.
+ *
+ * Stateless module. `demoAutoPartsSnapshot` gives the smoke test and any
+ * initial route a real graph to render; production surfaces will fetch a
+ * CausalGraphSnapshot from the API.
+ */
+
+import type {
+  CausalEdge,
+  CausalGraphSnapshot,
+  CausalHypothesis,
+  ClaimStatus,
+  WarrantSummary,
+} from './types';
+
+export function warrantsForEdge(
+  snapshot: CausalGraphSnapshot,
+  edge: CausalEdge,
+): WarrantSummary[] {
+  return edge.warrantRefs
+    .map((ref) => snapshot.warrants[ref])
+    .filter((w): w is WarrantSummary => Boolean(w));
+}
+
+export function warrantsForHypothesis(
+  snapshot: CausalGraphSnapshot,
+  hypothesis: CausalHypothesis,
+): WarrantSummary[] {
+  return hypothesis.warrantRefs
+    .map((ref) => snapshot.warrants[ref])
+    .filter((w): w is WarrantSummary => Boolean(w));
+}
+
+export interface SeverityBadge {
+  status: ClaimStatus;
+  label: string;
+  tone: 'neutral' | 'informational' | 'confident';
+}
+
+const BADGES: Record<ClaimStatus, SeverityBadge> = {
+  proposed: {
+    status: 'proposed', label: 'Proposed', tone: 'neutral',
+  },
+  evidenced: {
+    status: 'evidenced', label: 'Evidenced', tone: 'informational',
+  },
+  scored: {
+    status: 'scored', label: 'Scored', tone: 'confident',
+  },
+};
+
+export function severityBadge(hypothesis: CausalHypothesis): SeverityBadge {
+  return BADGES[hypothesis.claimStatus];
+}
+
+export function contributionSummary(edge: CausalEdge): string {
+  const direction = edge.sign === 'positive' ? 'raises' : 'lowers';
+  const weightPart = edge.weight === undefined
+    ? '' : ` (magnitude ${(edge.weight * 100).toFixed(0)}%)`;
+  const lagPart = edge.lagDays === undefined
+    ? '' : ` with a ${edge.lagDays}-day lag`;
+  const confPart = edge.confidence === undefined
+    ? '' : `, confidence ${(edge.confidence * 100).toFixed(0)}%`;
+  return `${direction}${weightPart}${lagPart}${confPart}`;
+}
+
+/**
+ * Assert every edge in a snapshot has at least one warrant AND every
+ * referenced warrant id resolves to a WarrantSummary. Cockpit refuses to
+ * render an unwarranted edge — the same contract economic-prophet
+ * `causal_graph.propagate` enforces at the engine layer. A snapshot that
+ * fails this assertion is a fabric bug, not a display quirk.
+ */
+export function assertWellFormed(snapshot: CausalGraphSnapshot): void {
+  for (const edge of snapshot.edges) {
+    if (edge.warrantRefs.length === 0) {
+      throw new Error(
+        `CausalGraphSnapshot ${snapshot.graphRef}: edge ${edge.id} has no warrantRefs — unwarranted causality is inadmissible`,
+      );
+    }
+    for (const ref of edge.warrantRefs) {
+      if (!snapshot.warrants[ref]) {
+        throw new Error(
+          `CausalGraphSnapshot ${snapshot.graphRef}: edge ${edge.id} references warrant ${ref} not present in snapshot.warrants`,
+        );
+      }
+    }
+  }
+  const hypIds = new Set(snapshot.hypotheses.map((h) => h.id));
+  for (const edge of snapshot.edges) {
+    if (!hypIds.has(edge.fromRef) || !hypIds.has(edge.toRef)) {
+      throw new Error(
+        `CausalGraphSnapshot ${snapshot.graphRef}: edge ${edge.id} references a hypothesis not in this snapshot`,
+      );
+    }
+    if (edge.fromRef === edge.toRef) {
+      throw new Error(
+        `CausalGraphSnapshot ${snapshot.graphRef}: edge ${edge.id} is a self-loop`,
+      );
+    }
+  }
+}
+
+/** The IBM HOPE auto-parts worked example — a real graph the cockpit can render today. */
+export const demoAutoPartsSnapshot: CausalGraphSnapshot = {
+  graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+  displayName: 'Auto parts — worked HOPE example',
+  hypotheses: [
+    {
+      id: 'urn:srcos:causal-hypothesis:auto_parts_demo_tariffs',
+      type: 'CausalHypothesis',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      label: 'Tariffs',
+      hypothesis: 'Tariff rates on imported product parts change materially.',
+      topics: [
+        { kind: 'literal', value: 'tariffs' },
+        { kind: 'literal', value: 'automotive' },
+      ],
+      claimStatus: 'evidenced',
+      warrantRefs: ['urn:srcos:evidence:atom_asx_gyg_tariff_2026_07'],
+    },
+    {
+      id: 'urn:srcos:causal-hypothesis:auto_parts_demo_op_cost',
+      type: 'CausalHypothesis',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      label: 'Operation cost',
+      hypothesis: 'Operating costs change materially for the parts manufacturer.',
+      topics: [{ kind: 'literal', value: 'operations' }],
+      claimStatus: 'evidenced',
+      warrantRefs: ['urn:srcos:evidence:atom_op_cost_2026_q2'],
+    },
+    {
+      id: 'urn:srcos:causal-hypothesis:auto_parts_demo_revenue',
+      type: 'CausalHypothesis',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      label: 'Revenue',
+      hypothesis: 'Quarterly revenue for the modeled manufacturer changes materially.',
+      topics: [{ kind: 'template', value: 'customer_name' }],
+      claimStatus: 'proposed',
+      warrantRefs: [],
+    },
+  ],
+  edges: [
+    {
+      id: 'urn:srcos:causal-edge:auto_parts_demo_tariffs_op_cost',
+      type: 'CausalEdge',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      fromRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_tariffs',
+      toRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_op_cost',
+      sign: 'positive', weight: 0.6, lagDays: 45, confidence: 0.75,
+      warrantRefs: ['urn:srcos:evidence:atom_asx_gyg_tariff_2026_07'],
+    },
+    {
+      id: 'urn:srcos:causal-edge:auto_parts_demo_op_cost_revenue',
+      type: 'CausalEdge',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      fromRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_op_cost',
+      toRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_revenue',
+      sign: 'negative', weight: 0.5, lagDays: 30, confidence: 0.7,
+      warrantRefs: ['urn:srcos:evidence:atom_op_cost_2026_q2'],
+    },
+    {
+      id: 'urn:srcos:causal-edge:auto_parts_demo_tariffs_revenue_direct',
+      type: 'CausalEdge',
+      specVersion: '0.1.0',
+      graphRef: 'urn:srcos:causal-graph:auto_parts_demo',
+      fromRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_tariffs',
+      toRef: 'urn:srcos:causal-hypothesis:auto_parts_demo_revenue',
+      sign: 'negative', weight: 0.4, lagDays: 90, confidence: 0.6,
+      warrantRefs: ['urn:srcos:evidence:atom_asx_gyg_tariff_2026_07'],
+    },
+  ],
+  warrants: {
+    'urn:srcos:evidence:atom_asx_gyg_tariff_2026_07': {
+      id: 'urn:srcos:evidence:atom_asx_gyg_tariff_2026_07',
+      sourceDocRef: 'urn:srcos:doc:asx_gyg_annual_2026',
+      excerpt: 'Tariff exposure on imported components remains material to FY2026 unit economics.',
+    },
+    'urn:srcos:evidence:atom_op_cost_2026_q2': {
+      id: 'urn:srcos:evidence:atom_op_cost_2026_q2',
+      sourceDocRef: 'urn:srcos:doc:internal_q2_ops_review',
+      excerpt: 'Q2 operating-cost review notes a 3.4% uplift attributable to tariff pass-through.',
+    },
+  },
+};

--- a/socioprophet-web/client-vue/src/features/causal-graph/types.ts
+++ b/socioprophet-web/client-vue/src/features/causal-graph/types.ts
@@ -1,0 +1,81 @@
+/**
+ * TypeScript types mirroring the causal-graph contracts shipped in
+ * sourceos-spec PR #209 (CausalHypothesis, CausalEdge) and the MPCC channel
+ * envelopes shipped in profit-mpcc #7.
+ *
+ * These are cockpit-side types — the schemas of record live in sourceos-spec.
+ * They mirror the shape so the client can render, drill down, and route
+ * without having to re-derive the vocabulary. When either canonical schema
+ * bumps, this file bumps to match: parity is enforced by
+ * src/__tests__/CausalGraphFixtureShape.test.ts, which asserts every
+ * required field of the shipped v0.1 contracts appears on a fixture the
+ * cockpit already renders.
+ *
+ * DELIBERATE OMISSIONS. This is the read-side shape. It carries the
+ * signal a viewer needs (label, hypothesis text, warrants, sign, weight,
+ * lag, confidence, claim status) and NOT extraction internals (extractor
+ * digests, KKO ontology refs, ER cluster refs) — those are payload
+ * concerns for the ingest layer, not display concerns. A callable can
+ * request the full document; the cockpit view uses this subset.
+ */
+
+export type SpecVersion = '0.1.0';
+
+export type ClaimStatus = 'proposed' | 'evidenced' | 'scored';
+export type EdgeSign = 'positive' | 'negative';
+
+export interface TopicRef {
+  kind: 'literal' | 'template';
+  value: string;
+}
+
+export interface CausalHypothesis {
+  id: string;                    // urn:srcos:causal-hypothesis:...
+  type: 'CausalHypothesis';
+  specVersion: SpecVersion;
+  graphRef: string;              // urn:srcos:causal-graph:...
+  label: string;                 // display label — "Tariffs", "Revenue"
+  hypothesis: string;            // direction-neutral falsifiable statement
+  topics: TopicRef[];
+  claimStatus: ClaimStatus;
+  warrantRefs: string[];         // urn:srcos:evidence:...
+}
+
+export interface CausalEdge {
+  id: string;                    // urn:srcos:causal-edge:...
+  type: 'CausalEdge';
+  specVersion: SpecVersion;
+  graphRef: string;
+  fromRef: string;               // hypothesis id
+  toRef: string;                 // hypothesis id
+  sign: EdgeSign;                // polarity lives ONLY here
+  weight?: number;               // magnitude in [0,1]
+  lagDays?: number;
+  confidence?: number;           // in [0,1]
+  warrantRefs: string[];         // mandatory + non-empty by contract
+}
+
+/**
+ * A warrant surfaced in the cockpit. This is what "every surface shows its
+ * warrant" (the W11 cockpit-UX register principle) resolves to for the
+ * viewer: the id, the source-document reference, and a short human excerpt.
+ *
+ * The full warrant lives in the evidence-intake-kernel catalog now that
+ * `evidence-intake-kernel#1` shipped hash-chained storage; this is the
+ * display projection.
+ */
+export interface WarrantSummary {
+  id: string;                    // urn:srcos:evidence:...
+  sourceDocRef: string;          // e.g. urn:srcos:doc:asx_gyg_annual_2026
+  excerpt: string;               // short human quote
+  ledgerChainDigest?: string;    // sha256:... if fetched from the eik chain
+}
+
+/** A single graph as rendered in the cockpit — hypotheses + edges + warrant lookup. */
+export interface CausalGraphSnapshot {
+  graphRef: string;
+  displayName: string;
+  hypotheses: CausalHypothesis[];
+  edges: CausalEdge[];
+  warrants: Record<string, WarrantSummary>;
+}

--- a/socioprophet-web/client-vue/src/pages/CausalGraphView.vue
+++ b/socioprophet-web/client-vue/src/pages/CausalGraphView.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+/**
+ * CausalGraphView — read-only cockpit surface for a CausalGraphSnapshot.
+ *
+ * Minimal by design. This is the plumbing: it demonstrates that a snapshot
+ * loaded from the API round-trips into a rendered surface, and that every
+ * edge exposes its warrant on click. Styling and interactive layout come
+ * later; a designer or later PR can turn the list into a real DAG.
+ *
+ * What the surface commits to today (the W11 principle):
+ *   - Every edge line shows its warrant excerpts on demand.
+ *   - Every hypothesis reports its claim status distinctly (proposed /
+ *     evidenced / scored), so a viewer can tell a well-evidenced contested
+ *     claim from a thinly-sourced confident one.
+ *   - Nothing renders that hasn't passed assertWellFormed — an unwarranted
+ *     edge or a broken snapshot throws, not silently displays.
+ */
+import { computed, ref } from 'vue';
+import {
+  assertWellFormed,
+  contributionSummary,
+  demoAutoPartsSnapshot,
+  severityBadge,
+  warrantsForEdge,
+  warrantsForHypothesis,
+} from '../features/causal-graph/state';
+import type { CausalEdge, CausalHypothesis } from '../features/causal-graph/types';
+
+const snapshot = ref(demoAutoPartsSnapshot);
+
+// Validate at mount time; a malformed snapshot is a bug to surface, not to render.
+assertWellFormed(snapshot.value);
+
+const hypothesisById = computed(() => {
+  const m: Record<string, CausalHypothesis> = {};
+  for (const h of snapshot.value.hypotheses) m[h.id] = h;
+  return m;
+});
+
+const expandedEdgeId = ref<string | null>(null);
+const expandedHypId = ref<string | null>(null);
+
+function toggleEdge(edge: CausalEdge) {
+  expandedEdgeId.value = expandedEdgeId.value === edge.id ? null : edge.id;
+}
+function toggleHyp(h: CausalHypothesis) {
+  expandedHypId.value = expandedHypId.value === h.id ? null : h.id;
+}
+</script>
+
+<template>
+  <section class="causal-graph-view">
+    <header>
+      <h1>{{ snapshot.displayName }}</h1>
+      <p class="graph-ref">
+        <code>{{ snapshot.graphRef }}</code>
+      </p>
+    </header>
+
+    <section class="hypotheses" aria-label="Hypotheses">
+      <h2>Hypotheses</h2>
+      <ul>
+        <li
+          v-for="h in snapshot.hypotheses"
+          :key="h.id"
+          class="hypothesis"
+        >
+          <button class="row" @click="toggleHyp(h)">
+            <span class="label">{{ h.label }}</span>
+            <span class="badge" :data-tone="severityBadge(h).tone">
+              {{ severityBadge(h).label }}
+            </span>
+          </button>
+          <p class="statement">{{ h.hypothesis }}</p>
+          <div v-if="expandedHypId === h.id" class="drill-down">
+            <p v-if="warrantsForHypothesis(snapshot, h).length === 0" class="no-warrants">
+              No warrants attached yet — status is
+              <em>{{ h.claimStatus }}</em>.
+            </p>
+            <ul v-else class="warrants">
+              <li
+                v-for="w in warrantsForHypothesis(snapshot, h)"
+                :key="w.id"
+              >
+                <p class="excerpt">"{{ w.excerpt }}"</p>
+                <p class="source"><code>{{ w.sourceDocRef }}</code></p>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <section class="edges" aria-label="Causal edges">
+      <h2>Causal edges</h2>
+      <ul>
+        <li
+          v-for="edge in snapshot.edges"
+          :key="edge.id"
+          class="edge"
+        >
+          <button class="row" @click="toggleEdge(edge)">
+            <span class="direction">
+              {{ hypothesisById[edge.fromRef]?.label ?? edge.fromRef }}
+              →
+              {{ hypothesisById[edge.toRef]?.label ?? edge.toRef }}
+            </span>
+            <span class="sign" :data-sign="edge.sign">
+              {{ edge.sign }}
+            </span>
+          </button>
+          <p class="summary">{{ contributionSummary(edge) }}</p>
+          <div v-if="expandedEdgeId === edge.id" class="drill-down">
+            <h3>Warrants</h3>
+            <ul class="warrants">
+              <li
+                v-for="w in warrantsForEdge(snapshot, edge)"
+                :key="w.id"
+              >
+                <p class="excerpt">"{{ w.excerpt }}"</p>
+                <p class="source"><code>{{ w.sourceDocRef }}</code></p>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
+  </section>
+</template>
+
+<style scoped>
+.causal-graph-view { padding: 1rem 1.5rem; max-width: 900px; }
+h1 { margin: 0 0 0.25rem; }
+.graph-ref code { font-size: 0.85em; opacity: 0.7; }
+section + section { margin-top: 1.5rem; }
+h2 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.7; }
+ul { list-style: none; padding: 0; margin: 0.5rem 0 0; }
+.hypothesis, .edge {
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 0.5rem;
+}
+.row { display: flex; justify-content: space-between; align-items: center; width: 100%;
+  background: none; border: 0; padding: 0; color: inherit; cursor: pointer; font-size: 1rem; }
+.label, .direction { font-weight: 600; }
+.badge { font-size: 0.75rem; padding: 0.15rem 0.5rem; border-radius: 3px; opacity: 0.9; }
+.badge[data-tone="neutral"] { background: rgba(120,120,120,0.25); }
+.badge[data-tone="informational"] { background: rgba(80,150,220,0.3); }
+.badge[data-tone="confident"] { background: rgba(80,200,120,0.3); }
+.sign[data-sign="positive"] { color: #7dd39a; }
+.sign[data-sign="negative"] { color: #e39a7d; }
+.statement, .summary { margin: 0.4rem 0 0; font-size: 0.9rem; opacity: 0.85; }
+.drill-down { margin-top: 0.75rem; padding-top: 0.5rem; border-top: 1px dashed rgba(255,255,255,0.15); }
+.excerpt { font-style: italic; margin: 0 0 0.25rem; }
+.source code { font-size: 0.8em; opacity: 0.7; }
+.no-warrants em { font-style: normal; opacity: 0.8; }
+</style>


### PR DESCRIPTION
## What changed

Closes [#472](https://github.com/SocioProphet/socioprophet/issues/472). **Completes the three epistemic-kernel program downstreams** in a single trio: [sourceos-spec #209](https://github.com/SourceOS-Linux/sourceos-spec/pull/209) shipped `CausalHypothesis`/`CausalEdge`; [economic-prophet #32](https://github.com/SocioProphet/economic-prophet/pull/32) landed the engine; [profit-mpcc #7](https://github.com/SocioProphet/profit-mpcc/pull/7) landed the fabric channels; this PR lands the cockpit surface.

**Deliberately minimal.** The plumbing that proves a `CausalGraphSnapshot` from the fabric round-trips into a rendered surface, with the *every surface shows its warrant* principle (W11 cockpit-UX register) demonstrated end-to-end. A designer's polish pass turns the list into a real DAG layout later; this PR is the data path.

- `src/features/causal-graph/types.ts` — TypeScript mirror of the shipped v0.1 subset the cockpit renders. Ingest-only fields (`kkoTypeRef`, `entityClusterRef`, `extractor` digests) deliberately omitted; schemas of record stay in sourceos-spec.
- `src/features/causal-graph/state.ts` — read-model helpers: `warrantsForEdge`, `warrantsForHypothesis` (the W11 primitive), `severityBadge` with a distinct tone per claim status, `contributionSummary` as pure text, and `assertWellFormed` which **refuses to render unwarranted edges, missing endpoints, self-loops, or unresolvable warrant lookups**. Same contract economic-prophet #32 enforces at the engine layer — the read layer and the compute layer agree on what a well-formed graph looks like.
- `src/pages/CausalGraphView.vue` — read-only page. Rows per hypothesis and per edge, click-to-drill-down warrants. Calls `assertWellFormed` at mount: a malformed snapshot is a bug to surface, not to silently display.

## Exact commands run

```
npx vitest run src/__tests__/CausalGraph
npm run typecheck
npm run test
```

## Pass/fail summary

- **New tests: 15 passed** across two files. `CausalGraphFixtureShape.test.ts` pins parity with the shipped v0.1 contracts (a drift in the mirror fails the build) and exercises every invariant. `CausalGraphView.smoke.test.ts` confirms the surface renders and warrant drill-down actually shows the source-document URN.
- Full client-vue suite: **437 passed, 0 failed.** No regressions.
- Typecheck: **clean.**

## Known gaps

- **Route not wired into `main.ts`**. That file has ~90 page imports and adding another one deserves a designer's decision about nav placement, not this PR. The page mounts standalone and is exercised end-to-end by the smoke test.
- **Not a DAG layout yet.** Rows over lines. A real graph rendering (edge crossings, sink at revenue, etc.) is where a design pass belongs — this PR proves the data reaches a Vue component and the drill-down works.
- **Snapshot is inlined** in `state.ts` as `demoAutoPartsSnapshot`. Production surfaces will fetch via the API (a `causalGraphApi.ts` alongside the existing `causalValuationApi.ts` pattern), which is follow-up. Keeping the demo inline for this PR so the smoke test doesn't need a mock adapter.
- **No 'backward reasoning' UI**. Forward propagation runs on the economic-prophet engine; the abduction path (KPI → ranked causal explanations) that HOPE deferred is queued for the engine PR after eco-prophet #32.

## Blocked

Nothing.