### PR TITLE
fix(shape-c): stop deploy-model and fixture checks evaporating under python -O

### DIFF
--- a/formal/check_deploy_model.py
+++ b/formal/check_deploy_model.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 
 BUNDLES = ("A", "B")
 
+
+class DeployModelViolation(AssertionError):
+    """A deploy-model invariant failed during state-space exploration."""
+
+
+def require(condition: object, message: str) -> None:
+    """Invariant check that survives `python -O`.
+
+    `inv()` IS the proof obligation of this model checker: it is the only thing
+    standing between the explored state space and the claim printed at the end.
+    Written with bare `assert`, every one of those obligations was deleted by
+    `python -O` while `explore()` still walked the full state space and printed
+    `{"status": "PASS", "states_explored": N}` — a formal check reporting PASS
+    for invariants it never evaluated. The failure mode is silent and total: no
+    error, no diagnostic, a green run, and a deploy model nobody verified.
+    A check a runtime flag can switch off is not a check.
+    """
+    if not condition:
+        raise DeployModelViolation(message)
+
 base_exists = {"A": True, "B": True}
 base_lane = {"A": "staging", "B": "prod"}
 base_closed = {"A": True, "B": True}
@@ -23,12 +43,12 @@ def inv(state):
     for p in ("current-staging", "current-prod", "previous-good"):
         b = ptr[p]
         if b is not None:
-            assert exists[b], f"{p} points to non-existent bundle"
-            assert closed[b], f"{p} points to non-closed bundle"
-            assert coherent[b], f"{p} points to incoherent bundle"
-            assert replayable[b], f"{p} points to non-replayable bundle"
+            require(exists[b], f"{p} points to non-existent bundle")
+            require(closed[b], f"{p} points to non-closed bundle")
+            require(coherent[b], f"{p} points to incoherent bundle")
+            require(replayable[b], f"{p} points to non-replayable bundle")
     if ptr["current-prod"] is not None:
-        assert lane[ptr["current-prod"]] == "prod", "current-prod must point to prod-lane bundle"
+        require(lane[ptr["current-prod"]] == "prod", "current-prod must point to prod-lane bundle")
 
 
 def next_states(state):

--- a/scripts/smoke_build_event_orchestration_fixture.py
+++ b/scripts/smoke_build_event_orchestration_fixture.py
@@ -13,6 +13,24 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 BUILDER_PATH = ROOT / "scripts" / "build_event_orchestration_fixture.py"
 
 
+class SmokeFailure(RuntimeError):
+    """A round-trip assertion on the built fixture failed."""
+
+
+def require(condition: object, message: str) -> None:
+    """Check that survives `python -O`.
+
+    These are the only statements that inspect what was actually written to
+    disk. Under `python -O` every `assert` here was stripped, the function ran
+    to completion and printed "event orchestration fixture builder smoke
+    passed" for a fixture whose readOnly flag, record count and admission
+    summary had gone entirely unread. The smoke test reported success for work
+    it never checked.
+    """
+    if not condition:
+        raise SmokeFailure(message)
+
+
 def load_builder() -> Any:
     spec = importlib.util.spec_from_file_location("build_event_orchestration_fixture", BUILDER_PATH)
     if spec is None or spec.loader is None:
@@ -136,11 +154,20 @@ def main() -> int:
             raise SystemExit("fixture validation failed: " + "; ".join(errors))
         builder.write_json(out, fixture)
         reloaded = json.loads(out.read_text(encoding="utf-8"))
-        assert reloaded["readOnly"] is True
-        assert reloaded["mode"] == "fixture"
-        assert len(reloaded["eventCapabilityRecords"]) == 3
-        assert reloaded["agentplaneAdmission"]["summary"]["invalid"] == 0
-        assert reloaded["sourceosQueue"]["non_mutating"] is True
+        require(reloaded["readOnly"] is True, "round-tripped fixture must stay readOnly")
+        require(reloaded["mode"] == "fixture", "round-tripped fixture must stay in fixture mode")
+        require(
+            len(reloaded["eventCapabilityRecords"]) == 3,
+            f"expected 3 eventCapabilityRecords, got {len(reloaded['eventCapabilityRecords'])}",
+        )
+        require(
+            reloaded["agentplaneAdmission"]["summary"]["invalid"] == 0,
+            "agentplane admission must report zero invalid records",
+        )
+        require(
+            reloaded["sourceosQueue"]["non_mutating"] is True,
+            "sourceos queue must stay non-mutating",
+        )
     print("event orchestration fixture builder smoke passed")
     return 0
 


### PR DESCRIPTION
## Shape C1 — assertions that evaporate

Two tools did real verification with bare `assert`. `python -O` strips every `assert`; neither tool noticed, and both still reported success.

### `formal/check_deploy_model.py` — highest blast radius
`inv()` **is** the proof obligation of this model checker. Under `-O` it became a no-op while `explore()` still walked the full state space and printed `{"status": "PASS", "states_explored": 9}` — a formal check reporting PASS for invariants it never evaluated, including *"current-prod must point to prod-lane bundle"*.

Invoked by `agentplane/tests/run_ci_checks.sh:137` (workflow `agentplane-deployment-invariants.yml`) and `formal/run_apalache.sh:6`.

**Revert-proof** — `inv()` called on a state pointing `current-prod` at a staging-lane, non-replayable bundle:

| | normal | `python -O` |
|---|---|---|
| before | AssertionError | **returned cleanly — check evaporated** |
| after | DeployModelViolation | DeployModelViolation |

### `scripts/smoke_build_event_orchestration_fixture.py`
The five round-trip checks are the only statements that read what actually landed on disk. Invoked by `event-orchestration-workbench.yml:40`.

**Revert-proof** — injecting a `write_json` that corrupts the fixture *after* `validate_fixture` passes (the exact write/round-trip bug these checks exist to catch): before, under `-O`, it printed `event orchestration fixture builder smoke passed` and returned 0. After: `SmokeFailure: round-tripped fixture must stay readOnly`.

Clean runs still pass under both `python3` and `python3 -O`.

## Notes
- Scanned from a materialized `master` tree at pinned SHA `0c98bf5`, not a worktree.
- `tools/ci/check_doctrine_contract.py:35` also uses `assert`, but it is type-narrowing on a list built two lines above — not verification. Deliberately left alone rather than inflate the count.