### PR TITLE
fix(notebook): sanitize v-html on cell outputs (XSS via SVG/HTML)

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioNotebooks.vue
+++ b/socioprophet-web/app-vue/src/components/StudioNotebooks.vue
@@ -184,8 +184,18 @@ async function toggleChain() {
             <template v-for="(o, i) in cell.outputs" :key="i">
               <!-- rich: plots (png/svg) and tables/HTML (DataFrame._repr_html_) — real DS output -->
               <img v-if="o.png" class="rich" :src="'data:image/png;base64,' + o.png" alt="cell output" />
-              <div v-else-if="o.svg" class="rich" v-html="o.svg" />
-              <div v-else-if="o.html" class="rich htmlout" v-html="o.html" />
+              <!-- v-html on notebook cell output is untrusted (pandas _repr_html_,
+                   IPython.display.HTML, a compromised BFF over /api/studio/notebook/
+                   execute) — see fix in client-vue/src/utils/sanitizeHtml.ts. app-vue
+                   does not carry DOMPurify (the deploy pipeline uses `npm ci` and I do
+                   not want to hand-edit the lock file), so the two paths fail closed
+                   here: rich rendering is disabled and the operator is told where the
+                   full-fidelity notebook lives. Migration to client-vue is in progress. -->
+              <div v-else-if="o.svg || o.html" class="rich odeg" role="status">
+                ⛨ rich output (SVG/HTML) not rendered on the legacy cockpit — open in the
+                unified cockpit at <a href="/cockpit" rel="noopener">{{ '/cockpit' }}</a>
+                to view.
+              </div>
               <pre v-else-if="o.type === 'error'" class="oerr">{{ o.ename }}: {{ o.evalue }}</pre>
               <div v-else-if="o.type === 'degraded'" class="odeg">⚠ {{ o.text }}</div>
               <pre v-else class="stream">{{ o.text }}</pre>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
@@ -4,6 +4,7 @@ import {
   loadNotebookAdapters, createNotebookSession, executeCell, loadNotebookReceipts, proposeCell,
   type NbAdapter, type NbSession, type NbOutput, type NbReceipt,
 } from "../../services/studioApi";
+import { sanitizeCellHtml, sanitizeCellSvg } from "../../utils/sanitizeHtml";
 
 // a tiny inline bar chart (epistemic-coloured) to demonstrate rich output rendering in the preview
 const MINI_SVG = `<svg viewBox="0 0 260 120" width="260" height="120" xmlns="http://www.w3.org/2000/svg">
@@ -184,8 +185,8 @@ async function toggleChain() {
             <template v-for="(o, i) in cell.outputs" :key="i">
               <!-- rich: plots (png/svg) and tables/HTML (DataFrame._repr_html_) — real DS output -->
               <img v-if="o.png" class="rich" :src="'data:image/png;base64,' + o.png" alt="cell output" />
-              <div v-else-if="o.svg" class="rich" v-html="o.svg" />
-              <div v-else-if="o.html" class="rich htmlout" v-html="o.html" />
+              <div v-else-if="o.svg" class="rich" v-html="sanitizeCellSvg(o.svg)" />
+              <div v-else-if="o.html" class="rich htmlout" v-html="sanitizeCellHtml(o.html)" />
               <pre v-else-if="o.type === 'error'" class="oerr">{{ o.ename }}: {{ o.evalue }}</pre>
               <div v-else-if="o.type === 'degraded'" class="odeg">⚠ {{ o.text }}</div>
               <pre v-else class="stream">{{ o.text }}</pre>

--- a/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioNotebooks.vue
@@ -4,7 +4,7 @@ import {
   loadNotebookAdapters, createNotebookSession, executeCell, loadNotebookReceipts, proposeCell,
   type NbAdapter, type NbSession, type NbOutput, type NbReceipt,
 } from "../../services/studioApi";
-import { sanitizeCellHtml, sanitizeCellSvg } from "../../utils/sanitizeHtml";
+import { sanitizeCellHtmlMemo, sanitizeCellSvgMemo } from "../../utils/sanitizeHtml";
 
 // a tiny inline bar chart (epistemic-coloured) to demonstrate rich output rendering in the preview
 const MINI_SVG = `<svg viewBox="0 0 260 120" width="260" height="120" xmlns="http://www.w3.org/2000/svg">
@@ -185,8 +185,8 @@ async function toggleChain() {
             <template v-for="(o, i) in cell.outputs" :key="i">
               <!-- rich: plots (png/svg) and tables/HTML (DataFrame._repr_html_) — real DS output -->
               <img v-if="o.png" class="rich" :src="'data:image/png;base64,' + o.png" alt="cell output" />
-              <div v-else-if="o.svg" class="rich" v-html="sanitizeCellSvg(o.svg)" />
-              <div v-else-if="o.html" class="rich htmlout" v-html="sanitizeCellHtml(o.html)" />
+              <div v-else-if="o.svg" class="rich" v-html="sanitizeCellSvgMemo(o.svg)" />
+              <div v-else-if="o.html" class="rich htmlout" v-html="sanitizeCellHtmlMemo(o.html)" />
               <pre v-else-if="o.type === 'error'" class="oerr">{{ o.ename }}: {{ o.evalue }}</pre>
               <div v-else-if="o.type === 'degraded'" class="odeg">⚠ {{ o.text }}</div>
               <pre v-else class="stream">{{ o.text }}</pre>

--- a/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
+++ b/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
@@ -11,6 +11,14 @@
 import DOMPurify from 'dompurify';
 
 const HTML_OPTS: DOMPurify.Config = {
+  // Copilot round-2: pin the sanitiser to the HTML profile. Without this DOMPurify
+  // permits SVG and MathML inside an HTML payload, which reopens the SVG-smuggle
+  // surface `sanitizeCellSvg` was split out to police — an attacker could ship an
+  // `<svg><foreignObject>` carrying `<script>` inside what claims to be
+  // pandas' `_repr_html_` and bypass the stricter SVG allowlist. SVG cells go
+  // through `sanitizeCellSvg`; anything shaped like SVG in an HTML cell is
+  // deliberately dropped here.
+  USE_PROFILES: { html: true },
   // The chat path opts in `target` and `rel` for its markdown links; notebook HTML
   // can carry the same on plain <a>, so keep the same additions.
   ADD_ATTR: ['target', 'rel'],
@@ -32,4 +40,41 @@ export function sanitizeCellHtml(input: unknown): string {
 export function sanitizeCellSvg(input: unknown): string {
   if (typeof input !== 'string') return '';
   return DOMPurify.sanitize(input, SVG_OPTS);
+}
+
+// Copilot round-2: sanitising in the template means DOMPurify runs on every render
+// (a large DataFrame HTML repr can be tens of KB — Vue reactivity re-runs it any
+// time an unrelated cell mutates). Memoise by INPUT-STRING IDENTITY so a stable
+// cell output is sanitised exactly once per lifetime, and the cache is bounded
+// (~200 entries) with LRU-lite eviction so a chatty runtime cannot balloon it.
+const CACHE_MAX = 200;
+const htmlCache = new Map<string, string>();
+const svgCache = new Map<string, string>();
+
+function cached(cache: Map<string, string>, input: string, run: (s: string) => string): string {
+  const hit = cache.get(input);
+  if (hit !== undefined) {
+    // Touch: re-insert to move to the end of the Map's insertion order (JS Map is
+    // insertion-ordered, so the OLDEST key is `keys().next().value`).
+    cache.delete(input);
+    cache.set(input, hit);
+    return hit;
+  }
+  const out = run(input);
+  cache.set(input, out);
+  if (cache.size > CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  return out;
+}
+
+export function sanitizeCellHtmlMemo(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  return cached(htmlCache, input, (s) => DOMPurify.sanitize(s, HTML_OPTS));
+}
+
+export function sanitizeCellSvgMemo(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  return cached(svgCache, input, (s) => DOMPurify.sanitize(s, SVG_OPTS));
 }

--- a/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
+++ b/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
@@ -1,0 +1,35 @@
+// Sanitise HTML/SVG that arrives from the notebook runtime before it is committed
+// to `v-html`. Cell outputs are untrusted by construction — pandas' `_repr_html_`,
+// an `IPython.display.HTML(...)`, an `<img onerror>` slipped into a shared cell, or
+// a compromised BFF response over `/api/studio/notebook/execute` all render through
+// the same path. Vue does NOT sanitise `v-html`; without this the event handlers
+// run in the operator's tab, against every endpoint the cockpit is authenticated to.
+//
+// DOMPurify is already the shipped pattern for the chat markdown path — see
+// `renderMarkdown` in `./markdown.ts`. Using it here keeps notebook rendering on
+// the same audited allowlist rather than inventing a second, weaker one.
+import DOMPurify from 'dompurify';
+
+const HTML_OPTS: DOMPurify.Config = {
+  // The chat path opts in `target` and `rel` for its markdown links; notebook HTML
+  // can carry the same on plain <a>, so keep the same additions.
+  ADD_ATTR: ['target', 'rel'],
+};
+
+const SVG_OPTS: DOMPurify.Config = {
+  // Cell PNGs go through `:src="'data:image/png;base64,'+..."`, but SVG plots
+  // (matplotlib, plotly static) come in as raw markup. Restrict DOMPurify to the
+  // SVG grammar rather than the HTML grammar so a stray `<script>` in an SVG is
+  // stripped and cannot smuggle in event handlers via foreignObject.
+  USE_PROFILES: { svg: true, svgFilters: true },
+};
+
+export function sanitizeCellHtml(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  return DOMPurify.sanitize(input, HTML_OPTS);
+}
+
+export function sanitizeCellSvg(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  return DOMPurify.sanitize(input, SVG_OPTS);
+}


### PR DESCRIPTION
fix(notebook): sanitize v-html on cell outputs (XSS via SVG/HTML)

StudioNotebooks.vue rendered `o.svg` and `o.html` from notebook cell
outputs through `v-html` with zero sanitization. Any cell producing
untrusted HTML/SVG (pandas `_repr_html_`, `IPython.display.HTML(...)`,
an `<img onerror>` slipped into a shared notebook, or a compromised
BFF response over `/api/studio/notebook/execute`) would execute event
handlers in the operator's tab, against any endpoint the cockpit is
authenticated to.

The chat markdown path (utils/markdown.ts) already funnels model output
through DOMPurify — the notebook path missed the same discipline.

### client-vue (canonical cockpit)

New helper `utils/sanitizeHtml.ts` — `sanitizeCellSvg` uses DOMPurify's
`USE_PROFILES: { svg: true, svgFilters: true }` so a stray `<script>`
inside an SVG (or a foreignObject smuggle) is stripped rather than
letting the SVG grammar be re-parsed as HTML; `sanitizeCellHtml` uses
the same `ADD_ATTR: ['target','rel']` allowlist as the chat path.
Applied in-template at lines 188-189.

### app-vue (legacy shell)

Deploy pipeline is `npm ci`, so adding DOMPurify requires a lock-file
regen I cannot do without running npm here. Fail closed: replace the
`v-html` render with a placeholder that directs the operator to the
unified cockpit at /cockpit. The functionality gap is visible and
honest; XSS surface is gone.

Found by the adversarial review of merged PRs (batch A) — surface
originally shipped in #443/#464.
