### PR TITLE
fix(cockpit): four v-for :key collisions in Studio surfaces

### DIFF
--- a/socioprophet-web/app-vue/src/components/StudioCompute.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCompute.vue
@@ -32,7 +32,7 @@ async function runPlan() {
   try {
     const res = await runCompute({ kind: "workflow", spec: p.spec as Record<string, unknown>, project: props.project });
     result.value = res;
-    if (res.status === "ok" || res.status === "degraded") chain.value.unshift(res);
+    appendToChain(res);
   } catch (e) {
     runErr.value = e instanceof Error ? e.message : "run failed";
   } finally {
@@ -111,7 +111,18 @@ const running = ref(false);
 const runErr = ref("");
 const result = ref<ComputeResultLite | null>(null);
 // the receipt chain: every sealed run in this session, newest first (the tamper-evident record).
-const chain = ref<ComputeResultLite[]>([]);
+// Each entry carries a per-session localId so `v-for :key` is stable even when a run
+// completed without a receipt id (degraded status, or a gateway that omitted it). Without
+// it the fallback `row-${i}` shifted every existing key on each unshift and Vue rebuilt
+// the whole list, losing signed/attest transition state per row (Copilot round-2).
+interface ChainEntry extends ComputeResultLite { localId: string }
+let _chainSeq = 0;
+const chain = ref<ChainEntry[]>([]);
+function appendToChain(res: ComputeResultLite) {
+  if (res.status === "ok" || res.status === "degraded") {
+    chain.value.unshift({ ...res, localId: `local-${++_chainSeq}` });
+  }
+}
 
 const canRun = computed(() => !!selected.value && !running.value && fields.value.some((f) => (spec[f.key] ?? "").trim().length > 0 || f.type === "select"));
 
@@ -150,7 +161,7 @@ async function run() {
   try {
     const res = await runCompute({ kind: k.kind, spec: payloadSpec, project: props.project, backend: backend.value || undefined });
     result.value = res;
-    if (res.status === "ok" || res.status === "degraded") chain.value.unshift(res);
+    appendToChain(res);
   } catch (e) {
     runErr.value = e instanceof Error ? e.message : "run failed";
   } finally {
@@ -382,7 +393,7 @@ function onKey(e: KeyboardEvent) { if (e.key === "Enter" && (e.shiftKey || e.ctr
       <!-- session receipt chain — the tamper-evident record of every run -->
       <div v-if="chain.length" class="chain">
         <div class="chain-head">⛨ Session receipt chain <span class="cn">{{ chain.length }}</span></div>
-        <div class="crow" v-for="(c, i) in chain" :key="c.receipt?.id ?? `row-${i}`">
+        <div class="crow" v-for="c in chain" :key="c.receipt?.id ?? c.localId">
           <span class="cdot" :style="{ background: EPISTEMIC_COLORS[c.epistemic_status] || 'var(--idle)' }" />
           <span class="mono cid">{{ c.receipt ? short(c.receipt.id) : '—' }}</span>
           <span class="ckind">{{ c.kind }} · {{ c.backend }}</span>

--- a/socioprophet-web/app-vue/src/components/StudioCompute.vue
+++ b/socioprophet-web/app-vue/src/components/StudioCompute.vue
@@ -382,7 +382,7 @@ function onKey(e: KeyboardEvent) { if (e.key === "Enter" && (e.shiftKey || e.ctr
       <!-- session receipt chain — the tamper-evident record of every run -->
       <div v-if="chain.length" class="chain">
         <div class="chain-head">⛨ Session receipt chain <span class="cn">{{ chain.length }}</span></div>
-        <div class="crow" v-for="(c, i) in chain" :key="i">
+        <div class="crow" v-for="(c, i) in chain" :key="c.receipt?.id ?? `row-${i}`">
           <span class="cdot" :style="{ background: EPISTEMIC_COLORS[c.epistemic_status] || 'var(--idle)' }" />
           <span class="mono cid">{{ c.receipt ? short(c.receipt.id) : '—' }}</span>
           <span class="ckind">{{ c.kind }} · {{ c.backend }}</span>

--- a/socioprophet-web/app-vue/src/components/StudioGraph.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGraph.vue
@@ -306,7 +306,7 @@ async function loadDerived() {
           </div>
           <div v-if="derived.derivation_count" class="dlist">
             <div class="dlbl">Derived / co-observed with</div>
-            <div v-for="(d, i) in derived.derivations" :key="i" class="drow">
+            <div v-for="d in derived.derivations" :key="`${d.direction}:${d.relation}:${d.with.id}`" class="drow">
               <span class="rel">{{ d.direction === 'out' ? '→' : '←' }} {{ d.relation }}</span>
               <span class="dwith">{{ d.with.name }}</span>
               <span class="dpill" :style="{ borderColor: color(d.with.epistemic_mode), color: color(d.with.epistemic_mode) }">{{ d.with.epistemic_mode }}</span>

--- a/socioprophet-web/app-vue/src/components/StudioQuery.vue
+++ b/socioprophet-web/app-vue/src/components/StudioQuery.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed } from "vue";
 import { runQuery, EPISTEMIC_COLORS, type QueryLang, type QueryResult } from "../services/studioApi";
 
 const props = defineProps<{ project: string }>();
@@ -32,6 +32,42 @@ async function run() {
 
 function epiOf(v: unknown): string | null { return result.value?.epistemic[String(v)] ?? null; }
 function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "var(--faint)"; }
+
+// Copilot round-2: computing `JSON.stringify(r).slice(...)` in the template ran on
+// every reactivity tick for every row (expensive on large result sets), and using
+// the loop index in the key meant DOM was recreated on any row-order change. Move
+// key derivation to a computed keyed off `result.value.rows` — recomputed only when
+// the result set itself changes, not per render. Keys are content-derived (a cheap
+// FNV-1a 32-bit rolling hash over the JSON serialisation, capped so a giant row
+// doesn't dominate) and disambiguated only when the same content appears twice, so
+// reordering the same rows preserves each row's DOM identity.
+function fnv1a32(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h >>> 0;
+}
+function rowSignature(r: Record<string, unknown>): string {
+  // Bounded: an unbounded JSON.stringify would defeat the point of moving off the
+  // template. 512 bytes of the canonical form is more than enough to distinguish
+  // rows in practice, and duplicate content collapses onto the disambiguator below.
+  const s = JSON.stringify(r);
+  return fnv1a32(s.length > 512 ? s.slice(0, 512) : s).toString(36);
+}
+const rowKeys = computed<string[]>(() => {
+  const rows = result.value?.rows ?? [];
+  const seen = new Map<string, number>();
+  return rows.map((r) => {
+    const sig = rowSignature(r as Record<string, unknown>);
+    const n = seen.get(sig) ?? 0;
+    seen.set(sig, n + 1);
+    // Same-content rows get a stable dup-index suffix so Vue doesn't collapse them,
+    // but a reorder of distinct rows produces identical keys → DOM stays with the row.
+    return n === 0 ? sig : `${sig}#${n}`;
+  });
+});
 </script>
 
 <template>
@@ -66,7 +102,7 @@ function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "var(--f
         <table class="qgrid">
           <thead><tr><th v-for="(c, colIdx) in result.columns" :key="`${c}:${colIdx}`">{{ c }}</th></tr></thead>
           <tbody>
-            <tr v-for="(r, i) in result.rows" :key="`${i}:${JSON.stringify(r).slice(0, 120)}`">
+            <tr v-for="(r, i) in result.rows" :key="rowKeys[i]">
               <td v-for="(c, colIdx) in result.columns" :key="`${c}:${colIdx}`">
                 <span class="val">{{ r[c] }}</span>
                 <span v-if="epiOf(r[c])" class="epi" :style="{ background: color(epiOf(r[c])!) }" :title="`epistemic: ${epiOf(r[c])}`" />

--- a/socioprophet-web/app-vue/src/components/StudioQuery.vue
+++ b/socioprophet-web/app-vue/src/components/StudioQuery.vue
@@ -64,10 +64,10 @@ function color(mode: string): string { return EPISTEMIC_COLORS[mode] || "var(--f
 
       <div v-if="result.columns.length" class="qscroll">
         <table class="qgrid">
-          <thead><tr><th v-for="c in result.columns" :key="c">{{ c }}</th></tr></thead>
+          <thead><tr><th v-for="(c, colIdx) in result.columns" :key="`${c}:${colIdx}`">{{ c }}</th></tr></thead>
           <tbody>
-            <tr v-for="(r, i) in result.rows" :key="i">
-              <td v-for="c in result.columns" :key="c">
+            <tr v-for="(r, i) in result.rows" :key="`${i}:${JSON.stringify(r).slice(0, 120)}`">
+              <td v-for="(c, colIdx) in result.columns" :key="`${c}:${colIdx}`">
                 <span class="val">{{ r[c] }}</span>
                 <span v-if="epiOf(r[c])" class="epi" :style="{ background: color(epiOf(r[c])!) }" :title="`epistemic: ${epiOf(r[c])}`" />
               </td>

--- a/socioprophet-web/app-vue/src/views/Studio.vue
+++ b/socioprophet-web/app-vue/src/views/Studio.vue
@@ -180,7 +180,7 @@ const actionsFor: Record<StudioSection, { label: string; hint: string }[]> = {
       <div class="rc-head"><b>Verified-compute receipts</b><span class="rc-sub">replayable proof-of-work · {{ receiptsData?.services_reachable ?? 0 }} services answering</span><button class="rc-x" @click="receiptsOpen = false" aria-label="Close receipts panel">✕</button></div>
       <div v-if="receiptsErr" class="rc-err">{{ receiptsErr }}</div>
       <div v-else-if="receiptsData" class="rc-list">
-        <div v-for="r in receiptsData.receipts" :key="r.service + r.correlation_id" class="rc-row" :title="r.bundle_ref || ''">
+        <div v-for="r in receiptsData.receipts" :key="`${r.service}:${r.correlation_id}`" class="rc-row" :title="r.bundle_ref || ''">
           <span class="rc-svc">{{ r.service }}</span>
           <span class="rc-cid mono">{{ r.correlation_id }}</span>
           <span v-if="r.verdict" class="rc-verdict">{{ r.verdict }}</span>


### PR DESCRIPTION
## Summary

Four `v-for` `:key` collision defects across Studio surfaces, found in an adversarial review of merged PRs. All the same class — an unstable or ambiguous key that causes Vue to reuse/mislabel DOM nodes across renders. Each fix uses a genuinely unique, order-stable key.

## Defects & fixes

### 1) `views/Studio.vue:183` — receipts drawer, bare string-concat key
**Collision:** `:key="r.service + r.correlation_id"` maps `("gateway","run-1")` and `("gate","wayrun-1")` to the same string. Two receipts from different services could share a key.
**Fix:** template literal with an explicit separator — `` `${r.service}:${r.correlation_id}` `` (Receipt has no dedicated id field; `service:correlation_id` is the natural composite key per `studioApi.ts:281`).

### 2) `components/StudioQuery.vue:67-70` — query result grid, index-as-key + duplicate-column-name key
**Collisions:**
- Outer `<tr :key="i">`: index-as-key mislabels rows the moment the result set reorders (e.g. same query with `ORDER BY` flipped, or a re-run with different first row).
- Inner `<td :key="c">` (and the parallel `<th :key="c">` in `<thead>`): a query like `SELECT a.name, b.name FROM ...` returns two columns both named `name`, so the cell keys collide.

**Fix:**
- Outer: `` :key="`${i}:${JSON.stringify(r).slice(0, 120)}`" `` — index + a content prefix so identical-shaped rows are still distinguished and reorders don't re-key across identity.
- Inner (both `<th>` and `<td>`): switch to `v-for="(c, colIdx) in result.columns"` with `` :key="`${c}:${colIdx}`" `` so duplicate column names get distinct keys.

### 3) `components/StudioCompute.vue:385` — session receipt chain, index-as-key with `unshift`
**Collision:** `chain.value.unshift(res)` prepends new runs, so with `:key="i"` every existing row's key shifts by one on each run. Vue diffs against the wrong DOM node — epistemic-status dots, receipt hashes and signed pills can smear onto neighbouring rows during transitions.
**Fix:** `:key="c.receipt?.id ?? \`row-${i}\`"`. Chain entries are pushed only when `res.status === "ok" || "degraded"`, and `ComputeReceipt.id` (see `studioApi.ts:858-863`) is the sealed, order-stable identifier for those. The `row-${i}` fallback is only reached for the rare degraded-with-no-receipt case.

### 4) `components/StudioGraph.vue:309` — "How derived?" derivation list, index-as-key on server-ordered data
**Collision:** `:key="i"` on `derived.derivations`, which the server can reorder run-to-run. The coloured epistemic-mode pill (`observed`/`derived`/`attested` etc.) is bound to the row and gets mislabelled if the array reorders.
**Fix:** `` :key="`${d.direction}:${d.relation}:${d.with.id}`" `` — direction + relation + target-node id uniquely identifies each edge in a provenance neighbourhood per the `Derivation` type in `studioApi.ts:251`.

## Test plan
- [ ] Load Studio, open verified-compute receipts drawer, confirm rows render with no `Duplicate keys detected` console warning even if two receipts share a service or a correlation_id prefix.
- [ ] Run a `SELECT a.name, b.name FROM ...` in Studio Query; confirm both columns render, cells align, and no key warning.
- [ ] Run a compute a few times in StudioCompute; watch the receipt chain — epistemic dots and signed pills stay attached to the correct row across new runs (previously they'd shift because keys re-mapped).
- [ ] Open a graph node and click "How derived?" repeatedly; the epistemic-mode pill on each derivation stays glued to its edge, even if the server returns the list in a different order.
