### PR TITLE
fix(ci): SHA-pin the app-vue deploy pipeline actions

### DIFF
--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -35,8 +35,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      # SHA-pinned per convention — this workflow holds FIREBASE_TOKEN with full Hosting
+      # deploy authority; a moving-tag compromise (as in the tj-actions/changed-files
+      # incident, Mar 2025) executes attacker-controlled code in a job whose secret can
+      # deploy arbitrary content to prod. Version comments name the tag so
+      # renovate/dependabot can bump against them.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with: { node-version: '20', cache: 'npm', cache-dependency-path: socioprophet-web/app-vue/package-lock.json }
       - name: Build app-vue
         working-directory: socioprophet-web/app-vue
@@ -50,7 +55,7 @@ jobs:
           npm ci
           npm run build
       - name: Upload build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with: { name: app-vue-dist, path: socioprophet-web/app-vue/dist, retention-days: 3 }
 
   deploy:
@@ -60,14 +65,17 @@ jobs:
     # `production` Environment so it inherits that Environment's protection rules (required reviewers).
     environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.environment == 'prod') && 'production' || 'development' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with: { name: app-vue-dist, path: socioprophet-web/app-vue/dist }
       - name: Resolve alias
         id: env
         run: echo "alias=${{ github.event_name == 'workflow_dispatch' && inputs.environment || 'dev' }}" >> "$GITHUB_OUTPUT"
       - name: Deploy to Firebase Hosting (app target)
-        uses: w9jds/firebase-action@v15.24.0
+        # SHA-pinned. THIS action receives FIREBASE_TOKEN — if the w9jds account or repo
+        # is compromised and the maintainer force-moves the tag, the next master push
+        # exfils the token and lets the attacker deploy arbitrary Hosting content.
+        uses: w9jds/firebase-action@af97ff3f81136bba7d9048915ba5f05ba42a551d # v15.24.0
         with:
           args: deploy --only hosting:app --project ${{ steps.env.outputs.alias }}
         env:

--- a/.github/workflows/app-vue-deploy.yml
+++ b/.github/workflows/app-vue-deploy.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04  # Copilot round-2: pin the runner image to align with the SHA-pinned actions above — `ubuntu-latest` moves as GitHub retires images and can introduce non-deterministic changes to a workflow that holds FIREBASE_TOKEN.
     steps:
       # SHA-pinned per convention — this workflow holds FIREBASE_TOKEN with full Hosting
       # deploy authority; a moving-tag compromise (as in the tj-actions/changed-files
@@ -60,7 +60,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04  # Copilot round-2: pin the runner image to align with the SHA-pinned actions above — `ubuntu-latest` moves as GitHub retires images and can introduce non-deterministic changes to a workflow that holds FIREBASE_TOKEN.
     # A push to master deploys dev; a manual run deploys the chosen alias. The `prod` alias runs under the
     # `production` Environment so it inherits that Environment's protection rules (required reviewers).
     environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.environment == 'prod') && 'production' || 'development' }}


### PR DESCRIPTION
fix(ci): SHA-pin the app-vue deploy pipeline actions

`app-vue-deploy.yml` holds `FIREBASE_TOKEN` — full Hosting deploy authority
for socioprophet-web-dev-env and socioprophet-web (prod). Every action in
the deploy chain was on a moving-tag reference (`@v4`, `@v15.24.0`), so a
supply-chain compromise of any of them — actions/checkout, actions/setup-node,
actions/upload-artifact, actions/download-artifact, or w9jds/firebase-action
— executes attacker-controlled code inside a job that can deploy arbitrary
content to prod. The tj-actions/changed-files incident (March 2025) is the
concrete precedent.

Pinned to tag-resolved commit SHAs with version comments:
- actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0 (both jobs)
- actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
- actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
- actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
- w9jds/firebase-action@af97ff3f81136bba7d9048915ba5f05ba42a551d # v15.24.0

Follow-up: the remaining ~20 workflow files (CodeQL, checks, contract
tests) still use `@vN` tags. They don't hold secrets with prod-deploy
authority, so their risk is lower, but a full sweep is a valid follow-up.
This PR fixes the highest-risk one first.
