### PR TITLE
fix(noetica-chat): quota-legible persistence + regenerate/fanout after fan-out + attach caps

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/useNoeticaChat.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/useNoeticaChat.test.ts
@@ -1,0 +1,251 @@
+// Pure-function unit tests for the useNoeticaChat composable — pinning three
+// adversarial-review defects so a regression trips CI instead of silently
+// corrupting the compare / regenerate flow or ingesting a 500 MB file.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { nextTick } from 'vue';
+import {
+  popTrailingAssistants,
+  buildSharedHistory,
+  validateAttachments,
+  isAllowedAttachmentMime,
+  MAX_ATTACH_BYTES,
+  MAX_ATTACH_TOTAL_BYTES,
+  persistState,
+  createNoeticaChat,
+  type ChatTurn,
+} from '../composables/useNoeticaChat';
+
+const u = (content: string): ChatTurn => ({ role: 'user', content });
+const a = (content: string, extra: Partial<ChatTurn> = {}): ChatTurn => ({ role: 'assistant', content, ...extra });
+
+describe('popTrailingAssistants — regenerate after fan-out', () => {
+  it('pops every trailing assistant column back to the last user turn', () => {
+    // fan-out of one prompt → 3 columns; regenerate must drop all 3
+    const turns: ChatTurn[] = [
+      u('what is verified compute?'),
+      a('answer A', { fanoutModel: 'qwen' }),
+      a('answer B', { fanoutModel: 'llama' }),
+      a('answer C', { fanoutModel: 'gpt' }),
+    ];
+    const next = popTrailingAssistants(turns);
+    expect(next.map((t) => t.role)).toEqual(['user']);
+    expect(next[0].content).toBe('what is verified compute?');
+  });
+
+  it('preserves earlier user+assistant history — only trailing assistants go', () => {
+    const turns: ChatTurn[] = [
+      u('q1'), a('a1'),
+      u('q2'), a('a2 column 1', { fanoutModel: 'x' }), a('a2 column 2', { fanoutModel: 'y' }),
+    ];
+    const next = popTrailingAssistants(turns);
+    expect(next.map((t) => `${t.role}:${t.content}`)).toEqual(['user:q1', 'assistant:a1', 'user:q2']);
+  });
+
+  it('no-op when the last turn is already a user turn', () => {
+    const turns: ChatTurn[] = [u('q1'), a('a1'), u('q2')];
+    expect(popTrailingAssistants(turns)).toEqual(turns);
+  });
+
+  it('does not mutate the input array', () => {
+    const turns: ChatTurn[] = [u('q'), a('a1'), a('a2')];
+    const before = turns.slice();
+    popTrailingAssistants(turns);
+    expect(turns).toEqual(before);
+  });
+});
+
+describe('buildSharedHistory — fan-out re-run after a prior fan-out', () => {
+  it('includes prior assistant turns (not user-only)', () => {
+    // The regression: the composable filtered to `role === 'user'`, so
+    // every model in a fresh fan-out saw a memoryless chat.
+    const turns: ChatTurn[] = [u('q1'), a('a1'), u('q2')];
+    const h = buildSharedHistory(turns);
+    expect(h).toEqual([
+      { role: 'user', content: 'q1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'q2' },
+    ]);
+  });
+
+  it('takes only the FIRST assistant column per user turn when a prior fan-out produced N columns', () => {
+    const turns: ChatTurn[] = [
+      u('q1'),
+      a('a1 qwen', { fanoutModel: 'qwen' }),
+      a('a1 llama', { fanoutModel: 'llama' }),
+      a('a1 gpt', { fanoutModel: 'gpt' }),
+      u('q2'),
+    ];
+    const h = buildSharedHistory(turns);
+    expect(h).toEqual([
+      { role: 'user', content: 'q1' },
+      { role: 'assistant', content: 'a1 qwen' },   // FIRST column only
+      { role: 'user', content: 'q2' },
+    ]);
+  });
+
+  it('skips in-flight streaming assistant turns', () => {
+    const turns: ChatTurn[] = [u('q1'), a('partial…', { streaming: true }), u('q2')];
+    const h = buildSharedHistory(turns);
+    expect(h).toEqual([
+      { role: 'user', content: 'q1' },
+      { role: 'user', content: 'q2' },
+    ]);
+  });
+
+  it('handles interleaved multi-turn fan-outs — one assistant per user, in order', () => {
+    const turns: ChatTurn[] = [
+      u('q1'), a('a1 A', { fanoutModel: 'A' }), a('a1 B', { fanoutModel: 'B' }),
+      u('q2'), a('a2 A', { fanoutModel: 'A' }), a('a2 B', { fanoutModel: 'B' }),
+      u('q3'),
+    ];
+    const h = buildSharedHistory(turns);
+    expect(h).toEqual([
+      { role: 'user', content: 'q1' }, { role: 'assistant', content: 'a1 A' },
+      { role: 'user', content: 'q2' }, { role: 'assistant', content: 'a2 A' },
+      { role: 'user', content: 'q3' },
+    ]);
+  });
+
+  it('drops orphan assistant turns with no preceding user turn', () => {
+    const turns: ChatTurn[] = [a('stray'), u('q1'), a('a1')];
+    const h = buildSharedHistory(turns);
+    expect(h).toEqual([
+      { role: 'user', content: 'q1' },
+      { role: 'assistant', content: 'a1' },
+    ]);
+  });
+});
+
+describe('quota-legible persistence', () => {
+  let origSetItem: (k: string, v: string) => void;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // reset the module-level state before each test — persistState leaks across
+    // tests otherwise (it's shared by design so the UI sees one signal).
+    persistState.value = 'ok';
+    localStorage.clear();
+    origSetItem = localStorage.setItem.bind(localStorage);
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    localStorage.setItem = origSetItem;
+    warn.mockRestore();
+  });
+
+  it('flips persistState to "quota" on QuotaExceededError and stops persisting', async () => {
+    const chat = createNoeticaChat();
+    // First mutation persists cleanly.
+    chat.turns.value.push({ role: 'user', content: 'q1' });
+    await nextTick();
+    expect(persistState.value).toBe('ok');
+    expect(localStorage.getItem('noetica-chat-v1')).toBeTruthy();
+
+    // Now every setItem throws — the next mutation should flip state to 'quota'
+    // and log ONE warning. Subsequent mutations must not attempt setItem again.
+    const setSpy = vi.fn((_k: string, _v: string) => {
+      const e = new DOMException('quota', 'QuotaExceededError');
+      throw e;
+    });
+    localStorage.setItem = setSpy as unknown as typeof localStorage.setItem;
+
+    chat.turns.value.push({ role: 'assistant', content: 'a1' });
+    await nextTick();
+    expect(persistState.value).toBe('quota');
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toMatch(/persistence disabled/);
+
+    // Further mutations must NOT attempt setItem again (silent-drop regression).
+    chat.turns.value.push({ role: 'user', content: 'q2' });
+    await nextTick();
+    chat.turns.value.push({ role: 'assistant', content: 'a2' });
+    await nextTick();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reset() clears the store and puts persistence back to "ok"', async () => {
+    const chat = createNoeticaChat();
+    chat.turns.value.push({ role: 'user', content: 'q' });
+    await nextTick();
+    localStorage.setItem = () => { throw new DOMException('quota', 'QuotaExceededError'); };
+    chat.turns.value.push({ role: 'assistant', content: 'a' });
+    await nextTick();
+    expect(persistState.value).toBe('quota');
+
+    localStorage.setItem = origSetItem;
+    chat.reset();
+    expect(persistState.value).toBe('ok');
+    expect(chat.turns.value).toEqual([]);
+  });
+});
+
+describe('validateAttachments — per-file cap, aggregate cap, MIME allowlist', () => {
+  const file = (name: string, size: number, type: string) => ({ name, size, type });
+
+  it('accepts allowed MIME types under the cap', () => {
+    const v = validateAttachments([
+      file('a.pdf', 1_000_000, 'application/pdf'),
+      file('b.txt', 500,       'text/plain'),
+      file('c.png', 250_000,   'image/png'),
+    ]);
+    expect(v.errors).toEqual([]);
+    expect(v.batchRejected).toBe(false);
+    expect(v.accepted.map((f) => f.name)).toEqual(['a.pdf', 'b.txt', 'c.png']);
+  });
+
+  it('rejects files over the per-file cap with a visible error', () => {
+    const oversized = file('big.pdf', MAX_ATTACH_BYTES + 1, 'application/pdf');
+    const ok = file('ok.txt', 100, 'text/plain');
+    const v = validateAttachments([oversized, ok]);
+    expect(v.accepted.map((f) => f.name)).toEqual(['ok.txt']);
+    expect(v.errors).toHaveLength(1);
+    expect(v.errors[0]).toMatch(/big\.pdf/);
+    expect(v.errors[0]).toMatch(/per-file cap/);
+  });
+
+  it('rejects the ENTIRE batch when aggregate exceeds the total cap', () => {
+    // Three 19 MB files → 57 MB > 40 MB total cap → whole batch dropped, not
+    // truncated (truncation would silently lose the tail).
+    const nineteen = 19 * 1024 * 1024;
+    const v = validateAttachments([
+      file('a.pdf', nineteen, 'application/pdf'),
+      file('b.pdf', nineteen, 'application/pdf'),
+      file('c.pdf', nineteen, 'application/pdf'),
+    ]);
+    expect(v.batchRejected).toBe(true);
+    expect(v.accepted).toEqual([]);
+    expect(v.errors.at(-1)).toMatch(/batch total/);
+    expect(v.errors.at(-1)).toMatch(String(MAX_ATTACH_TOTAL_BYTES / 1024 / 1024));
+  });
+
+  it('rejects disallowed MIME types', () => {
+    const v = validateAttachments([
+      file('a.exe', 1000, 'application/x-msdownload'),
+      file('b.zip', 1000, 'application/zip'),
+      file('c.txt', 1000, 'text/plain'),
+    ]);
+    expect(v.accepted.map((f) => f.name)).toEqual(['c.txt']);
+    expect(v.errors).toHaveLength(2);
+    expect(v.errors[0]).toMatch(/unsupported type/);
+  });
+
+  it('handles empty MIME strings — some browsers report "" for unknown types', () => {
+    const v = validateAttachments([file('mystery', 1000, '')]);
+    expect(v.accepted).toEqual([]);
+    expect(v.errors[0]).toMatch(/unknown/);
+  });
+
+  it('isAllowedAttachmentMime allows the documented set only', () => {
+    expect(isAllowedAttachmentMime('image/png')).toBe(true);
+    expect(isAllowedAttachmentMime('image/svg+xml')).toBe(true);
+    expect(isAllowedAttachmentMime('application/pdf')).toBe(true);
+    expect(isAllowedAttachmentMime('text/plain')).toBe(true);
+    expect(isAllowedAttachmentMime('text/markdown')).toBe(true);
+    expect(isAllowedAttachmentMime('application/zip')).toBe(false);
+    expect(isAllowedAttachmentMime('application/octet-stream')).toBe(false);
+    expect(isAllowedAttachmentMime('')).toBe(false);
+  });
+});

--- a/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
+++ b/socioprophet-web/client-vue/src/composables/useNoeticaChat.ts
@@ -12,13 +12,115 @@ import { useMcp } from '../stores/mcp';
 import { meshChatStream } from '../config/mesh';
 
 const STORE_KEY = 'noetica-chat-v1';
+
+// Persistence health — module-level so the same signal is shared across every
+// consumer (chat header, settings badge, tests). Once the quota is hit we STOP
+// trying to persist so writes don't churn silently; the UI can surface "chat
+// history is no longer being saved" and offer a Reset. Reset clears the store
+// and puts us back to 'ok'.
+export type PersistState = 'ok' | 'quota' | 'blocked';
+export const persistState = ref<PersistState>('ok');
+let persistWarned = false;
+function classifyPersistError(e: unknown): 'quota' | 'blocked' {
+  if (e instanceof DOMException) {
+    // Chrome: 'QuotaExceededError'; Firefox: 'NS_ERROR_DOM_QUOTA_REACHED' (code 22 / 1014)
+    if (/quota/i.test(e.name) || e.code === 22 || e.code === 1014) return 'quota';
+  }
+  const name = (e as { name?: string } | null)?.name ?? '';
+  if (/quota/i.test(name)) return 'quota';
+  return 'blocked';
+}
+
+// Trace / thinking / retrieval are large per-turn observability payloads that only
+// matter while the operator is looking at the live turn — dropping them from the
+// persisted copy keeps the store small so quota is hit later, and a reload still
+// restores content + model + badge + judgment (the pieces a chat log needs).
+function slimForPersist(turnsList: ChatTurn[]): Array<Omit<ChatTurn, 'streaming' | 'trace' | 'thinking' | 'retrieval'>> {
+  return turnsList
+    .filter((x) => !x.streaming)
+    .map(({ streaming: _s, trace: _t, thinking: _k, retrieval: _r, ...rest }) => rest);
+}
+
 function loadPersisted(): ChatTurn[] {
   try {
     const raw = localStorage.getItem(STORE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as ChatTurn[];
     return Array.isArray(parsed) ? parsed.map((t) => ({ ...t, streaming: false })) : [];
-  } catch { return []; }
+  } catch (e) {
+    persistState.value = classifyPersistError(e);
+    return [];
+  }
+}
+
+// Pop every trailing assistant turn back to the last user turn. Regenerate uses
+// this so a fan-out (N assistant columns for one user turn) doesn't leave N-1
+// orphaned columns dangling as prior context on the retry.
+export function popTrailingAssistants(turns: ChatTurn[]): ChatTurn[] {
+  const next = turns.slice();
+  while (next.length && next[next.length - 1].role === 'assistant') next.pop();
+  return next;
+}
+
+// Shared history for fan-out: all prior turns as one linear conversation, but
+// only the FIRST assistant column per user turn (so a prior fan-out doesn't
+// re-inject N assistant answers to a single question). In-flight streaming
+// turns are excluded — we haven't heard the full answer yet.
+export function buildSharedHistory(turns: ChatTurn[]): Array<{ role: Role; content: string }> {
+  const out: Array<{ role: Role; content: string }> = [];
+  let awaitingAssistant = false;
+  for (const t of turns) {
+    if (t.streaming) continue;
+    if (t.role === 'user') {
+      out.push({ role: 'user', content: t.content });
+      awaitingAssistant = true;
+    } else if (awaitingAssistant) {
+      out.push({ role: 'assistant', content: t.content });
+      awaitingAssistant = false;
+    }
+    // additional assistant columns for the same user turn are dropped
+  }
+  return out;
+}
+
+// Attachment limits — the operator uploads via <input type="file">, and we
+// base64-encode the file in-browser before POSTing to the ingest queue. Cap
+// per-file and aggregate size, and restrict MIME to what the ingest pipeline
+// actually understands (docs, PDFs, plain text, images for OCR).
+export const MAX_ATTACH_BYTES = 20 * 1024 * 1024;
+export const MAX_ATTACH_TOTAL_BYTES = 40 * 1024 * 1024;
+const ALLOWED_MIME_PATTERNS: RegExp[] = [/^image\//, /^application\/pdf$/, /^text\//];
+export function isAllowedAttachmentMime(mime: string): boolean {
+  return ALLOWED_MIME_PATTERNS.some((r) => r.test(mime));
+}
+export interface AttachCandidate { name: string; size: number; type: string }
+export interface AttachmentValidation<T extends AttachCandidate> {
+  accepted: T[];
+  errors: string[];
+  batchRejected: boolean;   // aggregate cap exceeded — the whole batch is dropped
+}
+export function validateAttachments<T extends AttachCandidate>(files: T[]): AttachmentValidation<T> {
+  const errors: string[] = [];
+  const accepted: T[] = [];
+  let total = 0;
+  const mb = (n: number) => (n / 1024 / 1024).toFixed(1);
+  for (const f of files) {
+    if (!isAllowedAttachmentMime(f.type || '')) {
+      errors.push(`${f.name}: unsupported type (${f.type || 'unknown'}) — allowed: image/*, application/pdf, text/*`);
+      continue;
+    }
+    if (f.size > MAX_ATTACH_BYTES) {
+      errors.push(`${f.name}: ${mb(f.size)} MB exceeds ${mb(MAX_ATTACH_BYTES)} MB per-file cap`);
+      continue;
+    }
+    total += f.size;
+    accepted.push(f);
+  }
+  if (total > MAX_ATTACH_TOTAL_BYTES) {
+    errors.push(`batch total ${mb(total)} MB exceeds ${mb(MAX_ATTACH_TOTAL_BYTES)} MB — split the upload`);
+    return { accepted: [], errors, batchRejected: true };
+  }
+  return { accepted, errors, batchRejected: false };
 }
 
 export type Role = 'user' | 'assistant';
@@ -77,12 +179,31 @@ export function createNoeticaChat() {
   let controller: AbortController | null = null;
   function stop() { controller?.abort(); stopFanout(); }
 
-  // Persist finalized history so a reload keeps the conversation.
+  // Persist finalized history so a reload keeps the conversation. If the store
+  // ever refuses a write (quota exceeded / private mode), flip persistState and
+  // STOP retrying — the previous silent try/catch let every subsequent mutation
+  // be dropped without the UI ever knowing memory and disk had diverged. The
+  // exported ref lets the header show "chat history not being persisted".
   watch(turns, (t) => {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(t.filter((x) => !x.streaming))); } catch { /* quota/private-mode */ }
+    if (persistState.value !== 'ok') return;
+    let json = '';
+    try {
+      json = JSON.stringify(slimForPersist(t));
+      localStorage.setItem(STORE_KEY, json);
+    } catch (e) {
+      persistState.value = classifyPersistError(e);
+      if (!persistWarned) {
+        persistWarned = true;
+        // eslint-disable-next-line no-console
+        console.warn(`[noetica-chat] persistence disabled (${persistState.value}) at ~${json.length} bytes`);
+      }
+    }
   }, { deep: true });
 
-  function reset() { turns.value = []; try { localStorage.removeItem(STORE_KEY); } catch { /* */ } }
+  function reset() {
+    turns.value = [];
+    try { localStorage.removeItem(STORE_KEY); persistState.value = 'ok'; persistWarned = false; } catch { /* */ }
+  }
 
   async function send(text: string) {
     const msg = text.trim();
@@ -215,10 +336,13 @@ export function createNoeticaChat() {
     }
   }
 
-  // Regenerate: drop the last assistant turn and re-run against the history.
+  // Regenerate: drop EVERY trailing assistant turn back to the last user turn,
+  // then re-run against the history. A fan-out call produces N assistant turns
+  // for one user turn — a single pop would leave N-1 orphaned columns dangling
+  // as prior context on the retry.
   function regenerate() {
     if (busy.value) return;
-    if (turns.value.at(-1)?.role === 'assistant') turns.value.pop();
+    turns.value = popTrailingAssistants(turns.value);
     void stream();
   }
 
@@ -290,7 +414,11 @@ export function createNoeticaChat() {
     const msg = text.trim();
     if (!msg || busy.value || modelIds.length === 0) return;
     turns.value.push({ role: 'user', content: msg });
-    const history = turns.value.filter((t) => t.role === 'user').map((t) => ({ role: t.role, content: t.content }));
+    // Every model in the compare sees the SAME shared context: all prior turns,
+    // but only the first assistant column per user turn (so a prior fan-out
+    // doesn't re-inject N answers to one question). Filtering to user-only
+    // dropped every prior assistant response and made compare a memoryless run.
+    const history = buildSharedHistory(turns.value);
     const slots = modelIds.map((mid) => {
       const a: ChatTurn = { role: 'assistant', content: '', streaming: true, fanoutModel: mid };
       turns.value.push(a);

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -12,6 +12,13 @@
         <span class="nx-localpill" title="Local-first — your data never leaves this device">Local-first</span>
       </div>
       <div class="nx-head-r">
+        <span
+          v-if="persistState !== 'ok'"
+          class="nx-persist-warn"
+          :title="persistState === 'quota'
+            ? 'Local storage full — new turns are only in memory. Clear to restore persistence.'
+            : 'Local storage unavailable (private mode?) — turns will not persist across reload.'"
+        >⚠ history not saved</span>
         <span class="nx-sess">session {{ chat.sessionId.slice(0, 8) }}</span>
         <button v-if="chat.turns.value.length" class="nx-clear" @click="chat.reset()">Clear</button>
       </div>
@@ -154,6 +161,10 @@
           <input ref="attachRef" type="file" multiple class="nx-hidden" @change="onAttach" />
           <span v-if="ingesting" class="nx-ingest">ingesting…</span>
           <span v-else-if="ingestedCount" class="nx-ingest" :title="ingestedCount + ' files ingested this session'">✓ {{ ingestedCount }}</span>
+          <span v-if="attachErrors.length" class="nx-attach-err" role="alert" :title="attachErrors.join('\n')">
+            ⚠ {{ attachErrors.length }} attachment issue{{ attachErrors.length === 1 ? '' : 's' }}
+            <button type="button" class="nx-attach-err-x" @click="attachErrors = []" title="Dismiss">✕</button>
+          </span>
 
           <!-- fan-out: compare multiple models -->
           <div v-if="models.length" class="nx-scope">
@@ -212,7 +223,12 @@
 
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, computed } from 'vue';
-import { useNoeticaChat, type ChatTurn } from '../composables/useNoeticaChat';
+import {
+  useNoeticaChat,
+  type ChatTurn,
+  validateAttachments,
+  persistState,
+} from '../composables/useNoeticaChat';
 import { useProjects, projectCollectionId } from '../stores/projects';
 import { useMcp, toolKey } from '../stores/mcp';
 import { AM_BASE, labsCatalog, type ModelEntry } from '../services/agentMachineApi';
@@ -259,12 +275,23 @@ function uploadCollection(): string {
   if (chat.retrievalScope.value === 'project' && projects.active) return projectCollectionId(projects.active.id);
   return `chat-${chat.sessionId.replace(/-/g, '').slice(0, 8)}`;   // mirrors Noetica chatCollectionId
 }
+const attachErrors = ref<string[]>([]);
 async function onAttach(e: Event) {
-  const files = Array.from((e.target as HTMLInputElement).files ?? []);
+  const input = e.target as HTMLInputElement;
+  const files = Array.from(input.files ?? []);
   if (!files.length) return;
+  attachErrors.value = [];
+  // Gate on MIME + per-file cap + aggregate cap BEFORE we start reading anything
+  // into memory as base64 — an unfiltered Promise.all would blow up the tab.
+  const validated = validateAttachments(files);
+  if (validated.errors.length) attachErrors.value = [...validated.errors];
+  if (validated.batchRejected || !validated.accepted.length) {
+    if (input) input.value = '';
+    return;
+  }
   ingesting.value = true;
   const collection = uploadCollection();
-  const results = await Promise.all(files.map((f) => new Promise<boolean>((resolve) => {
+  const results = await Promise.all(validated.accepted.map((f) => new Promise<boolean>((resolve) => {
     const reader = new FileReader();
     reader.onload = async () => {
       const dataBase64 = (reader.result as string).split(',')[1] ?? '';
@@ -273,15 +300,24 @@ async function onAttach(e: Event) {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ filename: f.name, mimeType: f.type, dataBase64, collection }),
         });
+        if (!r.ok) attachErrors.value.push(`${f.name}: upload failed (${r.status})`);
         resolve(r.ok);
-      } catch { resolve(false); }
+      } catch (err) {
+        // Surface the failure — the previous silent catch let the batch look
+        // successful even when every request had errored.
+        attachErrors.value.push(`${f.name}: ${err instanceof Error ? err.message : 'upload failed'}`);
+        resolve(false);
+      }
     };
-    reader.onerror = () => resolve(false);
+    reader.onerror = () => {
+      attachErrors.value.push(`${f.name}: read failed`);
+      resolve(false);
+    };
     reader.readAsDataURL(f);
   })));
   ingestedCount.value += results.filter(Boolean).length;
   ingesting.value = false;
-  if (attachRef.value) attachRef.value.value = '';
+  if (input) input.value = '';
 }
 const expanded = ref<Set<number>>(new Set());
 function toggleTrace(i: number) { if (expanded.value.has(i)) expanded.value.delete(i); else expanded.value.add(i); }
@@ -569,6 +605,11 @@ onMounted(() => inputEl.value?.focus());
 .nx-spacer { flex: 1 1 auto; }
 .nx-hidden { display: none; }
 .nx-ingest { font-size: 10px; color: var(--nblue); }
+.nx-attach-err { display: inline-flex; align-items: center; gap: 4px; font-size: 10px; color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, .35); background: rgba(239, 68, 68, .08); padding: 2px 6px; border-radius: 6px; }
+.nx-attach-err-x { border: 0; background: transparent; color: inherit; cursor: pointer; font-size: 11px; line-height: 1; padding: 0 2px; }
+.nx-persist-warn { font-size: 10px; color: #f59e0b; border: 1px solid rgba(245, 158, 11, .35);
+  background: rgba(245, 158, 11, .08); padding: 2px 6px; border-radius: 6px; cursor: help; }
 .nx-scope { position: relative; }
 .nx-scope-btn { display: inline-flex; align-items: center; gap: 4px; border: 1px solid var(--nline-weak); background: transparent;
   color: var(--ntext3); font: inherit; font-size: 10.5px; font-weight: 600; padding: 3px 8px; border-radius: 7px; cursor: pointer; }


### PR DESCRIPTION
## Summary

Four defects in the Noetica chat surface (`socioprophet-web/client-vue/src/composables/useNoeticaChat.ts` + `src/pages/NoeticaChat.vue`), all found in an adversarial review. Landed together because the fixes share extracted helpers and one test suite.

### 1. Quota-legible persistence (`useNoeticaChat.ts:~82`)
`watch(turns, ..., {deep:true})` serialized the entire chat history (including `trace`, `thinking`, `retrieval`, `plan`, `judgment`) to `localStorage['noetica-chat-v1']` on every mutation, wrapped in `try{...}catch{/* quota/private-mode */}`. Once ~5 MB was exceeded every subsequent save was silently dropped — on reload the persisted state was arbitrarily stale relative to memory.

Fixed by:
- Module-level `persistState: ref<'ok'|'quota'|'blocked'>` (exported so a UI component can surface "chat history not being persisted").
- On quota/blocked error: flip the state and STOP retrying — no more silent-drop churn.
- Emit one `console.warn` with byte-size at failure (not per mutation).
- Slim the persisted shape (drop `trace` / `thinking` / `retrieval` — visual-only payloads) so quota is reached later.
- `reset()` restores `'ok'`.
- Chat header now shows `⚠ history not saved` when persistence is degraded.

### 2. `regenerate()` pops one, leaves N-1 orphans (`~L221`)
`if (turns.value.at(-1)?.role === 'assistant') turns.value.pop()` — a fan-out call produced N assistant columns for one user turn, so N-1 dangled and were forwarded as prior context on the retry.

Fixed by extracting `popTrailingAssistants(turns)` that pops EVERY trailing assistant back to the last user turn.

### 3. `fanout()` drops all prior assistant context (`~L293`)
Built the per-model history as `turns.value.filter(t => t.role === 'user')` — every prior assistant turn was dropped, making compare memoryless.

Fixed by `buildSharedHistory(turns)`: includes all prior turns (user + assistant), but takes only the FIRST assistant column per user turn — so a prior fan-out doesn't re-inject N answers to one question. All models in the compare see the same shared context.

### 4. `onAttach` loads any-size any-MIME files, swallows failures (`NoeticaChat.vue:~262-285`)
`Promise.all(files.map(new FileReader().readAsDataURL))` loaded every file entirely into memory as base64 simultaneously — no size cap, no MIME check, and `catch { resolve(false) }` silently swallowed fetch failure per file (ingest counter was accurate-looking even when every request had errored).

Fixed by `validateAttachments`:
- Per-file cap: `MAX_ATTACH_BYTES` (default 20 MB).
- Aggregate cap: `MAX_ATTACH_TOTAL_BYTES` (default 40 MB) — batch REJECTED not truncated.
- MIME allowlist: `image/*`, `application/pdf`, `text/*`.
- Fetch/reader failures populate an `attachErrors` list surfaced in the composer toolbar as `⚠ N attachment issues` (hover for detail).

## Tests

New `src/__tests__/useNoeticaChat.test.ts` — 17 pure-function assertions pinning each fix:
- **regenerate after fan-out**: `popTrailingAssistants` covers N-column fan-out, no-op on trailing user, non-mutating.
- **fan-out history**: `buildSharedHistory` contains prior assistant context, one column per user turn even after a prior fan-out, skips streaming turns, drops orphans.
- **attachment caps**: per-file cap rejects with visible error, aggregate cap rejects the WHOLE batch (not truncated), MIME allowlist accepts/refuses the documented set including empty types.
- **quota persistence**: `persistState` transitions to `'quota'` on `QuotaExceededError`, further mutations do NOT attempt `setItem`, warns once, `reset()` returns to `'ok'`.

`npm test` — 461/461 pass. `vue-tsc --noEmit` — clean. `vite build` — clean.

## Test plan

- [ ] CI green (typecheck + tests + build).
- [ ] Reviewer to spot-check: the chat header persistence badge appears when localStorage is full.
- [ ] Reviewer to spot-check: uploading a 25 MB PDF surfaces `⚠ 1 attachment issue`; three 19 MB PDFs together reject the whole batch.
- [ ] Reviewer to spot-check: fan-out compare against 3 models, then regenerate — no orphan columns remain, prior assistant context is passed to the next turn.