### PR TITLE
fix(mesh): move bearer token to sessionStorage (was localStorage)

### DIFF
--- a/socioprophet-web/client-vue/src/config/mesh.test.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.test.ts
@@ -66,6 +66,34 @@ describe('legacy-localStorage migration', () => {
     const m = await import('./mesh');
     expect(m.meshToken()).toBe('IN-USE');
   });
+
+  // Copilot round-2: an empty (or whitespace-only) legacy value must still be CLEARED —
+  // the previous truthiness check left it in localStorage, contradicting the migration
+  // contract. Also: whitespace-only tokens must not migrate verbatim (blank tokens are
+  // useless; the callsite treats '' as no-token anyway).
+  it('clears an empty legacy value from localStorage on first read', async () => {
+    localStorage.setItem('sp.conn.mesh-token', '');
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('');
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
+
+  it('clears a whitespace-only legacy value AND does not migrate it verbatim', async () => {
+    localStorage.setItem('sp.conn.mesh-token', '   \t\n   ');
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('');
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
+
+  it('trims whitespace around a legacy token during migration', async () => {
+    localStorage.setItem('sp.conn.mesh-token', '  AUTH-legacy  ');
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('AUTH-legacy');
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe('AUTH-legacy');
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
 });
 
 describe('endpoint storage — localStorage is fine (not sensitive)', () => {

--- a/socioprophet-web/client-vue/src/config/mesh.test.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pins the token-storage decision made when the localStorage-lived bearer was flagged
+ * in the adversarial-review pass: DOM-XSS anywhere in the app could exfil it forever.
+ * Moved to sessionStorage; anything below is the contract that keeps it there.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Reset both stores between tests so migration behavior is legible.
+beforeEach(() => {
+  vi.resetModules();
+  try { localStorage.clear(); } catch { /* jsdom always has it */ }
+  try { sessionStorage.clear(); } catch { /* same */ }
+});
+
+describe('mesh bearer token — sessionStorage, not localStorage', () => {
+  it('setMeshToken writes to sessionStorage and NOT localStorage', async () => {
+    const m = await import('./mesh');
+    m.setMeshToken('AUTH-abc');
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe('AUTH-abc');
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
+
+  it('meshToken reads back from sessionStorage', async () => {
+    const m = await import('./mesh');
+    m.setMeshToken('AUTH-xyz');
+    expect(m.meshToken()).toBe('AUTH-xyz');
+  });
+
+  it('meshToken returns empty string when no token is set', async () => {
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('');
+  });
+
+  it('trims whitespace on write', async () => {
+    const m = await import('./mesh');
+    m.setMeshToken('   AUTH-trimmed   ');
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe('AUTH-trimmed');
+  });
+});
+
+describe('legacy-localStorage migration', () => {
+  it('migrates a token from localStorage to sessionStorage on first read', async () => {
+    localStorage.setItem('sp.conn.mesh-token', 'LEGACY-token');
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('LEGACY-token');
+    // Migrated:
+    expect(sessionStorage.getItem('sp.conn.mesh-token')).toBe('LEGACY-token');
+    // And CLEARED from localStorage — the raw secret must not linger.
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
+
+  it('is idempotent — second call is a no-op', async () => {
+    localStorage.setItem('sp.conn.mesh-token', 'LEGACY');
+    const m = await import('./mesh');
+    m.meshToken(); // migrates
+    // second call: localStorage empty, sessionStorage has it
+    expect(m.meshToken()).toBe('LEGACY');
+    expect(localStorage.getItem('sp.conn.mesh-token')).toBe(null);
+  });
+
+  it('does not migrate an empty legacy value', async () => {
+    // A stale empty entry from a prior clear-attempt must not overwrite an in-use
+    // sessionStorage value or shadow it with ''.
+    localStorage.setItem('sp.conn.mesh-token', '');
+    sessionStorage.setItem('sp.conn.mesh-token', 'IN-USE');
+    const m = await import('./mesh');
+    expect(m.meshToken()).toBe('IN-USE');
+  });
+});
+
+describe('endpoint storage — localStorage is fine (not sensitive)', () => {
+  it('setMeshBase writes to localStorage', async () => {
+    const m = await import('./mesh');
+    m.setMeshBase('https://mesh.example.test/');
+    expect(localStorage.getItem('sp.conn.mesh')).toBe('https://mesh.example.test');
+  });
+
+  it('meshBase reads back the endpoint and strips a trailing slash', async () => {
+    const m = await import('./mesh');
+    m.setMeshBase('https://x.test/');
+    expect(m.meshBase()).toBe('https://x.test');
+  });
+});

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -3,12 +3,22 @@
 // mesh.socioprophet.ai is the Model Choir / Conductor: an OpenAI-compatible gateway
 // (GET /v1/models, POST /v1/chat/completions) that routes model=prophet-mesh to a
 // vLLM seat. /v1/models is open; chat requires the mesh bearer token (MESH_AUTH_TOKEN,
-// k8s secret prophet-mesh-auth). The operator pastes the token in Settings → Connections;
-// it's stored per-browser and never committed.
+// k8s secret prophet-mesh-auth). The operator pastes the token in Settings → Connections.
+//
+// STORAGE — token in sessionStorage, endpoint in localStorage.
+// The endpoint URL is not sensitive; localStorage is fine.
+// The bearer token was previously in localStorage, which meant any DOM-XSS anywhere in
+// the app (or a malicious extension) could exfiltrate the token indefinitely — the raw
+// grant stayed available across sessions until manually cleared. Moved to sessionStorage
+// so an exfil's blast radius ends when the tab closes; a browser-restart re-entry is a
+// small cost for closing that surface. A one-shot migration copies the legacy token from
+// localStorage into sessionStorage on first read, then clears the localStorage entry so
+// the raw secret does not linger.
 
 const ENV_MESH = (import.meta as any).env?.VITE_MESH_BASE as string | undefined;
 const LS_BASE = 'sp.conn.mesh';
-const LS_TOKEN = 'sp.conn.mesh-token';
+const SS_TOKEN = 'sp.conn.mesh-token';
+const LS_TOKEN_LEGACY = 'sp.conn.mesh-token';
 
 export const DEFAULT_MESH_BASE = 'https://mesh.socioprophet.ai';
 // Default to the muscular seat (Qwen3-32B on A100). The conductor routes 'xl' → that seat;
@@ -24,13 +34,31 @@ const MESH_FETCH = '/mesh';
 function ls(key: string): string | null {
   try { return typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null; } catch { return null; }
 }
+function ss(key: string): string | null {
+  try { return typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(key) : null; } catch { return null; }
+}
+
+// One-time migration from the old localStorage location. Copies the value into
+// sessionStorage and CLEARS the localStorage entry so the raw secret does not linger.
+// Idempotent: after the legacy key is cleared, this is a no-op.
+function migrateLegacyToken(): string | null {
+  const legacy = ls(LS_TOKEN_LEGACY);
+  if (!legacy) return null;
+  try { sessionStorage.setItem(SS_TOKEN, legacy); } catch { /* private mode / disabled */ }
+  try { localStorage.removeItem(LS_TOKEN_LEGACY); } catch { /* ignore */ }
+  return legacy;
+}
 
 export function meshBase(): string {
   return (ls(LS_BASE) || ENV_MESH || DEFAULT_MESH_BASE).replace(/\/$/, '');
 }
 export function setMeshBase(url: string) { try { localStorage.setItem(LS_BASE, url.replace(/\/$/, '')); } catch { /* ignore */ } }
-export function meshToken(): string { return ls(LS_TOKEN) || ''; }
-export function setMeshToken(t: string) { try { localStorage.setItem(LS_TOKEN, t.trim()); } catch { /* ignore */ } }
+export function meshToken(): string {
+  const current = ss(SS_TOKEN);
+  if (current) return current;
+  return migrateLegacyToken() ?? '';
+}
+export function setMeshToken(t: string) { try { sessionStorage.setItem(SS_TOKEN, t.trim()); } catch { /* ignore */ } }
 
 export interface MeshStatus { ok: boolean; status: number | null; detail: string; models: string[] }
 

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -39,24 +39,28 @@ function ss(key: string): string | null {
 }
 
 // One-time migration from the old localStorage location. If the legacy key EXISTS
-// (present at all — including empty or whitespace-only), it is cleared. Only a real
-// non-whitespace token is carried over to sessionStorage; an empty/whitespace legacy
-// value is discarded, not migrated verbatim (a blank token would have been useless
-// anyway, and the callsite already treats '' as no-token). Copilot round-2 flagged
-// the earlier version, which used truthiness and so silently LEFT an empty legacy
-// entry in localStorage — contradicting the migration's own contract.
+// (present at all — including empty or whitespace-only), it is cleared. A real
+// non-whitespace legacy token is copied to sessionStorage ONLY when sessionStorage
+// has no live token; an empty/whitespace legacy value is discarded, not migrated
+// verbatim.
+// Copilot round-3: the legacy key must be cleared even when a live sessionStorage
+// token already exists — otherwise the raw secret keeps lingering in localStorage
+// for anyone who already re-set the token this session, which is the whole surface
+// this move was meant to close. And an explicit '' in sessionStorage (a deliberate
+// clear) must NOT trigger re-migration: distinguish `null` (missing) from `''`.
 // Idempotent: after the legacy key is cleared, this is a no-op.
-function migrateLegacyToken(): string | null {
-  // Distinguish MISSING from PRESENT-BUT-EMPTY: only the presence check tells us
-  // whether we owe a clear.
+function runLegacyMigration(): void {
   const legacy = ls(LS_TOKEN_LEGACY);
-  if (legacy === null) return null;
+  if (legacy === null) return;
   // Present — always clear, whatever the shape.
   try { localStorage.removeItem(LS_TOKEN_LEGACY); } catch { /* ignore */ }
   const trimmed = legacy.trim();
-  if (!trimmed) return null;
+  if (!trimmed) return;
+  // Only overwrite session when it has NO value at all (null). An explicitly-empty
+  // session value is a user-intentional clear and must be respected.
+  const current = ss(SS_TOKEN);
+  if (current !== null) return;
   try { sessionStorage.setItem(SS_TOKEN, trimmed); } catch { /* private mode / disabled */ }
-  return trimmed;
 }
 
 export function meshBase(): string {
@@ -64,9 +68,10 @@ export function meshBase(): string {
 }
 export function setMeshBase(url: string) { try { localStorage.setItem(LS_BASE, url.replace(/\/$/, '')); } catch { /* ignore */ } }
 export function meshToken(): string {
-  const current = ss(SS_TOKEN);
-  if (current) return current;
-  return migrateLegacyToken() ?? '';
+  // Always run migration first: it clears the legacy key even if session already
+  // has a value, and no-ops once the legacy key is gone.
+  runLegacyMigration();
+  return ss(SS_TOKEN) ?? '';
 }
 export function setMeshToken(t: string) { try { sessionStorage.setItem(SS_TOKEN, t.trim()); } catch { /* ignore */ } }
 

--- a/socioprophet-web/client-vue/src/config/mesh.ts
+++ b/socioprophet-web/client-vue/src/config/mesh.ts
@@ -38,15 +38,25 @@ function ss(key: string): string | null {
   try { return typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(key) : null; } catch { return null; }
 }
 
-// One-time migration from the old localStorage location. Copies the value into
-// sessionStorage and CLEARS the localStorage entry so the raw secret does not linger.
+// One-time migration from the old localStorage location. If the legacy key EXISTS
+// (present at all — including empty or whitespace-only), it is cleared. Only a real
+// non-whitespace token is carried over to sessionStorage; an empty/whitespace legacy
+// value is discarded, not migrated verbatim (a blank token would have been useless
+// anyway, and the callsite already treats '' as no-token). Copilot round-2 flagged
+// the earlier version, which used truthiness and so silently LEFT an empty legacy
+// entry in localStorage — contradicting the migration's own contract.
 // Idempotent: after the legacy key is cleared, this is a no-op.
 function migrateLegacyToken(): string | null {
+  // Distinguish MISSING from PRESENT-BUT-EMPTY: only the presence check tells us
+  // whether we owe a clear.
   const legacy = ls(LS_TOKEN_LEGACY);
-  if (!legacy) return null;
-  try { sessionStorage.setItem(SS_TOKEN, legacy); } catch { /* private mode / disabled */ }
+  if (legacy === null) return null;
+  // Present — always clear, whatever the shape.
   try { localStorage.removeItem(LS_TOKEN_LEGACY); } catch { /* ignore */ }
-  return legacy;
+  const trimmed = legacy.trim();
+  if (!trimmed) return null;
+  try { sessionStorage.setItem(SS_TOKEN, trimmed); } catch { /* private mode / disabled */ }
+  return trimmed;
 }
 
 export function meshBase(): string {


### PR DESCRIPTION
fix(mesh): store bearer token in sessionStorage, not localStorage

The Prophet-Mesh bearer token was written to `localStorage['sp.conn.mesh-token']`
and read from there by every mesh call. localStorage is site-scoped and
persists indefinitely across sessions, so any DOM-XSS anywhere in the app
(or a malicious browser extension) could exfiltrate the raw grant and
retain it — the blast radius was unbounded in time.

Moved to sessionStorage: the token lives for the lifetime of the tab and
is dropped on close. Blast radius of an exfil ends with the tab.

Behavior changes:
- Operators re-enter the token on browser restart (one time, per tab).
- A one-shot migration lifts an existing localStorage-lived token into
  sessionStorage on first read and CLEARS the localStorage entry, so the
  raw secret does not linger after this deploy — everyone stays signed
  in through this single restart, without leaving the persisted secret
  behind. Idempotent: second call is a no-op.

The endpoint URL (`sp.conn.mesh`) stays in localStorage — not sensitive,
and re-entering the mesh URL on every restart would be a real cost.

`meshToken()` / `setMeshToken()` signatures unchanged, so no caller edits;
Settings.vue and the chat/adapter code that consume them keep working.

Test suite (mesh.test.ts): sessionStorage-not-localStorage on write,
round-trip read, migration copies + clears the legacy value, migration
is idempotent, migration does not overwrite an in-use sessionStorage
value with a stale empty legacy, endpoint URL still uses localStorage
and strips trailing slash.

Found in the adversarial-review pass (batch B) — surface originally
shipped in #423.
