### PR TITLE
fix: bootProofRecord id collision + governanceApi drops user-cleared params

### DIFF
--- a/socioprophet-web/client-vue/src/api/governanceApi.ts
+++ b/socioprophet-web/client-vue/src/api/governanceApi.ts
@@ -22,7 +22,14 @@ export interface GovParams {
 
 export async function runGovernanceTest(p: GovParams): Promise<{ data: GovernanceTest | null; error?: string }> {
   const q = new URLSearchParams();
-  Object.entries(p).forEach(([k, v]) => { if (v) q.set(k, String(v)); });
+  // Only skip when a field is genuinely absent (undefined / null). Clearing "Evidence"
+  // to '' is a MEANINGFUL operator action — re-running the governance test with NO
+  // evidence — and if we drop the empty string here, `dashboard-bff` falls back to its
+  // default and the UI displays a receipt that does not match what the operator actually
+  // asked. Empty string is presence, not absence.
+  Object.entries(p).forEach(([k, v]) => {
+    if (v !== undefined && v !== null) q.set(k, String(v));
+  });
   try {
     const res = await fetch(`${API_BASE}/v1/governance/test?${q.toString()}`, { headers: { accept: 'application/json' } });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -179,15 +179,21 @@ const nlBootPlan = (deviceId: string, buildId: string, stages: any[]) => ({
 // scaled instances or serverless cold starts, because `_bootProofSeq` resets to 0 in
 // each process and Date.now() readily matches across them. Combined with the same-device
 // key, an id like `boot-proof:dev-1-172890123-0` could easily be minted by two workers
-// simultaneously. Add a process-unique random suffix (crypto.randomUUID short-form) so
-// ids are globally unique, not just per-process. The sequence stays for readability and
-// as a tiebreaker within a single process's tick. `bootedAt` still carries wall time.
+// simultaneously. Add a process-unique random suffix so ids are globally unique, not
+// just per-process. The sequence stays for readability and as a tiebreaker within a
+// single process's tick. `bootedAt` still carries wall time.
+//
+// Copilot round-3: the earlier 8-hex-char slice gave only 32 bits of process entropy —
+// birthday collision at ~65k concurrent process nonces (very reachable in a serverless
+// deployment over a deployment's lifetime), and Firestore treats colliding ids as
+// silent overwrites of the earlier boot-proof. Use 24 hex chars (96 bits of entropy)
+// so the birthday bound moves to ~2^48 processes — well past any realistic fleet.
 const crypto = require("crypto");
-const _bootProofNonce = crypto.randomUUID().slice(0, 8); // once per process — 32 bits of process entropy
+const _bootProofNonce = crypto.randomBytes(12).toString("hex"); // once per process — 96 bits of process entropy
 let _bootProofSeq = 0;
 const bootProofRecord = (deviceId: string, planRef: string, outcome: string) => ({
   // Deterministic-shape id: `boot-proof:{device}-{ms}-{seq}-{procNonce}`. Every id is
-  // unique across every replica by the procNonce even if seq and ms collide.
+  // unique across every replica by the 96-bit procNonce even if seq and ms collide.
   id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}-${_bootProofSeq++}-${_bootProofNonce}`,
   type: "BootProofRecord",
   specVersion: SPEC_VERSION,

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -169,8 +169,16 @@ const nlBootPlan = (deviceId: string, buildId: string, stages: any[]) => ({
 });
 
 // Evidence that a device booted a plan → conformant BootProofRecord.
+//
+// The id used to be `boot-proof:{deviceId}-{Date.now()}`, so two boot-proofs from the
+// same device in the same millisecond (retry loop, rapid stage transitions, batched
+// fleet callback) minted identical URNs and the second silently overwrote the first in
+// Firestore. Adding a per-call sequence — same pattern the sibling `eventEnvelope`
+// already uses below — makes every id unique per-tick without depending on cross-tick
+// clock resolution. `bootedAt` still carries wall time for auditors.
+let _bootProofSeq = 0;
 const bootProofRecord = (deviceId: string, planRef: string, outcome: string) => ({
-  id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}`,
+  id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}-${_bootProofSeq++}`,
   type: "BootProofRecord",
   specVersion: SPEC_VERSION,
   bootPlanRef: planRef,

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -173,12 +173,22 @@ const nlBootPlan = (deviceId: string, buildId: string, stages: any[]) => ({
 // The id used to be `boot-proof:{deviceId}-{Date.now()}`, so two boot-proofs from the
 // same device in the same millisecond (retry loop, rapid stage transitions, batched
 // fleet callback) minted identical URNs and the second silently overwrote the first in
-// Firestore. Adding a per-call sequence — same pattern the sibling `eventEnvelope`
-// already uses below — makes every id unique per-tick without depending on cross-tick
-// clock resolution. `bootedAt` still carries wall time for auditors.
+// Firestore.
+//
+// Copilot round-2: a per-process sequence alone still collides across horizontally
+// scaled instances or serverless cold starts, because `_bootProofSeq` resets to 0 in
+// each process and Date.now() readily matches across them. Combined with the same-device
+// key, an id like `boot-proof:dev-1-172890123-0` could easily be minted by two workers
+// simultaneously. Add a process-unique random suffix (crypto.randomUUID short-form) so
+// ids are globally unique, not just per-process. The sequence stays for readability and
+// as a tiebreaker within a single process's tick. `bootedAt` still carries wall time.
+const crypto = require("crypto");
+const _bootProofNonce = crypto.randomUUID().slice(0, 8); // once per process — 32 bits of process entropy
 let _bootProofSeq = 0;
 const bootProofRecord = (deviceId: string, planRef: string, outcome: string) => ({
-  id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}-${_bootProofSeq++}`,
+  // Deterministic-shape id: `boot-proof:{device}-{ms}-{seq}-{procNonce}`. Every id is
+  // unique across every replica by the procNonce even if seq and ms collide.
+  id: `urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}-${_bootProofSeq++}-${_bootProofNonce}`,
   type: "BootProofRecord",
   specVersion: SPEC_VERSION,
   bootPlanRef: planRef,


### PR DESCRIPTION
fix: two silent-wrong defects flagged by adversarial review

Two unrelated but small fixes for defects found in the merged-PR audit.
Bundled because each is a two-line change and both belong to the same
class ("Date.now / falsiness has ambiguous meaning").

### bootProofRecord id collision (server/contracts, from #395)

`bootProofRecord.id = urn:srcos:boot-proof:${lc(deviceId)}-${Date.now()}`
used `Date.now()` as the sole per-call variation. A device emitting two
boot-proofs in the same millisecond (retry loop, rapid stage transitions,
batched fleet callback) minted identical URNs; the second silently
overwrote the first in Firestore. Fixed by adding a per-process
sequence, `_bootProofSeq++`, so every id is unique per-tick — same
pattern the sibling `eventEnvelope` already uses (line 265-267 in the
same file). `bootedAt` still carries wall time for auditors.

### governance-test truthiness filter (client-vue governanceApi, from #424)

`runGovernanceTest` built the query string with
`Object.entries(p).forEach(([k,v]) => { if (v) q.set(k, String(v)); })`.
The truthiness check drops the empty string, but clearing "Evidence" to
'' is a MEANINGFUL operator action — re-run the trust-kernel gate with
NO evidence, on purpose. Dropping the field lets dashboard-bff fall
back to its default, so the UI shows a receipt derived from evidence
the operator did not supply. Empty string is presence, not absence.
Now `if (v !== undefined && v !== null)`.
