### PR TITLE
fix(ci): declare least-priv permissions on the two GRLPlus workflows

### DIFF
--- a/.github/workflows/validate-grlplus-export-snapshots.yml
+++ b/.github/workflows/validate-grlplus-export-snapshots.yml
@@ -22,6 +22,12 @@ on:
       - 'ci/validate_grlplus_*.sh'
       - '.github/workflows/validate-grlplus-export-snapshots.yml'
 
+# Least privilege — read-only. Same reasoning as validate-grlplus-exports.yml: without
+# this the job inherits the repo default (write-all on some installs), so a transitive
+# Python dep compromise gets a token that can push master.
+permissions:
+  contents: read
+
 jobs:
   validate-grlplus-export-snapshots:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-grlplus-export-snapshots.yml
+++ b/.github/workflows/validate-grlplus-export-snapshots.yml
@@ -24,7 +24,7 @@ on:
 
 # Least privilege — read-only. Same reasoning as validate-grlplus-exports.yml: without
 # this the job inherits the repo default (write-all on some installs), so a transitive
-# Python dep compromise gets a token that can push master.
+# Python dep compromise gets a token that can push to the default branch.
 permissions:
   contents: read
 

--- a/.github/workflows/validate-grlplus-exports.yml
+++ b/.github/workflows/validate-grlplus-exports.yml
@@ -22,10 +22,10 @@ on:
 
 # Least privilege — read-only. Without this block the job inherits the repo default,
 # which on some installs is write-all: a supply-chain compromise of any Python transitive
-# dep in the validate step would then get a token that can push to master. The step only
-# runs `bash ci/validate_grlplus_*.sh` on a checked-out tree, which needs contents:read
-# and nothing else. Sibling workflows (client-vue-product-build, builder-contract-tests,
-# app-vue-deploy) declare the same block for the same reason.
+# dep in the validate step would then get a token that can push to the default branch.
+# The step only runs `bash ci/validate_grlplus_*.sh` on a checked-out tree, which needs
+# contents:read and nothing else. Sibling workflows (client-vue-product-build,
+# builder-contract-tests, app-vue-deploy) declare the same block for the same reason.
 permissions:
   contents: read
 

--- a/.github/workflows/validate-grlplus-exports.yml
+++ b/.github/workflows/validate-grlplus-exports.yml
@@ -20,6 +20,15 @@ on:
       - 'ci/validate_grlplus_*.sh'
       - '.github/workflows/validate-grlplus-exports.yml'
 
+# Least privilege — read-only. Without this block the job inherits the repo default,
+# which on some installs is write-all: a supply-chain compromise of any Python transitive
+# dep in the validate step would then get a token that can push to master. The step only
+# runs `bash ci/validate_grlplus_*.sh` on a checked-out tree, which needs contents:read
+# and nothing else. Sibling workflows (client-vue-product-build, builder-contract-tests,
+# app-vue-deploy) declare the same block for the same reason.
+permissions:
+  contents: read
+
 jobs:
   validate-grlplus-exports:
     runs-on: ubuntu-latest


### PR DESCRIPTION
fix(ci): declare least-priv permissions on the two GRLPlus workflows

Both validate-grlplus-exports.yml and validate-grlplus-export-snapshots.yml
shipped without a `permissions:` block, so on installs where the repo
default GITHUB_TOKEN is `write-all` (default on many GHES tenants and older
GitHub.com repos), these jobs run with contents:write, issues:write,
pull-requests:write — far more than a `bash ci/validate_grlplus_*.sh` step
needs. A supply-chain compromise of any Python transitive dep in the
validate step would then get a token that can push to master.

Sibling workflows (client-vue-product-build.yml, builder-contract-tests.yml,
app-vue-deploy.yml) already declare `permissions: { contents: read }` for
this exact reason — this was a real oversight, not house style.

Both files now:
  permissions:
    contents: read

Nothing else changes; both were already read-only in behaviour.
