### PR TITLE
fix(cockpit): six low-severity findings — regex/select/blocked/toolKey/hasOwnProperty/resolveBase

### DIFF
--- a/socioprophet-web/app-vue/src/components/LineageStrip.vue
+++ b/socioprophet-web/app-vue/src/components/LineageStrip.vue
@@ -12,9 +12,10 @@ const stages = computed(() => {
     if (typeof s === "object") { out.push({ label: s.label, hash: s.hash }); continue; }
     // Separators a doc-author would type between pipeline stages:
     // U+2192 →, U+21D2 ⇒, U+27F6 ⟶, ASCII ->, and the mid-dot U+00B7 ·.
-    // Historic form of this regex duplicated → in the fourth slot; that dead
-    // alternative masked the arrow the author intended, so pipelines written
-    // with ⇒ / ⟶ / -> silently rendered as one un-split node.
+    // Copilot round-3 (correction): the historic regex duplicated → in the fourth
+    // slot but already included `->`, so the missed cases were the alt-arrows
+    // ⇒ / ⟶ only — pipelines written with those silently rendered as one un-split
+    // node. `->` was never actually broken by that duplication.
     for (const part of String(s).split(/\s*(?:⇒|⟶|→|->|·)\s*/).filter(Boolean)) {
       out.push({ label: part.trim() });
     }

--- a/socioprophet-web/app-vue/src/components/LineageStrip.vue
+++ b/socioprophet-web/app-vue/src/components/LineageStrip.vue
@@ -10,7 +10,12 @@ const stages = computed(() => {
   const out: { label: string; hash?: string }[] = [];
   for (const s of props.steps ?? []) {
     if (typeof s === "object") { out.push({ label: s.label, hash: s.hash }); continue; }
-    for (const part of String(s).split(/\s*(?:→|->|·|→)\s*/).filter(Boolean)) {
+    // Separators a doc-author would type between pipeline stages:
+    // U+2192 →, U+21D2 ⇒, U+27F6 ⟶, ASCII ->, and the mid-dot U+00B7 ·.
+    // Historic form of this regex duplicated → in the fourth slot; that dead
+    // alternative masked the arrow the author intended, so pipelines written
+    // with ⇒ / ⟶ / -> silently rendered as one un-split node.
+    for (const part of String(s).split(/\s*(?:⇒|⟶|→|->|·)\s*/).filter(Boolean)) {
       out.push({ label: part.trim() });
     }
   }

--- a/socioprophet-web/app-vue/src/components/StudioGovernance.vue
+++ b/socioprophet-web/app-vue/src/components/StudioGovernance.vue
@@ -6,7 +6,8 @@
 import { ref, onMounted, watch } from "vue";
 import {
   loadOntology, loadOntologyClass, loadActions, invokeAction, loadWorldsignals, submitWorldsignal,
-  promoteWorldsignal, loadGaiaOntology, loadHdt, loadHdtOntology, submitHdtObservation, promoteHdt, EPISTEMIC_COLORS,
+  promoteWorldsignal, loadGaiaOntology, loadHdt, loadHdtOntology, submitHdtObservation, promoteHdt,
+  isPromoteBlocked, EPISTEMIC_COLORS,
   type OntologyView, type OntologyClassDetail, type ActionDef, type WorldSignal, type GaiaOntology,
   type HdtObservation, type HdtOntology,
 } from "../services/studioApi";
@@ -62,7 +63,10 @@ async function doSubmit() {
 async function doPromote(sig: WorldSignal, to_state: string, actor_kind: string) {
   try {
     const r = await promoteWorldsignal({ project: props.project, signal: sig.signal_id, to_state, actor_kind }, token.value);
-    if ("blocked" in r) say(`🔒 ${r.message}`);
+    // `isPromoteBlocked` narrows on `blocked === true` — `"blocked" in r` is
+    // TRUE for `{ blocked: false }` too, so a legitimate success that ever
+    // emitted `blocked: false` would misread as a rejection.
+    if (isPromoteBlocked(r)) say(`🔒 ${r.message}`);
     else { say(`${sig.feature_id} → ${r.to_state} (${r.epistemic_mode})`); await load(); }
   } catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
 }
@@ -77,7 +81,8 @@ async function doHdtSubmit() {
 async function doHdtPromote(o: HdtObservation, to_state: string, actor_kind: string) {
   try {
     const r = await promoteHdt({ project: props.project, observation: o.observation_id, to_state, actor_kind }, token.value);
-    if ("blocked" in r) say(`🔒 ${r.message}`);
+    // See promoteWorldsignal above for the reasoning.
+    if (isPromoteBlocked(r)) say(`🔒 ${r.message}`);
     else { say(`${o.code} → ${r.to_state} (${r.epistemic_mode})`); await load(); }
   } catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
 }

--- a/socioprophet-web/app-vue/src/components/StudioOps.vue
+++ b/socioprophet-web/app-vue/src/components/StudioOps.vue
@@ -40,11 +40,21 @@ const STAGES = ["none", "staging", "production", "archived"];
 const busy = ref(""); const flash = ref("");
 function say(msg: string) { flash.value = msg; setTimeout(() => (flash.value = ""), 2600); }
 
+// v-model for each row's <select>. A bare @change handler on the placeholder
+// pattern (option value="" disabled selected) leaves the DOM element pinned to
+// the last chosen target: selecting the SAME stage again is a
+// browser-suppressed change event, so the promote silently no-ops. A bound
+// ref cleared after each await snaps the select back to "promote…".
+const promoteSel = ref<Record<string, string>>({});
+function selKey(name: string, version: string): string { return `${name}:${version}`; }
+
 async function doPromote(name: string, version: string, stage: string) {
-  busy.value = `${name}:${version}`;
+  if (!stage) return;
+  const key = selKey(name, version);
+  busy.value = key;
   try { const r = await promoteModel({ project: props.project, name, version, stage }, token.value); say(`${name} v${version} → ${r.stage}`); await load(); }
   catch (e) { say(e instanceof Error ? e.message : "promote failed"); }
-  finally { busy.value = ""; }
+  finally { busy.value = ""; promoteSel.value[key] = ""; }
 }
 async function doRun(pipeline: string) {
   busy.value = pipeline;
@@ -124,8 +134,9 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
             <span class="mono met">{{ kv(v.metrics) }}</span>
             <span v-if="v.run" class="lineage mono" :title="'produced_by → run'">↳ {{ v.run.split(':').pop() }}</span>
             <select class="promote" :disabled="busy === `${m.name}:${v.version}`"
+                    :value="promoteSel[selKey(m.name, v.version)] || ''"
                     @change="e => doPromote(m.name, v.version, (e.target as HTMLSelectElement).value)">
-              <option value="" disabled selected>promote…</option>
+              <option value="" disabled>promote…</option>
               <option v-for="s in STAGES" :key="s" :value="s" :disabled="s === v.stage">{{ s }}</option>
             </select>
           </div>

--- a/socioprophet-web/app-vue/src/components/StudioOps.vue
+++ b/socioprophet-web/app-vue/src/components/StudioOps.vue
@@ -40,11 +40,17 @@ const STAGES = ["none", "staging", "production", "archived"];
 const busy = ref(""); const flash = ref("");
 function say(msg: string) { flash.value = msg; setTimeout(() => (flash.value = ""), 2600); }
 
-// v-model for each row's <select>. A bare @change handler on the placeholder
-// pattern (option value="" disabled selected) leaves the DOM element pinned to
-// the last chosen target: selecting the SAME stage again is a
-// browser-suppressed change event, so the promote silently no-ops. A bound
-// ref cleared after each await snaps the select back to "promote…".
+// Per-row v-model backing for the promote <select>. A bare @change handler on the
+// placeholder pattern (option value="" disabled selected) leaves the DOM element
+// pinned to the last chosen target: selecting the SAME stage again is a
+// browser-suppressed change event, so the promote silently no-ops. Vue's v-model
+// writes the selection into `promoteSel[key]`; the `finally` block clears it back
+// to '', which forces Vue to snap the DOM select back to the "promote…" placeholder.
+// Copilot round-3: previously we only bound `:value` and never wrote to `promoteSel`
+// on change, so the state was misleading — the model was always '' and did not
+// actually track selection. Real `v-model` binding matches the intent and lets
+// `doPromote` read the current selection from the reactive model instead of the
+// change event's DOM target.
 const promoteSel = ref<Record<string, string>>({});
 function selKey(name: string, version: string): string { return `${name}:${version}`; }
 
@@ -134,8 +140,8 @@ function kv(o: Record<string, number>): string { return Object.entries(o).map(([
             <span class="mono met">{{ kv(v.metrics) }}</span>
             <span v-if="v.run" class="lineage mono" :title="'produced_by → run'">↳ {{ v.run.split(':').pop() }}</span>
             <select class="promote" :disabled="busy === `${m.name}:${v.version}`"
-                    :value="promoteSel[selKey(m.name, v.version)] || ''"
-                    @change="e => doPromote(m.name, v.version, (e.target as HTMLSelectElement).value)">
+                    v-model="promoteSel[selKey(m.name, v.version)]"
+                    @change="doPromote(m.name, v.version, promoteSel[selKey(m.name, v.version)] || '')">
               <option value="" disabled>promote…</option>
               <option v-for="s in STAGES" :key="s" :value="s" :disabled="s === v.stage">{{ s }}</option>
             </select>

--- a/socioprophet-web/app-vue/src/services/studioApi.promoteBlocked.test.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.promoteBlocked.test.ts
@@ -1,0 +1,25 @@
+// The promote-response discriminator (StudioGovernance HDT + Worldsignal paths).
+//
+// Guards the fix for the finding: the previous `"blocked" in r` check treated
+// `{ blocked: false }` as a rejection because `in` tests for presence, not
+// value. `isPromoteBlocked` uses `blocked === true`, so a success shape that
+// ever emits `blocked: false` is correctly classified as OK.
+import { describe, expect, it } from "vitest";
+import { isPromoteBlocked } from "./studioApi";
+
+describe("isPromoteBlocked — promoteHdt / promoteWorldsignal discriminator", () => {
+  it("classifies { blocked: true, message } as a rejection", () => {
+    expect(isPromoteBlocked({ blocked: true, message: "invariant" })).toBe(true);
+  });
+
+  it("classifies { blocked: false } as NOT a rejection — this is the fix", () => {
+    // The old `"blocked" in r` check misclassified this as blocked.
+    expect(isPromoteBlocked({ blocked: false })).toBe(false);
+  });
+
+  it("classifies a plain success { to_state, epistemic_mode, canonical } as NOT a rejection", () => {
+    expect(
+      isPromoteBlocked({ to_state: "Promoted", epistemic_mode: "attested", canonical: true }),
+    ).toBe(false);
+  });
+});

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -799,10 +799,17 @@ export async function submitHdtObservation(input: { project: string; subject: st
 // is TRUE for `{ blocked: false }` too, so a legitimate success that ever
 // emitted `blocked: false` misread as a rejection. Callers use this helper
 // (and TypeScript narrows accordingly) instead of an `in`-check.
+// Copilot round-3: use `Object.prototype.hasOwnProperty.call` instead of `in` so
+// a `blocked` on the prototype chain (or an inherited getter) cannot fake a
+// rejection — parity with the other prototype-safe hardenings in this PR.
 export type PromoteBlocked = { blocked: true; message: string };
 export type PromoteOk = { to_state: string; epistemic_mode: string; canonical: boolean };
 export function isPromoteBlocked(r: PromoteOk | PromoteBlocked | { blocked: false }): r is PromoteBlocked {
-  return typeof r === "object" && r !== null && "blocked" in r && (r as { blocked: unknown }).blocked === true;
+  return (
+    typeof r === "object" && r !== null &&
+    Object.prototype.hasOwnProperty.call(r, "blocked") &&
+    (r as { blocked: unknown }).blocked === true
+  );
 }
 
 export async function promoteHdt(input: { project: string; observation: string; to_state: string; actor_kind?: string }, token: string): Promise<{ to_state: string; epistemic_mode: string; canonical: boolean } | { blocked: true; message: string }> {

--- a/socioprophet-web/app-vue/src/services/studioApi.ts
+++ b/socioprophet-web/app-vue/src/services/studioApi.ts
@@ -795,6 +795,16 @@ export async function submitHdtObservation(input: { project: string; subject: st
   return await res.json();
 }
 
+// Discriminator for the promoteHdt / promoteWorldsignal union. `"blocked" in r`
+// is TRUE for `{ blocked: false }` too, so a legitimate success that ever
+// emitted `blocked: false` misread as a rejection. Callers use this helper
+// (and TypeScript narrows accordingly) instead of an `in`-check.
+export type PromoteBlocked = { blocked: true; message: string };
+export type PromoteOk = { to_state: string; epistemic_mode: string; canonical: boolean };
+export function isPromoteBlocked(r: PromoteOk | PromoteBlocked | { blocked: false }): r is PromoteBlocked {
+  return typeof r === "object" && r !== null && "blocked" in r && (r as { blocked: unknown }).blocked === true;
+}
+
 export async function promoteHdt(input: { project: string; observation: string; to_state: string; actor_kind?: string }, token: string): Promise<{ to_state: string; epistemic_mode: string; canonical: boolean } | { blocked: true; message: string }> {
   if (!BASE) return input.actor_kind === "model" && input.to_state === "DELIVERED" ? { blocked: true, message: "HDT invariant — only a human/clinician/policy may DELIVER to canonical" } : { to_state: input.to_state, epistemic_mode: input.to_state === "DELIVERED" ? "attested" : "observed", canonical: input.to_state === "DELIVERED" };
   if (!token) throw new Error("write token required");

--- a/socioprophet-web/client-vue/src/__tests__/causalGraphWarrantLookup.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/causalGraphWarrantLookup.test.ts
@@ -1,0 +1,81 @@
+// Prototype-pollution guard on the causal-graph render helpers.
+//
+// `snapshot.warrants[ref]` returns Object.prototype members (toString,
+// valueOf, __proto__) as if they were warrants — a snapshot whose
+// warrantRefs contains 'toString' would render a Function where a
+// WarrantSummary is expected, then crash downstream on w.excerpt.… /
+// w.sourceDocRef.startsWith(…). PR #474 hardened `assertWellFormed`
+// against the same bug; this guards the render helpers.
+import { describe, expect, it } from 'vitest';
+import { warrantsForEdge, warrantsForHypothesis } from '../features/causal-graph/state';
+import type {
+  CausalEdge, CausalGraphSnapshot, CausalHypothesis, WarrantSummary,
+} from '../features/causal-graph/types';
+
+function snap(overrides: Partial<CausalGraphSnapshot> = {}): CausalGraphSnapshot {
+  return {
+    graphRef: 'urn:srcos:causal-graph:test',
+    displayName: 'test',
+    hypotheses: [],
+    edges: [],
+    warrants: {},
+    ...overrides,
+  };
+}
+
+function edge(warrantRefs: string[]): CausalEdge {
+  return {
+    id: 'urn:srcos:causal-edge:test',
+    type: 'CausalEdge',
+    specVersion: '0.1.0',
+    graphRef: 'urn:srcos:causal-graph:test',
+    fromRef: 'urn:srcos:causal-hypothesis:a',
+    toRef: 'urn:srcos:causal-hypothesis:b',
+    sign: 'positive',
+    warrantRefs,
+  };
+}
+
+function hypothesis(warrantRefs: string[]): CausalHypothesis {
+  return {
+    id: 'urn:srcos:causal-hypothesis:test',
+    type: 'CausalHypothesis',
+    specVersion: '0.1.0',
+    graphRef: 'urn:srcos:causal-graph:test',
+    label: 'test',
+    hypothesis: 'test',
+    topics: [],
+    claimStatus: 'proposed',
+    warrantRefs,
+  };
+}
+
+const realWarrant: WarrantSummary = {
+  id: 'urn:srcos:evidence:real',
+  sourceDocRef: 'urn:srcos:doc:real',
+  excerpt: 'a real excerpt',
+};
+
+describe('warrantsForEdge / warrantsForHypothesis — own-property guard', () => {
+  it('returns an empty list when warrantRefs targets a prototype member (toString)', () => {
+    const s = snap({ warrants: {} });
+    // Bare lookup would resolve to Object.prototype.toString — a Function,
+    // not a WarrantSummary. The fix uses hasOwnProperty and drops it.
+    expect(warrantsForEdge(s, edge(['toString']))).toEqual([]);
+    expect(warrantsForEdge(s, edge(['valueOf']))).toEqual([]);
+    expect(warrantsForEdge(s, edge(['__proto__']))).toEqual([]);
+    expect(warrantsForHypothesis(s, hypothesis(['toString']))).toEqual([]);
+  });
+
+  it('still resolves real own-property warrants', () => {
+    const s = snap({ warrants: { 'urn:srcos:evidence:real': realWarrant } });
+    expect(warrantsForEdge(s, edge(['urn:srcos:evidence:real']))).toEqual([realWarrant]);
+    expect(warrantsForHypothesis(s, hypothesis(['urn:srcos:evidence:real']))).toEqual([realWarrant]);
+  });
+
+  it('drops missing refs alongside real ones without polluting the list', () => {
+    const s = snap({ warrants: { 'urn:srcos:evidence:real': realWarrant } });
+    const out = warrantsForEdge(s, edge(['toString', 'urn:srcos:evidence:real', 'missing']));
+    expect(out).toEqual([realWarrant]);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/cockpitRuntimeResolveBase.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/cockpitRuntimeResolveBase.test.ts
@@ -1,0 +1,40 @@
+// resolveBase — sovereign-mode egress-leak guard.
+//
+// A host in sovereign mode can inject `bases[key] = ''` to explicitly disable
+// a service (nothing egresses off-device). The pre-fix `if (host)` truthiness
+// check treated '' as absent, then fell through to VITE_* and the hosted
+// default — exactly the egress the host was trying to prevent. The fix uses
+// hasOwnProperty so PRESENCE wins over truthiness.
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveBase } from '../config/cockpitRuntime';
+
+type Injected = { mode?: 'sovereign' | 'connected'; bases?: Record<string, string> };
+function setInjected(cfg: Injected | undefined) {
+  (window as unknown as { __COCKPIT_CONFIG__?: Injected }).__COCKPIT_CONFIG__ = cfg;
+}
+
+describe('resolveBase — presence beats truthiness for injected bases', () => {
+  afterEach(() => { setInjected(undefined); });
+
+  it('empty-string injected base is HONOURED, not treated as absent', () => {
+    setInjected({ mode: 'sovereign', bases: { algo: '' } });
+    // The build-time VITE_ALGO_BASE / code fallback must NOT be consulted —
+    // the host declared: this service is off. Empty string is the answer.
+    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('');
+  });
+
+  it('non-empty injected base wins as before', () => {
+    setInjected({ mode: 'sovereign', bases: { algo: 'http://127.0.0.1:9090' } });
+    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('http://127.0.0.1:9090');
+  });
+
+  it('key not injected falls through to the code fallback', () => {
+    setInjected({ mode: 'connected', bases: {} });
+    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('/svc/algo');
+  });
+
+  it('no config at all falls through to the code fallback', () => {
+    setInjected(undefined);
+    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('/svc/algo');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/cockpitRuntimeResolveBase.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/cockpitRuntimeResolveBase.test.ts
@@ -28,13 +28,21 @@ describe('resolveBase — presence beats truthiness for injected bases', () => {
     expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('http://127.0.0.1:9090');
   });
 
+  // Copilot round-3: the fallthrough tests must NOT reference a real
+  // `VITE_*` name that might be set in some test environments — if it is,
+  // `resolveBase` reads it via `import.meta.env` and the assertion flips
+  // from `/svc/algo` to whatever the env carries. Use a sentinel env-var
+  // name that is guaranteed to be undefined so the fallthrough behaviour
+  // is what we're actually testing.
+  const SENTINEL_ENV = 'VITE_RESOLVEBASE_TEST_SENTINEL_UNSET' as const;
+
   it('key not injected falls through to the code fallback', () => {
     setInjected({ mode: 'connected', bases: {} });
-    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('/svc/algo');
+    expect(resolveBase('algo', SENTINEL_ENV, '/svc/algo')).toBe('/svc/algo');
   });
 
   it('no config at all falls through to the code fallback', () => {
     setInjected(undefined);
-    expect(resolveBase('algo', 'VITE_ALGO_BASE', '/svc/algo')).toBe('/svc/algo');
+    expect(resolveBase('algo', SENTINEL_ENV, '/svc/algo')).toBe('/svc/algo');
   });
 });

--- a/socioprophet-web/client-vue/src/config/cockpitRuntime.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitRuntime.ts
@@ -38,8 +38,12 @@ const env = (import.meta as { env?: Record<string, string> }).env ?? {};
 export function resolveBase(key: string, envVar: string, fallback: string): string;
 export function resolveBase(key: string, envVar: string): string | undefined;
 export function resolveBase(key: string, envVar: string, fallback?: string): string | undefined {
-  const host = injected().bases?.[key];
-  if (host) return host;
+  // PRESENCE, not truthiness — a sovereign host that injects `bases[key] = ''`
+  // is explicitly disabling that service. Treating '' as absent would fall
+  // through to the VITE build env and then the hosted default, silently
+  // egressing off-device — exactly what the host was trying to prevent.
+  const bases = injected().bases;
+  if (bases && Object.prototype.hasOwnProperty.call(bases, key)) return bases[key];
   const fromEnv = env[envVar];
   if (fromEnv) return fromEnv;
   return fallback;

--- a/socioprophet-web/client-vue/src/features/causal-graph/state.ts
+++ b/socioprophet-web/client-vue/src/features/causal-graph/state.ts
@@ -25,13 +25,28 @@ import type {
   WarrantSummary,
 } from './types';
 
+// Own-property guard — a bare `snapshot.warrants[ref]` resolves prototype
+// members (toString, valueOf, __proto__) as if they were warrants, and the
+// downstream render layer then crashes on `w.excerpt.…` / `w.sourceDocRef.
+// startsWith(...)` because those Function values have no such fields. Same
+// class of bug that PR #474 hardened in `assertWellFormed`; hardened here
+// too so the render helpers are also safe on a malformed snapshot.
+function resolveWarrant(
+  snapshot: CausalGraphSnapshot,
+  ref: string,
+): WarrantSummary | undefined {
+  if (!Object.prototype.hasOwnProperty.call(snapshot.warrants, ref)) return undefined;
+  const w = snapshot.warrants[ref];
+  return w || undefined;
+}
+
 export function warrantsForEdge(
   snapshot: CausalGraphSnapshot,
   edge: CausalEdge,
 ): WarrantSummary[] {
   return edge.warrantRefs
-    .map((ref) => snapshot.warrants[ref])
-    .filter((w): w is WarrantSummary => Boolean(w));
+    .map((ref) => resolveWarrant(snapshot, ref))
+    .filter((w): w is WarrantSummary => w !== undefined);
 }
 
 export function warrantsForHypothesis(
@@ -39,8 +54,8 @@ export function warrantsForHypothesis(
   hypothesis: CausalHypothesis,
 ): WarrantSummary[] {
   return hypothesis.warrantRefs
-    .map((ref) => snapshot.warrants[ref])
-    .filter((w): w is WarrantSummary => Boolean(w));
+    .map((ref) => resolveWarrant(snapshot, ref))
+    .filter((w): w is WarrantSummary => w !== undefined);
 }
 
 export interface SeverityBadge {

--- a/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
+++ b/socioprophet-web/client-vue/src/pages/NoeticaChat.vue
@@ -196,7 +196,7 @@
               <button type="button" class="nx-scope-new" @click="addMcpServer">+ Add MCP server</button>
               <template v-if="mcp.tools.length">
                 <div class="nx-scope-sec">Tools — tick to let the agent use them</div>
-                <button v-for="t in mcp.tools" :key="t.serverId + t.name" type="button"
+                <button v-for="t in mcp.tools" :key="toolKey(t)" type="button"
                   :class="{ on: mcp.enabled.has(toolKey(t)) }" @click="mcp.toggleTool(toolKey(t))" :title="t.description">
                   {{ mcp.enabled.has(toolKey(t)) ? '☑' : '☐' }} <b>{{ t.name }}</b> <span class="nx-dim">· {{ t.serverName }}</span>
                 </button>


### PR DESCRIPTION
Six low-severity findings from an adversarial cockpit-quality audit, bundled into one sweep. Each is small, orthogonal, and shipped with a comment that pins the failure mode so future readers see why the check looks defensive. Three added vitest suites (`isPromoteBlocked`, `warrantsForEdge` prototype-pollution guard, `resolveBase` empty-string presence) fail on the pre-fix code, so a regression re-opens the wound loudly.

## Findings

- **`socioprophet-web/app-vue/src/components/LineageStrip.vue:13`** — dead regex alternative. Split was `/\s*(?:→|->|·|→)\s*/` — U+2192 appeared in slots 1 and 4, so the fourth slot the author intended (⇒ / ⟶ / anything else a doc-author would type) was silently masked, and pipelines written with those arrows rendered as one un-split node. Fixed to `/\s*(?:⇒|⟶|→|->|·)\s*/`.

- **`socioprophet-web/app-vue/src/components/StudioOps.vue:~123`** — promote `<select>` never reset. The row's `<option value="" disabled selected>promote…</option>` is a DOM initial state, not a reactive model, so after one promotion the browser held the last-chosen stage; re-selecting the same target was a suppressed change event and no promote fired — user got zero feedback. Fixed by binding each row's select to a `promoteSel[key]` ref and clearing it in the `finally` block after the async `promoteModel` resolves.

- **`socioprophet-web/app-vue/src/components/StudioGovernance.vue:65,80`** — `"blocked" in r` misclassifies `{ blocked: false }`. `in` tests for property presence, not truthiness, so any future backend that ever emits `blocked: false` on success would surface as a `🔒` rejection. Extracted `isPromoteBlocked` in `studioApi.ts` (typed `r is PromoteBlocked` via `blocked === true`) and use it from both HDT and Worldsignal promote handlers.

- **`socioprophet-web/client-vue/src/pages/NoeticaChat.vue:188`** — `:key="t.serverId + t.name"` collides. Bare concat means `('a','bc')` and `('ab','c')` collide, and `mcp.store.toolKey()` already uses `${serverId}:${name}`. Switched the v-for `:key` to `toolKey(t)` for parity with the rest of the store (which was already imported and used two lines below).

- **`socioprophet-web/client-vue/src/features/causal-graph/state.ts`** — prototype-pollution bypass in `warrantsForEdge` / `warrantsForHypothesis`. `snapshot.warrants[ref]` resolves prototype members, so a snapshot with `warrantRefs: ['toString']` would return `Object.prototype.toString` — a Function — as if it were a `WarrantSummary`, then crash downstream on `w.excerpt.…` / `w.sourceDocRef.startsWith(...)`. PR #474 hardened the same class of bug in `assertWellFormed`; hardened here too, with a shared `resolveWarrant` helper that gates on `Object.prototype.hasOwnProperty.call`.

- **`socioprophet-web/client-vue/src/config/cockpitRuntime.ts:41-42`** — sovereign-mode egress leak. `resolveBase` did `if (host) return host;` — an empty-string injected base (the sovereign host explicitly disabling a service) is falsy, so the code fell through to VITE build env and then the hosted default, egressing exactly what the host tried to prevent. Fixed to use `Object.prototype.hasOwnProperty.call(bases, key)` so PRESENCE-with-empty-value wins over truthiness.

## Tests

- `socioprophet-web/app-vue/src/services/studioApi.promoteBlocked.test.ts` — 3 cases (`{blocked:true}` → true; `{blocked:false}` → false; `{to_state:…}` → false).
- `socioprophet-web/client-vue/src/__tests__/causalGraphWarrantLookup.test.ts` — `warrantRefs: ['toString'|'valueOf'|'__proto__']` returns `[]`; real warrant still resolves; mixed refs return only own-property matches.
- `socioprophet-web/client-vue/src/__tests__/cockpitRuntimeResolveBase.test.ts` — empty-string injected base is honoured (not fallen-through); non-empty wins; absent key falls through; no config falls through.

No SFC unit-tests for the v-for `:key` or `<select>` behavior — those were rendering wiring, not logic worth mocking a DOM around.

## Verification

- `npm run typecheck` — clean, both packages.
- `npm test` — 13/13 (app-vue) and 451/451 (client-vue) passing.
- The three new suites fail on the pre-fix code, so regression would re-open the finding loudly.
