### PR TITLE
feat(space): 4D Space Twin surface — solar system & galaxy digital twin (/space)

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/spaceEphemeris.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/spaceEphemeris.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { PLANETS, heliocentric, orbitPath, solveKepler, julianCenturiesSinceJ2000 } from '../space/ephemeris';
+
+const mag = ([x, y, z]: [number, number, number]) => Math.hypot(x, y, z);
+
+describe('Kepler solver', () => {
+  it('is exact for a circular orbit (e=0 ⇒ E=M)', () => {
+    for (const M of [0, 0.5, 1, 3, -2]) expect(solveKepler(M, 0)).toBeCloseTo(((M % (2 * Math.PI)) + Math.PI) % (2 * Math.PI) - Math.PI, 6);
+  });
+  it('satisfies M = E − e·sinE at its solution', () => {
+    for (const e of [0.01, 0.2, 0.5, 0.9]) {
+      for (const M of [0.3, 1.7, 4.2]) {
+        const E = solveKepler(M, e);
+        const m = ((M % (2 * Math.PI)) + 3 * Math.PI) % (2 * Math.PI) - Math.PI;
+        expect(E - e * Math.sin(E)).toBeCloseTo(m, 6);
+      }
+    }
+  });
+});
+
+describe('J2000 epoch', () => {
+  it('is zero Julian centuries at 2000-01-01 12:00 UTC', () => {
+    expect(julianCenturiesSinceJ2000(new Date(Date.UTC(2000, 0, 1, 12, 0, 0)))).toBeCloseTo(0, 6);
+  });
+});
+
+describe('heliocentric distances stay within true perihelion/aphelion bounds', () => {
+  // Sampling across two centuries must never place a planet outside a(1±e).
+  const dates = [
+    new Date(Date.UTC(1900, 0, 1)), new Date(Date.UTC(2000, 0, 1, 12)),
+    new Date(Date.UTC(2025, 6, 15)), new Date(Date.UTC(2099, 11, 31)),
+  ];
+  for (const p of PLANETS) {
+    it(`${p.name} r ∈ [a(1−e), a(1+e)]`, () => {
+      const { a, e } = p.elements;
+      const peri = a * (1 - e), apo = a * (1 + e);
+      for (const d of dates) {
+        const r = mag(heliocentric(p, d));
+        expect(r).toBeGreaterThanOrEqual(peri - 0.01);
+        expect(r).toBeLessThanOrEqual(apo + 0.01);
+      }
+    });
+  }
+});
+
+describe('known positions', () => {
+  it('Earth is near perihelion (~0.983 AU) in early January 2000', () => {
+    const r = mag(heliocentric(PLANETS.find((p) => p.id === 'earth')!, new Date(Date.UTC(2000, 0, 1, 12))));
+    expect(r).toBeGreaterThan(0.982);
+    expect(r).toBeLessThan(0.985);
+  });
+  it('planets are ordered outward by semi-major axis', () => {
+    const rs = PLANETS.map((p) => p.elements.a);
+    for (let k = 1; k < rs.length; k++) expect(rs[k]).toBeGreaterThan(rs[k - 1]);
+  });
+});
+
+describe('orbit path', () => {
+  it('is a closed ring whose radii bracket peri/aphelion', () => {
+    const mars = PLANETS.find((p) => p.id === 'mars')!;
+    const path = orbitPath(mars, new Date(Date.UTC(2025, 0, 1)), 64);
+    expect(path.length).toBe(65);
+    expect(mag(path[0])).toBeCloseTo(mag(path[64]), 6); // closed
+    const radii = path.map(mag);
+    const { a, e } = mars.elements;
+    expect(Math.min(...radii)).toBeGreaterThanOrEqual(a * (1 - e) - 0.02);
+    expect(Math.max(...radii)).toBeLessThanOrEqual(a * (1 + e) + 0.02);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/spaceGalaxy.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/spaceGalaxy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { generateGalaxy } from '../space/galaxy';
+
+describe('procedural galaxy', () => {
+  it('is deterministic for a given seed', () => {
+    const a = generateGalaxy({ seed: 7, count: 500 });
+    const b = generateGalaxy({ seed: 7, count: 500 });
+    expect(a).toEqual(b);
+  });
+  it('a different seed yields a different galaxy', () => {
+    const a = generateGalaxy({ seed: 1, count: 500 });
+    const b = generateGalaxy({ seed: 2, count: 500 });
+    expect(a).not.toEqual(b);
+  });
+  it('emits the requested count and stays within the disk radius', () => {
+    const stars = generateGalaxy({ seed: 3, count: 1000, radius: 90 });
+    expect(stars.length).toBe(1000);
+    for (const s of stars) {
+      const [x, y, z] = s.position;
+      expect(Math.hypot(x, y)).toBeLessThanOrEqual(90 + 1e-6);
+      expect(Math.abs(z)).toBeLessThan(90); // thin disk, always inside a cube
+      expect(s.color.every((c) => c >= 0 && c <= 255)).toBe(true);
+    }
+  });
+});

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -229,6 +229,7 @@ export const AGENT_COCKPIT: NavGroup[] = [
       { label: 'Control Plane', to: '/control-plane/org' },
       { label: 'Provenance (why a decision)', to: '/control-plane/provenance' },
       { label: 'Universe Viewer', to: '/universe' },
+      { label: 'Space Twin (4D)', to: '/space' },
       { label: 'Situations (n-ary)', to: '/situations' },
     ],
   },

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -53,6 +53,7 @@ import PortfolioBoard from './pages/PortfolioBoard.vue';
 import OperatorSurface from './pages/OperatorSurface.vue';
 import OntologySurface from './pages/OntologySurface.vue';
 import UniverseViewer from './pages/UniverseViewer.vue';
+import SpaceTwin from './pages/SpaceTwin.vue';
 import SupplyChainOrchestrator from './pages/SupplyChainOrchestrator.vue';
 import HolographMe from './pages/HolographMe.vue';
 import SituationsSurface from './pages/SituationsSurface.vue';
@@ -87,6 +88,7 @@ const explicitRoutes = [
   { path: '/operator/:id', component: OperatorSurface },
   { path: '/ontology', component: OntologySurface },
   { path: '/universe', component: UniverseViewer },
+  { path: '/space', component: SpaceTwin },
   { path: '/situations', component: SituationsSurface },
   { path: '/marketplace/orchestrate', component: SupplyChainOrchestrator },
   { path: '/capability/algorithmic-trading', component: AlgoTradingBoard },

--- a/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
+++ b/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
@@ -163,9 +163,14 @@ function initialViewState(): OrbitViewState {
     : { target: [0, 0, 0], rotationX: 62, rotationOrbit: 0, zoom: -3.4, minZoom: -6, maxZoom: 4 };
 }
 
-// deck's setProps takes view state keyed by view id, so the single OrbitView is named.
-function viewStates(extra: Partial<OrbitViewState> = {}) {
-  return { orbit: { ...initialViewState(), ...extra } };
+// The camera is CONTROLLED — we own the view state. `initialViewState()` is only the per-mode DEFAULT;
+// after mount `viewState` tracks the user's zoom/drag (via onViewStateChange), and the galaxy spin
+// advances ONLY rotationOrbit. The bug this replaces reapplied `initialViewState()` every frame, which
+// threw away the user's zoom/drag/target the instant the spin ran. deck's setProps takes view state
+// keyed by view id, so the single OrbitView is named.
+let viewState: OrbitViewState = initialViewState();
+function pushView() {
+  deck.value?.setProps({ viewState: { orbit: viewState } });
 }
 
 function render() {
@@ -177,7 +182,9 @@ function setMode(m: 'solar' | 'galaxy') {
   if (m === mode.value) return;
   mode.value = m;
   playing.value = false;
-  deck.value?.setProps({ initialViewState: viewStates(), layers: m === 'solar' ? solarLayers() : galaxyLayers() });
+  galaxyAngle = 0;                    // so re-entering galaxy mode does not resume mid-spin
+  viewState = initialViewState();     // a mode switch DELIBERATELY reframes to the new mode's default
+  deck.value?.setProps({ viewState: { orbit: viewState }, layers: m === 'solar' ? solarLayers() : galaxyLayers() });
 }
 
 // ── animation loop (time or galaxy spin) ─────────────────────────────────
@@ -190,7 +197,8 @@ function tick(ts: number) {
       if (dayOffset.value >= SPAN_DAYS) playing.value = false;
     } else {
       galaxyAngle += dt * 4;
-      deck.value?.setProps({ initialViewState: viewStates({ rotationOrbit: galaxyAngle }) });
+      viewState = { ...viewState, rotationOrbit: galaxyAngle };   // preserve the user's zoom/drag/target
+      pushView();
     }
   }
   raf = requestAnimationFrame(tick);
@@ -200,11 +208,15 @@ watch([dayOffset, mode], render);
 
 onMounted(() => {
   if (!canvasEl.value) return;
+  viewState = initialViewState();
   deck.value = new Deck<OrbitView[]>({
     canvas: canvasEl.value,
     views: [new OrbitView({ id: 'orbit', orbitAxis: 'Z', fovy: 50 })],
-    initialViewState: viewStates(),
+    viewState: { orbit: viewState },
     controller: true,
+    // Controlled view: fold the user's own zoom/drag back into `viewState` so the spin (which only
+    // touches rotationOrbit) never clobbers it, and a re-render never snaps the camera home.
+    onViewStateChange: ({ viewState: vs }) => { viewState = vs as OrbitViewState; pushView(); },
     // v9 clears to transparent by default, so the .st-stage gradient is the backdrop.
     layers: solarLayers(),
   });

--- a/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
+++ b/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
@@ -1,0 +1,248 @@
+<template>
+  <section class="st" aria-label="Space digital twin">
+    <SurfaceHeader title="Space Twin" eyebrow="Digital twinning · solar system &amp; galaxy">
+      <template #badge>
+        <ProvenanceBadge :p="mode === 'solar' ? solarProv : galaxyProv" compact />
+      </template>
+      <template #actions>
+        <div class="st-modes" role="tablist" aria-label="Twin scale">
+          <button role="tab" :aria-selected="mode === 'solar'" :class="{ on: mode === 'solar' }" @click="setMode('solar')">☉ Solar System</button>
+          <button role="tab" :aria-selected="mode === 'galaxy'" :class="{ on: mode === 'galaxy' }" @click="setMode('galaxy')">✦ Galaxy</button>
+        </div>
+      </template>
+    </SurfaceHeader>
+
+    <div class="st-stage">
+      <canvas ref="canvasEl" class="st-canvas" aria-label="3D space view — drag to orbit, scroll to zoom" />
+
+      <!-- readout overlay -->
+      <div class="st-readout" v-if="mode === 'solar'">
+        <div class="st-date">{{ dateLabel }}</div>
+        <ul class="st-planets">
+          <li v-for="p in planetReadout" :key="p.id">
+            <span class="st-dot" :style="{ background: p.css }" />{{ p.name }}
+            <span class="st-au">{{ p.au }} AU</span>
+          </li>
+        </ul>
+      </div>
+      <div class="st-readout" v-else>
+        <div class="st-date">Procedural galaxy</div>
+        <p class="st-note">{{ galaxyStars.length.toLocaleString() }} generated stars · {{ arms }} spiral arms</p>
+      </div>
+    </div>
+
+    <!-- the 4th dimension: time -->
+    <div class="st-time" v-if="mode === 'solar'">
+      <button class="st-play" :aria-label="playing ? 'Pause' : 'Play'" @click="playing = !playing">{{ playing ? '❚❚' : '▶' }}</button>
+      <input class="st-scrub" type="range" min="0" :max="SPAN_DAYS" step="1" v-model.number="dayOffset"
+             aria-label="Time" @input="playing = false" />
+      <button class="st-now" @click="goNow">Now</button>
+      <label class="st-speed">
+        speed
+        <select v-model.number="speed">
+          <option :value="1">1×</option>
+          <option :value="7">1 wk/s</option>
+          <option :value="30">1 mo/s</option>
+          <option :value="365">1 yr/s</option>
+          <option :value="3652">10 yr/s</option>
+        </select>
+      </label>
+    </div>
+    <div class="st-time st-time--galaxy" v-else>
+      <button class="st-play" :aria-label="playing ? 'Pause' : 'Play'" @click="playing = !playing">{{ playing ? '❚❚' : '▶' }}</button>
+      <span class="st-galaxy-hint">rotation is illustrative, not an angular-velocity model</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted, watch, shallowRef } from 'vue';
+import { Deck, OrbitView, COORDINATE_SYSTEM, type OrbitViewState } from '@deck.gl/core';
+import { PathLayer, PointCloudLayer, ScatterplotLayer } from '@deck.gl/layers';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import ProvenanceBadge from '../components/ProvenanceBadge.vue';
+import { prov } from '../features/provenance/types';
+import { PLANETS, heliocentric, orbitPath } from '../space/ephemeris';
+import { generateGalaxy } from '../space/galaxy';
+
+// Honest provenance — the whole point of an epistemic surface is that it declares HOW it
+// was produced. The solar system is computed & replayable (Kepler); the galaxy is admitted
+// to be a generated stand-in, never observed stellar data.
+const solarProv = prov('computed', {
+  verifier: 'Kepler propagation (src/space/ephemeris.ts, unit-tested)',
+  sources: ['JPL J2000 Keplerian elements (Standish, SSD)'],
+  formula: 'M = E − e·sinE → heliocentric ecliptic X,Y,Z',
+  note: 'Analytic Kepler, ~arc-minute fidelity 1800–2050. Not a live Horizons VECTORS ephemeris.',
+});
+const galaxyProv = prov('generated', {
+  note: 'Procedural logarithmic-spiral disk (seeded, reproducible). A structural stand-in — NOT a star catalogue.',
+});
+
+const mode = ref<'solar' | 'galaxy'>('solar');
+const canvasEl = ref<HTMLCanvasElement | null>(null);
+const deck = shallowRef<Deck<OrbitView[]> | null>(null);
+
+// ── time (the 4th dimension) ──────────────────────────────────────────────
+const SPAN_DAYS = 55152;                 // ~1950 → 2100
+const EPOCH = Date.UTC(1950, 0, 1);
+const dayOffset = ref(daysBetween(EPOCH, Date.now()));
+const playing = ref(false);
+const speed = ref(30);
+const simDate = computed(() => new Date(EPOCH + dayOffset.value * 86_400_000));
+const dateLabel = computed(() => simDate.value.toISOString().slice(0, 10));
+
+function daysBetween(a: number, b: number): number { return Math.round((b - a) / 86_400_000); }
+function goNow() { playing.value = false; dayOffset.value = daysBetween(EPOCH, Date.now()); }
+
+// ── galaxy field (generated once; deterministic) ──────────────────────────
+const arms = 4;
+const galaxyStars = Object.freeze(generateGalaxy({ seed: 42, arms, count: 6000, radius: 90 }));
+
+// ── readout ───────────────────────────────────────────────────────────────
+const planetReadout = computed(() =>
+  PLANETS.map((p) => {
+    const pos = heliocentric(p, simDate.value);
+    return {
+      id: p.id, name: p.name,
+      css: `rgb(${p.color[0]},${p.color[1]},${p.color[2]})`,
+      au: Math.hypot(pos[0], pos[1], pos[2]).toFixed(p.elements.a < 2 ? 3 : 2),
+    };
+  }),
+);
+
+// ── layer construction ──────────────────────────────────────────────────
+const AU = 20;            // scene units per AU (keeps numbers comfortable for the GPU)
+const cart = COORDINATE_SYSTEM.CARTESIAN;
+
+function solarLayers() {
+  const date = simDate.value;
+  const orbits = PLANETS.map((p) => ({
+    path: orbitPath(p, date, 160).map(([x, y, z]) => [x * AU, y * AU, z * AU]),
+    color: [...p.color, 90] as [number, number, number, number],
+  }));
+  const bodies = [
+    { position: [0, 0, 0], color: [255, 214, 92], radius: 9, name: 'Sun' },
+    ...PLANETS.map((p) => {
+      const [x, y, z] = heliocentric(p, date);
+      return {
+        position: [x * AU, y * AU, z * AU] as [number, number, number],
+        color: p.color, name: p.name,
+        radius: 2.5 + Math.log10(p.radiusKm) - 3, // log-scaled marker, never physical scale
+      };
+    }),
+  ];
+  return [
+    new PathLayer({
+      id: 'orbits', data: orbits, coordinateSystem: cart,
+      getPath: (d: any) => d.path, getColor: (d: any) => d.color,
+      getWidth: 1, widthUnits: 'pixels', widthMinPixels: 1, jointRounded: true,
+    }),
+    new ScatterplotLayer({
+      id: 'bodies', data: bodies, coordinateSystem: cart,
+      getPosition: (d: any) => d.position, getFillColor: (d: any) => d.color,
+      getRadius: (d: any) => d.radius, radiusUnits: 'pixels',
+      radiusMinPixels: 2, radiusMaxPixels: 40, stroked: false, pickable: true,
+      updateTriggers: { getPosition: dayOffset.value },
+    }),
+  ];
+}
+
+function galaxyLayers() {
+  return [
+    new PointCloudLayer({
+      id: 'galaxy', data: galaxyStars, coordinateSystem: cart,
+      getPosition: (d: any) => d.position, getColor: (d: any) => d.color,
+      getNormal: [0, 0, 1], pointSize: 1.6, sizeUnits: 'pixels', opacity: 0.9,
+    }),
+  ];
+}
+
+function initialViewState(): OrbitViewState {
+  return mode.value === 'solar'
+    ? { target: [0, 0, 0], rotationX: 42, rotationOrbit: 30, zoom: -3.2, minZoom: -6, maxZoom: 4 }
+    : { target: [0, 0, 0], rotationX: 62, rotationOrbit: 0, zoom: -3.4, minZoom: -6, maxZoom: 4 };
+}
+
+// deck's setProps takes view state keyed by view id, so the single OrbitView is named.
+function viewStates(extra: Partial<OrbitViewState> = {}) {
+  return { orbit: { ...initialViewState(), ...extra } };
+}
+
+function render() {
+  if (!deck.value) return;
+  deck.value.setProps({ layers: mode.value === 'solar' ? solarLayers() : galaxyLayers() });
+}
+
+function setMode(m: 'solar' | 'galaxy') {
+  if (m === mode.value) return;
+  mode.value = m;
+  playing.value = false;
+  deck.value?.setProps({ initialViewState: viewStates(), layers: m === 'solar' ? solarLayers() : galaxyLayers() });
+}
+
+// ── animation loop (time or galaxy spin) ─────────────────────────────────
+let raf = 0; let last = 0; let galaxyAngle = 0;
+function tick(ts: number) {
+  const dt = last ? (ts - last) / 1000 : 0; last = ts;
+  if (playing.value) {
+    if (mode.value === 'solar') {
+      dayOffset.value = Math.min(SPAN_DAYS, dayOffset.value + speed.value * Math.max(dt, 0));
+      if (dayOffset.value >= SPAN_DAYS) playing.value = false;
+    } else {
+      galaxyAngle += dt * 4;
+      deck.value?.setProps({ initialViewState: viewStates({ rotationOrbit: galaxyAngle }) });
+    }
+  }
+  raf = requestAnimationFrame(tick);
+}
+
+watch([dayOffset, mode], render);
+
+onMounted(() => {
+  if (!canvasEl.value) return;
+  deck.value = new Deck<OrbitView[]>({
+    canvas: canvasEl.value,
+    views: [new OrbitView({ id: 'orbit', orbitAxis: 'Z', fovy: 50 })],
+    initialViewState: viewStates(),
+    controller: true,
+    // v9 clears to transparent by default, so the .st-stage gradient is the backdrop.
+    layers: solarLayers(),
+  });
+  raf = requestAnimationFrame(tick);
+});
+
+onUnmounted(() => {
+  cancelAnimationFrame(raf);
+  deck.value?.finalize();
+  deck.value = null;
+});
+</script>
+
+<style scoped>
+.st { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+.st-modes { display: inline-flex; gap: 2px; background: var(--surface-2, #11151c); border-radius: 8px; padding: 3px; }
+.st-modes button { border: 0; background: transparent; color: var(--text-2, #9aa4b2); font: inherit; font-size: 0.82rem;
+  padding: 5px 12px; border-radius: 6px; cursor: pointer; }
+.st-modes button.on { background: var(--accent, #3a6df0); color: #fff; }
+.st-stage { position: relative; flex: 1; min-height: 0; border-radius: 12px; overflow: hidden;
+  background: radial-gradient(circle at 50% 40%, #0a0f18 0%, #05070c 70%); }
+.st-canvas { position: absolute; inset: 0; width: 100%; height: 100%; }
+.st-readout { position: absolute; top: 14px; left: 14px; background: rgba(6, 9, 15, 0.62);
+  backdrop-filter: blur(6px); border: 1px solid rgba(120, 140, 180, 0.18); border-radius: 10px;
+  padding: 10px 12px; color: #cfd8e6; font-size: 0.78rem; pointer-events: none; max-width: 210px; }
+.st-date { font-variant-numeric: tabular-nums; font-weight: 600; letter-spacing: 0.02em; margin-bottom: 6px; color: #eef3fa; }
+.st-planets { list-style: none; margin: 0; padding: 0; display: grid; gap: 2px; }
+.st-planets li { display: flex; align-items: center; gap: 6px; }
+.st-au { margin-left: auto; color: #8b97a8; font-variant-numeric: tabular-nums; }
+.st-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.st-note { margin: 4px 0 0; color: #8b97a8; }
+.st-time { display: flex; align-items: center; gap: 12px; padding: 12px 4px 2px; }
+.st-time--galaxy { color: #8b97a8; font-size: 0.8rem; }
+.st-play, .st-now { border: 1px solid rgba(120, 140, 180, 0.3); background: var(--surface-2, #11151c);
+  color: #cfd8e6; border-radius: 8px; padding: 6px 12px; cursor: pointer; font: inherit; }
+.st-scrub { flex: 1; accent-color: var(--accent, #3a6df0); }
+.st-speed { display: flex; align-items: center; gap: 6px; color: #8b97a8; font-size: 0.8rem; }
+.st-speed select { background: var(--surface-2, #11151c); color: #cfd8e6; border: 1px solid rgba(120, 140, 180, 0.3);
+  border-radius: 6px; padding: 4px 6px; }
+.st-galaxy-hint { margin-left: 4px; }
+</style>

--- a/socioprophet-web/client-vue/src/space/ephemeris.ts
+++ b/socioprophet-web/client-vue/src/space/ephemeris.ts
@@ -1,0 +1,159 @@
+// Heliocentric ephemeris for the eight planets — pure, deterministic, replayable.
+//
+// This is the "computed" tier of the estate's Assay: given a time, the position is
+// derived from published orbital elements by Kepler's equation, with no network call
+// and no hidden state. The whole solar-system twin is therefore sovereign (nothing
+// leaves the browser) and its provenance is honest — it is analytic Kepler from JPL's
+// J2000 approximate elements, NOT a live Horizons VECTORS ephemeris. Good to roughly
+// arc-minute fidelity over 1800–2050; the twin labels itself as such rather than
+// overclaiming a precision it does not have.
+//
+// Source of the element table: Standish, "Keplerian Elements for Approximate Positions
+// of the Major Planets" (JPL Solar System Dynamics). Elements are given at J2000 with
+// linear rates per Julian century.
+
+export interface KeplerElements {
+  /** semi-major axis, AU, and its rate (AU/century) */
+  a: number; aDot: number;
+  /** eccentricity (rad-less) and rate per century */
+  e: number; eDot: number;
+  /** inclination to the ecliptic, degrees, and rate */
+  i: number; iDot: number;
+  /** mean longitude, degrees, and rate */
+  L: number; LDot: number;
+  /** longitude of perihelion, degrees, and rate */
+  wBar: number; wBarDot: number;
+  /** longitude of the ascending node, degrees, and rate */
+  Omega: number; OmegaDot: number;
+}
+
+export interface Planet {
+  id: string;
+  name: string;
+  /** display colour [r,g,b] */
+  color: [number, number, number];
+  /** equatorial radius, km — for a log-scaled marker, never physical scale */
+  radiusKm: number;
+  /** sidereal orbital period in days, for the readout only */
+  periodDays: number;
+  elements: KeplerElements;
+}
+
+export const AU_KM = 149_597_870.7;
+const DEG = Math.PI / 180;
+const J2000 = 2_451_545.0; // Julian date of the J2000.0 epoch
+
+// a, aDot, e, eDot, i, iDot, L, LDot, wBar, wBarDot, Omega, OmegaDot
+export const PLANETS: Planet[] = [
+  { id: 'mercury', name: 'Mercury', color: [176, 156, 130], radiusKm: 2440, periodDays: 87.969,
+    elements: { a: 0.38709927, aDot: 0.00000037, e: 0.20563593, eDot: 0.00001906,
+      i: 7.00497902, iDot: -0.00594749, L: 252.25032350, LDot: 149472.67411175,
+      wBar: 77.45779628, wBarDot: 0.16047689, Omega: 48.33076593, OmegaDot: -0.12534081 } },
+  { id: 'venus', name: 'Venus', color: [222, 184, 135], radiusKm: 6052, periodDays: 224.701,
+    elements: { a: 0.72333566, aDot: 0.00000390, e: 0.00677672, eDot: -0.00004107,
+      i: 3.39467605, iDot: -0.00078890, L: 181.97909950, LDot: 58517.81538729,
+      wBar: 131.60246718, wBarDot: 0.00268329, Omega: 76.67984255, OmegaDot: -0.27769418 } },
+  { id: 'earth', name: 'Earth', color: [90, 160, 235], radiusKm: 6371, periodDays: 365.256,
+    elements: { a: 1.00000261, aDot: 0.00000562, e: 0.01671123, eDot: -0.00004392,
+      i: -0.00001531, iDot: -0.01294668, L: 100.46457166, LDot: 35999.37244981,
+      wBar: 102.93768193, wBarDot: 0.32327364, Omega: 0.0, OmegaDot: 0.0 } },
+  { id: 'mars', name: 'Mars', color: [214, 110, 74], radiusKm: 3390, periodDays: 686.980,
+    elements: { a: 1.52371034, aDot: 0.00001847, e: 0.09339410, eDot: 0.00007882,
+      i: 1.84969142, iDot: -0.00813131, L: -4.55343205, LDot: 19140.30268499,
+      wBar: -23.94362959, wBarDot: 0.44441088, Omega: 49.55953891, OmegaDot: -0.29257343 } },
+  { id: 'jupiter', name: 'Jupiter', color: [214, 178, 133], radiusKm: 69911, periodDays: 4332.589,
+    elements: { a: 5.20288700, aDot: -0.00011607, e: 0.04838624, eDot: -0.00013253,
+      i: 1.30439695, iDot: -0.00183714, L: 34.39644051, LDot: 3034.74612775,
+      wBar: 14.72847983, wBarDot: 0.21252668, Omega: 100.47390909, OmegaDot: 0.20469106 } },
+  { id: 'saturn', name: 'Saturn', color: [222, 202, 150], radiusKm: 58232, periodDays: 10759.22,
+    elements: { a: 9.53667594, aDot: -0.00125060, e: 0.05386179, eDot: -0.00050991,
+      i: 2.48599187, iDot: 0.00193609, L: 49.95424423, LDot: 1222.49362201,
+      wBar: 92.59887831, wBarDot: -0.41897216, Omega: 113.66242448, OmegaDot: -0.28867794 } },
+  { id: 'uranus', name: 'Uranus', color: [172, 214, 220], radiusKm: 25362, periodDays: 30685.4,
+    elements: { a: 19.18916464, aDot: -0.00196176, e: 0.04725744, eDot: -0.00004397,
+      i: 0.77263783, iDot: -0.00242939, L: 313.23810451, LDot: 428.48202785,
+      wBar: 170.95427630, wBarDot: 0.40805281, Omega: 74.01692503, OmegaDot: 0.04240589 } },
+  { id: 'neptune', name: 'Neptune', color: [110, 140, 235], radiusKm: 24622, periodDays: 60189.0,
+    elements: { a: 30.06992276, aDot: 0.00026291, e: 0.00859048, eDot: 0.00005105,
+      i: 1.77004347, iDot: 0.00035372, L: -55.12002969, LDot: 218.45945325,
+      wBar: 44.96476227, wBarDot: -0.32241464, Omega: 131.78422574, OmegaDot: -0.00508664 } },
+];
+
+/** Days since J2000.0 for a JS Date (UTC). 86_400_000 ms per day. */
+export function julianCenturiesSinceJ2000(date: Date): number {
+  const jd = date.getTime() / 86_400_000 + 2_440_587.5; // Unix epoch → JD
+  return (jd - J2000) / 36525;
+}
+
+/** Solve Kepler's equation M = E − e·sinE (E, M in radians) by Newton's method. */
+export function solveKepler(M: number, e: number, tol = 1e-8): number {
+  // normalise M to [−π, π] so the initial guess and convergence are well-behaved
+  let m = M % (2 * Math.PI);
+  if (m > Math.PI) m -= 2 * Math.PI;
+  if (m < -Math.PI) m += 2 * Math.PI;
+  let E = m + e * Math.sin(m); // standard first guess
+  for (let k = 0; k < 100; k++) {
+    const dE = (E - e * Math.sin(E) - m) / (1 - e * Math.cos(E));
+    E -= dE;
+    if (Math.abs(dE) < tol) break;
+  }
+  return E;
+}
+
+/** Heliocentric ecliptic position in AU at time `t`, as [x, y, z]. */
+export function heliocentric(planet: Planet, t: Date): [number, number, number] {
+  const T = julianCenturiesSinceJ2000(t);
+  const el = planet.elements;
+  const a = el.a + el.aDot * T;
+  const e = el.e + el.eDot * T;
+  const i = (el.i + el.iDot * T) * DEG;
+  const L = (el.L + el.LDot * T) * DEG;
+  const wBar = (el.wBar + el.wBarDot * T) * DEG;
+  const Omega = (el.Omega + el.OmegaDot * T) * DEG;
+
+  const omega = wBar - Omega;       // argument of perihelion
+  const M = L - wBar;               // mean anomaly
+  const E = solveKepler(M, e);
+
+  // position in the orbital plane (perifocal), x toward perihelion
+  const xOrb = a * (Math.cos(E) - e);
+  const yOrb = a * Math.sqrt(1 - e * e) * Math.sin(E);
+
+  // rotate perifocal → ecliptic: R_z(Omega) · R_x(i) · R_z(omega)
+  const cO = Math.cos(Omega), sO = Math.sin(Omega);
+  const ci = Math.cos(i), si = Math.sin(i);
+  const cw = Math.cos(omega), sw = Math.sin(omega);
+
+  const x = (cO * cw - sO * sw * ci) * xOrb + (-cO * sw - sO * cw * ci) * yOrb;
+  const y = (sO * cw + cO * sw * ci) * xOrb + (-sO * sw + cO * cw * ci) * yOrb;
+  const z = (sw * si) * xOrb + (cw * si) * yOrb;
+  return [x, y, z];
+}
+
+/** One full orbit sampled as a closed ring of ecliptic points, for the orbit path.
+ *  Sampling in eccentric anomaly (not time) keeps the ellipse smooth at perihelion. */
+export function orbitPath(planet: Planet, t: Date, samples = 128): [number, number, number][] {
+  const T = julianCenturiesSinceJ2000(t);
+  const el = planet.elements;
+  const a = el.a + el.aDot * T;
+  const e = el.e + el.eDot * T;
+  const i = (el.i + el.iDot * T) * DEG;
+  const wBar = (el.wBar + el.wBarDot * T) * DEG;
+  const Omega = (el.Omega + el.OmegaDot * T) * DEG;
+  const omega = wBar - Omega;
+  const cO = Math.cos(Omega), sO = Math.sin(Omega);
+  const ci = Math.cos(i), si = Math.sin(i);
+  const cw = Math.cos(omega), sw = Math.sin(omega);
+  const pts: [number, number, number][] = [];
+  for (let k = 0; k <= samples; k++) {
+    const E = (k / samples) * 2 * Math.PI;
+    const xOrb = a * (Math.cos(E) - e);
+    const yOrb = a * Math.sqrt(1 - e * e) * Math.sin(E);
+    pts.push([
+      (cO * cw - sO * sw * ci) * xOrb + (-cO * sw - sO * cw * ci) * yOrb,
+      (sO * cw + cO * sw * ci) * xOrb + (-sO * sw + cO * cw * ci) * yOrb,
+      (sw * si) * xOrb + (cw * si) * yOrb,
+    ]);
+  }
+  return pts;
+}

--- a/socioprophet-web/client-vue/src/space/galaxy.ts
+++ b/socioprophet-web/client-vue/src/space/galaxy.ts
@@ -1,0 +1,63 @@
+// Procedural galaxy point field — the far-field backdrop of the twin.
+//
+// This is NOT a star catalogue: it is a generated logarithmic-spiral disk, deterministic
+// given its seed, used as a structural stand-in until a real HYG/Gaia subset is wired in.
+// The screen labels it as such (provenance: "generated") so it is never mistaken for
+// observed stellar positions. Kept pure and seeded so the same seed always yields the
+// same galaxy — a twin must be reproducible, not a different sky each reload.
+
+export interface StarPoint {
+  position: [number, number, number];
+  color: [number, number, number];
+  size: number;
+}
+
+/** Mulberry32 — a tiny, fast, seedable PRNG. Determinism is the point. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface GalaxyOptions {
+  seed?: number;
+  arms?: number;
+  count?: number;
+  /** disk radius in scene units */
+  radius?: number;
+  /** how tightly the arms wind (radians of twist per unit radius) */
+  twist?: number;
+}
+
+/** A logarithmic-spiral galaxy: a warm bulge, cooler disk stars scattered around
+ *  `arms` trailing spiral arms, with vertical thickness falling off toward the rim. */
+export function generateGalaxy(opts: GalaxyOptions = {}): StarPoint[] {
+  const { seed = 42, arms = 4, count = 6000, radius = 90, twist = 2.6 } = opts;
+  const rnd = mulberry32(seed);
+  const out: StarPoint[] = [];
+  for (let k = 0; k < count; k++) {
+    // radius biased toward the centre (r = R·u² gives a denser bulge)
+    const u = rnd();
+    const r = radius * u * u;
+    const arm = Math.floor(rnd() * arms);
+    const armAngle = (arm / arms) * 2 * Math.PI;
+    // spiral: angle grows with radius; scatter shrinks outward so arms stay defined
+    const scatter = (rnd() - 0.5) * (0.6 - 0.4 * u);
+    const theta = armAngle + r * twist / radius + scatter;
+    const x = Math.cos(theta) * r;
+    const y = Math.sin(theta) * r;
+    const z = (rnd() - 0.5) * radius * 0.06 * (1 - u); // thin disk, thinner at the rim
+
+    // colour: warm/bright in the bulge, cool blue-white in the outer arms
+    const warm = 1 - u;
+    const cr = Math.round(150 + 105 * warm);
+    const cg = Math.round(150 + 70 * warm);
+    const cb = Math.round(200 + 55 * u);
+    out.push({ position: [x, y, z], color: [cr, cg, Math.min(255, cb)], size: 0.6 + rnd() * 1.4 });
+  }
+  return out;
+}

--- a/socioprophet-web/client-vue/src/space/galaxy.ts
+++ b/socioprophet-web/client-vue/src/space/galaxy.ts
@@ -36,7 +36,12 @@ export interface GalaxyOptions {
 /** A logarithmic-spiral galaxy: a warm bulge, cooler disk stars scattered around
  *  `arms` trailing spiral arms, with vertical thickness falling off toward the rim. */
 export function generateGalaxy(opts: GalaxyOptions = {}): StarPoint[] {
-  const { seed = 42, arms = 4, count = 6000, radius = 90, twist = 2.6 } = opts;
+  const { seed = 42, count = 6000, twist = 2.6 } = opts;
+  // `arms` and `radius` are DIVISORS below (`arm / arms`, `r * twist / radius`). A caller passing 0 —
+  // or a negative — would emit a whole field of NaN positions, which deck.gl renders as nothing (or
+  // scattered garbage) with no error. Clamp to safe positives; an unspecified value keeps the defaults.
+  const arms = Math.max(1, Math.trunc(opts.arms ?? 4));
+  const radius = opts.radius != null && opts.radius > 0 ? opts.radius : 90;
   const rnd = mulberry32(seed);
   const out: StarPoint[] = [];
   for (let k = 0; k < count; k++) {


### PR DESCRIPTION
A new **/space** screen in the Vue cockpit that renders `usol-space-library`'s domain as an interactive **3D-over-time** twin. `usol-space-library` is a headless Python ephemeris library with no UI; this is the surface that visualizes it.

## What it does
- **Solar System mode** — Sun + all eight planets on their orbits in a rotatable deck.gl `OrbitView` (the first standalone `Deck` in this app; prior deck use was a MapLibre overlay). A **time scrubber — the 4th dimension** — sweeps 1950→2100; play/pause runs the clock at 1× → 10 yr/s and every planet moves along its orbit. Live AU-distance readout per planet.
- **Galaxy mode** — a procedural logarithmic-spiral star field as the far-field twin.

## Why the twin is *honest* (the epistemic bit)
`src/space/ephemeris.ts` propagates **JPL J2000 Keplerian elements** (Standish/SSD) through Kepler's equation to heliocentric ecliptic X,Y,Z. Pure, deterministic, **no network** — the whole solar twin is sovereign (nothing leaves the browser).

The surface declares its own provenance via the estate `ProvenanceBadge`:
- solar system = **`computed`** tier (replayable from its inputs)
- galaxy = **`generated`** (a procedural stand-in, *not* a star catalogue)

It never claims a fidelity it doesn't have — no live-Horizons pretence, no observed-stellar-data pretence. Every surface shows its warrant.

## Tests — 17, on the pure math a WebGL view can't assert
- **ephemeris:** Kepler solver satisfies `M = E − e·sinE`; every planet's distance stays within its true perihelion/aphelion across two centuries; Earth ≈ 0.983 AU near perihelion at J2000; orbit paths close and bracket peri/aphelion.
- **galaxy:** seeded determinism, seed-sensitivity, count + disk-radius bounds.

`vue-tsc` clean on all new files. Route `/space` in `main.ts`; nav under **Studio** in `cockpitNav.ts`.

## Not in this PR (next)
Swap analytic Kepler for usol's **live Horizons VECTORS** via a backend endpoint (high-fidelity ephemeris); a real **HYG/Gaia** star subset + **DIRBE** all-sky backdrop for the galaxy. Visual in-browser verification is the natural next step (unit tests cover the math; the WebGL view is not asserted headlessly).