### PR TITLE
fix(client-vue): repair sanitizeHtml typecheck under dompurify v3

### DIFF
--- a/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
+++ b/socioprophet-web/client-vue/src/utils/sanitizeHtml.ts
@@ -8,9 +8,13 @@
 // DOMPurify is already the shipped pattern for the chat markdown path — see
 // `renderMarkdown` in `./markdown.ts`. Using it here keeps notebook rendering on
 // the same audited allowlist rather than inventing a second, weaker one.
-import DOMPurify from 'dompurify';
+import DOMPurify, { type Config } from 'dompurify';
 
-const HTML_OPTS: DOMPurify.Config = {
+// dompurify v3 exports `Config` as a named type (the old `DOMPurify.Config`
+// namespace is gone). Typing the options as `Config` also lets `sanitize`
+// resolve to its `(dirty, cfg?: Config): string` overload instead of the
+// `RETURN_TRUSTED_TYPE: true` one that returns TrustedHTML.
+const HTML_OPTS: Config = {
   // Copilot round-2: pin the sanitiser to the HTML profile. Without this DOMPurify
   // permits SVG and MathML inside an HTML payload, which reopens the SVG-smuggle
   // surface `sanitizeCellSvg` was split out to police — an attacker could ship an
@@ -24,7 +28,7 @@ const HTML_OPTS: DOMPurify.Config = {
   ADD_ATTR: ['target', 'rel'],
 };
 
-const SVG_OPTS: DOMPurify.Config = {
+const SVG_OPTS: Config = {
   // Cell PNGs go through `:src="'data:image/png;base64,'+..."`, but SVG plots
   // (matplotlib, plotly static) come in as raw markup. Restrict DOMPurify to the
   // SVG grammar rather than the HTML grammar so a stray `<script>` in an SVG is


### PR DESCRIPTION
`client-vue-product-build` has been **red on master** (last several pushes) at the **Typecheck** step — a pre-existing, estate-wide gate failure unrelated to any feature work.

## Cause
dompurify v3 (3.4.12) removed the `DOMPurify.Config` namespace — `Config` is now a **named type export**. So `const HTML_OPTS: DOMPurify.Config = …` fails with `TS2503: Cannot find namespace 'DOMPurify'`, which types the options as broken and makes `DOMPurify.sanitize()` resolve to the `RETURN_TRUSTED_TYPE: true` overload (returning `TrustedHTML`), tripping 4× `TS2322: Type 'TrustedHTML' is not assignable to type 'string'`. Six errors total, all in `src/utils/sanitizeHtml.ts`.

## Fix
Import the named `Config` type and annotate both option objects with it. That clears the namespace error **and** lets `sanitize` resolve to its `(dirty, cfg?: Config): string` overload. **No runtime or behaviour change** — purely a type annotation repair.

## Verified
`vue-tsc --noEmit` now reports **0 errors** (was 6). This unblocks the entire client-vue CI gate (and the pending cockpit PR #494).

🤖 Generated with [Claude Code](https://claude.com/claude-code)