### PR TITLE
chore(client-vue): gitignore stray bun.lock

### DIFF
--- a/socioprophet-web/client-vue/.gitignore
+++ b/socioprophet-web/client-vue/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 dist/
 package-lock.json
+bun.lock


### PR DESCRIPTION
A stray `bun.lock` (from someone running `bun install` locally) was sitting untracked in `socioprophet-web/client-vue/`. `pnpm-lock.yaml` is the projects canonical lockfile. Deleted the stray file and gitignored it so it stops showing up as noise in `git status`.