### PR TITLE
feat(cockpit): ProjectComputeSetting — governed cluster + federated-mesh compute, in Studio

### DIFF
--- a/.github/workflows/project-compute-setting.yml
+++ b/.github/workflows/project-compute-setting.yml
@@ -1,0 +1,32 @@
+name: project-compute-setting
+
+on:
+  pull_request:
+    paths:
+      - "schemas/control-plane/project-compute-setting.schema.json"
+      - "examples/control-plane/project-compute-setting*.json"
+      - "scripts/validate_project_compute_setting.py"
+      - ".github/workflows/project-compute-setting.yml"
+  push:
+    branches: [ main, master ]
+    paths:
+      - "schemas/control-plane/project-compute-setting.schema.json"
+      - "examples/control-plane/project-compute-setting*.json"
+      - "scripts/validate_project_compute_setting.py"
+      - ".github/workflows/project-compute-setting.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install jsonschema
+      - name: Validate ProjectComputeSetting contract
+        run: python3 scripts/validate_project_compute_setting.py

--- a/examples/control-plane/project-compute-setting.example.json
+++ b/examples/control-plane/project-compute-setting.example.json
@@ -1,0 +1,96 @@
+{
+  "apiVersion": "control.socioprophet.org/v1alpha1",
+  "kind": "ProjectComputeSetting",
+  "metadata": {
+    "id": "project-compute-setting:heller-personal-research",
+    "projectRef": "project:heller-personal-research",
+    "createdAt": "2026-08-03T00:00:00Z"
+  },
+  "spec": {
+    "planes": {
+      "governed": {
+        "enabled": true,
+        "clusterRef": "cluster:us-east-gov-1",
+        "region": "us-east",
+        "defaultEnclave": "US-East-Gov-1"
+      },
+      "mesh": {
+        "enabled": true,
+        "twinRef": "urn:srcos:agent-machine:a2a-state-machine:inception-twin-default",
+        "trustedNodes": [
+          {
+            "nodeRef": "node:edge-a-01",
+            "hostRef": "urn:srcos:agent-machine:m2-asahi-local",
+            "attestationRef": "attest:edge-a-01"
+          },
+          {
+            "nodeRef": "node:twin-k8s",
+            "hostRef": "urn:srcos:agent-machine:twin-k8s",
+            "attestationRef": "attest:twin-k8s"
+          }
+        ],
+        "minTrust": 3,
+        "revocation": {
+          "required": true,
+          "propagationSeconds": 5
+        }
+      }
+    },
+    "workUnitDefaults": {
+      "schemaId": "sha3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "proofMode": "tee",
+      "sandbox": "wasm",
+      "policyRef": "policy://compute/residency-pii"
+    },
+    "cryptoProfileRef": "crypto://tritrpc/fips",
+    "federationCryptoProfileRef": "fedcrypto://fips/ecdsa",
+    "deployments": [
+      {
+        "name": "FraudDetector-v2",
+        "type": "cluster",
+        "status": "running",
+        "regionEnclave": "US-East-Gov-1",
+        "dataClass": "PII-restricted",
+        "ownerRef": "user:j-rivera",
+        "iamRoles": [
+          "Users"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:1c8437..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/us-gov"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324578"
+        }
+      },
+      {
+        "name": "BatchRiskScore",
+        "type": "mesh",
+        "status": "stopped",
+        "regionEnclave": "EU-Sovereign-2",
+        "dataClass": "Trusted-TPM",
+        "ownerRef": "user:s-lee",
+        "iamRoles": [
+          "Trusted"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:aa0011..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/eu-sovereign"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324579"
+        }
+      }
+    ]
+  }
+}

--- a/examples/control-plane/project-compute-setting.mesh-no-twin.invalid.json
+++ b/examples/control-plane/project-compute-setting.mesh-no-twin.invalid.json
@@ -1,0 +1,95 @@
+{
+  "apiVersion": "control.socioprophet.org/v1alpha1",
+  "kind": "ProjectComputeSetting",
+  "metadata": {
+    "id": "project-compute-setting:heller-personal-research",
+    "projectRef": "project:heller-personal-research",
+    "createdAt": "2026-08-03T00:00:00Z"
+  },
+  "spec": {
+    "planes": {
+      "governed": {
+        "enabled": true,
+        "clusterRef": "cluster:us-east-gov-1",
+        "region": "us-east",
+        "defaultEnclave": "US-East-Gov-1"
+      },
+      "mesh": {
+        "enabled": true,
+        "trustedNodes": [
+          {
+            "nodeRef": "node:edge-a-01",
+            "hostRef": "urn:srcos:agent-machine:m2-asahi-local",
+            "attestationRef": "attest:edge-a-01"
+          },
+          {
+            "nodeRef": "node:twin-k8s",
+            "hostRef": "urn:srcos:agent-machine:twin-k8s",
+            "attestationRef": "attest:twin-k8s"
+          }
+        ],
+        "minTrust": 3,
+        "revocation": {
+          "required": true,
+          "propagationSeconds": 5
+        }
+      }
+    },
+    "workUnitDefaults": {
+      "schemaId": "sha3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "proofMode": "tee",
+      "sandbox": "wasm",
+      "policyRef": "policy://compute/residency-pii"
+    },
+    "cryptoProfileRef": "crypto://tritrpc/fips",
+    "federationCryptoProfileRef": "fedcrypto://fips/ecdsa",
+    "deployments": [
+      {
+        "name": "FraudDetector-v2",
+        "type": "cluster",
+        "status": "running",
+        "regionEnclave": "US-East-Gov-1",
+        "dataClass": "PII-restricted",
+        "ownerRef": "user:j-rivera",
+        "iamRoles": [
+          "Users"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:1c8437..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/us-gov"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324578"
+        }
+      },
+      {
+        "name": "BatchRiskScore",
+        "type": "mesh",
+        "status": "stopped",
+        "regionEnclave": "EU-Sovereign-2",
+        "dataClass": "Trusted-TPM",
+        "ownerRef": "user:s-lee",
+        "iamRoles": [
+          "Trusted"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:aa0011..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/eu-sovereign"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324579"
+        }
+      }
+    ]
+  }
+}

--- a/examples/control-plane/project-compute-setting.mesh-not-revocable.invalid.json
+++ b/examples/control-plane/project-compute-setting.mesh-not-revocable.invalid.json
@@ -1,0 +1,96 @@
+{
+  "apiVersion": "control.socioprophet.org/v1alpha1",
+  "kind": "ProjectComputeSetting",
+  "metadata": {
+    "id": "project-compute-setting:heller-personal-research",
+    "projectRef": "project:heller-personal-research",
+    "createdAt": "2026-08-03T00:00:00Z"
+  },
+  "spec": {
+    "planes": {
+      "governed": {
+        "enabled": true,
+        "clusterRef": "cluster:us-east-gov-1",
+        "region": "us-east",
+        "defaultEnclave": "US-East-Gov-1"
+      },
+      "mesh": {
+        "enabled": true,
+        "twinRef": "urn:srcos:agent-machine:a2a-state-machine:inception-twin-default",
+        "trustedNodes": [
+          {
+            "nodeRef": "node:edge-a-01",
+            "hostRef": "urn:srcos:agent-machine:m2-asahi-local",
+            "attestationRef": "attest:edge-a-01"
+          },
+          {
+            "nodeRef": "node:twin-k8s",
+            "hostRef": "urn:srcos:agent-machine:twin-k8s",
+            "attestationRef": "attest:twin-k8s"
+          }
+        ],
+        "minTrust": 3,
+        "revocation": {
+          "required": false,
+          "propagationSeconds": 5
+        }
+      }
+    },
+    "workUnitDefaults": {
+      "schemaId": "sha3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "proofMode": "tee",
+      "sandbox": "wasm",
+      "policyRef": "policy://compute/residency-pii"
+    },
+    "cryptoProfileRef": "crypto://tritrpc/fips",
+    "federationCryptoProfileRef": "fedcrypto://fips/ecdsa",
+    "deployments": [
+      {
+        "name": "FraudDetector-v2",
+        "type": "cluster",
+        "status": "running",
+        "regionEnclave": "US-East-Gov-1",
+        "dataClass": "PII-restricted",
+        "ownerRef": "user:j-rivera",
+        "iamRoles": [
+          "Users"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:1c8437..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/us-gov"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324578"
+        }
+      },
+      {
+        "name": "BatchRiskScore",
+        "type": "mesh",
+        "status": "stopped",
+        "regionEnclave": "EU-Sovereign-2",
+        "dataClass": "Trusted-TPM",
+        "ownerRef": "user:s-lee",
+        "iamRoles": [
+          "Trusted"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:aa0011..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/eu-sovereign"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324579"
+        }
+      }
+    ]
+  }
+}

--- a/examples/control-plane/project-compute-setting.noncompliant-deploy.invalid.json
+++ b/examples/control-plane/project-compute-setting.noncompliant-deploy.invalid.json
@@ -1,0 +1,96 @@
+{
+  "apiVersion": "control.socioprophet.org/v1alpha1",
+  "kind": "ProjectComputeSetting",
+  "metadata": {
+    "id": "project-compute-setting:heller-personal-research",
+    "projectRef": "project:heller-personal-research",
+    "createdAt": "2026-08-03T00:00:00Z"
+  },
+  "spec": {
+    "planes": {
+      "governed": {
+        "enabled": true,
+        "clusterRef": "cluster:us-east-gov-1",
+        "region": "us-east",
+        "defaultEnclave": "US-East-Gov-1"
+      },
+      "mesh": {
+        "enabled": true,
+        "twinRef": "urn:srcos:agent-machine:a2a-state-machine:inception-twin-default",
+        "trustedNodes": [
+          {
+            "nodeRef": "node:edge-a-01",
+            "hostRef": "urn:srcos:agent-machine:m2-asahi-local",
+            "attestationRef": "attest:edge-a-01"
+          },
+          {
+            "nodeRef": "node:twin-k8s",
+            "hostRef": "urn:srcos:agent-machine:twin-k8s",
+            "attestationRef": "attest:twin-k8s"
+          }
+        ],
+        "minTrust": 3,
+        "revocation": {
+          "required": true,
+          "propagationSeconds": 5
+        }
+      }
+    },
+    "workUnitDefaults": {
+      "schemaId": "sha3:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "proofMode": "tee",
+      "sandbox": "wasm",
+      "policyRef": "policy://compute/residency-pii"
+    },
+    "cryptoProfileRef": "crypto://tritrpc/fips",
+    "federationCryptoProfileRef": "fedcrypto://fips/ecdsa",
+    "deployments": [
+      {
+        "name": "FraudDetector-v2",
+        "type": "cluster",
+        "status": "running",
+        "regionEnclave": "US-East-Gov-1",
+        "dataClass": "PII-restricted",
+        "ownerRef": "user:j-rivera",
+        "iamRoles": [
+          "Users"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:1c8437..."
+        },
+        "policyDrift": {
+          "compliant": false,
+          "residencyPolicyRef": "policy://residency/us-gov"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324578"
+        }
+      },
+      {
+        "name": "BatchRiskScore",
+        "type": "mesh",
+        "status": "stopped",
+        "regionEnclave": "EU-Sovereign-2",
+        "dataClass": "Trusted-TPM",
+        "ownerRef": "user:s-lee",
+        "iamRoles": [
+          "Trusted"
+        ],
+        "attestation": {
+          "tpmVerified": true,
+          "firmwareHash": "sha256:aa0011..."
+        },
+        "policyDrift": {
+          "compliant": true,
+          "residencyPolicyRef": "policy://residency/eu-sovereign"
+        },
+        "legalBasis": {
+          "kind": "DPA",
+          "ref": "DPA-001324579"
+        }
+      }
+    ]
+  }
+}

--- a/schemas/control-plane/project-compute-setting.schema.json
+++ b/schemas/control-plane/project-compute-setting.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/control-plane/project-compute-setting.v1alpha1.schema.json",
+  "title": "ProjectComputeSetting",
+  "description": "A project's compute configuration in the cockpit: two planes (governed cluster + federated volunteer-mesh over the agent-machine inception-twin), the Work-Unit defaults, the FIPS crypto profiles, and the governed-deployment view (region/enclave, data-class, TPM attestation, policy-drift, legal-basis). Governance is fail-closed: no ungoverned compute, and a mesh plane must ride the inception-twin and be revocable. Rendered by the Studio 'Compute' tab.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": { "const": "control.socioprophet.org/v1alpha1" },
+    "kind": { "const": "ProjectComputeSetting" },
+    "metadata": {
+      "type": "object", "additionalProperties": false, "required": ["id", "projectRef"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "projectRef": { "type": "string", "minLength": 1 },
+        "createdAt": { "type": "string", "format": "date-time" }
+      }
+    },
+    "spec": {
+      "type": "object", "additionalProperties": false,
+      "required": ["planes", "workUnitDefaults", "cryptoProfileRef", "federationCryptoProfileRef", "deployments"],
+      "properties": {
+        "planes": {
+          "type": "object", "additionalProperties": false, "required": ["governed", "mesh"],
+          "properties": {
+            "governed": {
+              "type": "object", "additionalProperties": false, "required": ["enabled"],
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "clusterRef": { "type": "string" }, "region": { "type": "string" },
+                "defaultEnclave": { "type": "string" }
+              }
+            },
+            "mesh": {
+              "type": "object", "additionalProperties": false, "required": ["enabled"],
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "twinRef": { "type": "string", "description": "the agent-machine inception-twin A2AStateMachine this mesh rides" },
+                "trustedNodes": {
+                  "type": "array",
+                  "items": {
+                    "type": "object", "additionalProperties": false, "required": ["nodeRef", "hostRef", "attestationRef"],
+                    "properties": {
+                      "nodeRef": { "type": "string" }, "hostRef": { "type": "string" },
+                      "attestationRef": { "type": "string" }
+                    }
+                  }
+                },
+                "minTrust": { "type": "integer", "minimum": 0 },
+                "revocation": {
+                  "type": "object", "additionalProperties": false, "required": ["required", "propagationSeconds"],
+                  "properties": {
+                    "required": { "type": "boolean" },
+                    "propagationSeconds": { "type": "integer", "minimum": 1 }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "workUnitDefaults": {
+          "type": "object", "additionalProperties": false, "required": ["schemaId", "proofMode", "sandbox", "policyRef"],
+          "properties": {
+            "schemaId": { "type": "string", "pattern": "^sha3:" },
+            "proofMode": { "type": "string", "enum": ["redundant", "spot_check", "tee", "zk"] },
+            "sandbox": { "type": "string", "enum": ["docker", "lightning", "wasm", "kata"] },
+            "policyRef": { "type": "string", "minLength": 1 }
+          }
+        },
+        "cryptoProfileRef": { "type": "string", "minLength": 1, "description": "transport CryptoProfile (TriTRPC)" },
+        "federationCryptoProfileRef": { "type": "string", "minLength": 1, "description": "FederationCryptoProfile (Merkle-log)" },
+        "deployments": {
+          "type": "array",
+          "items": {
+            "type": "object", "additionalProperties": false,
+            "required": ["name", "type", "status", "regionEnclave", "dataClass", "ownerRef", "iamRoles", "attestation", "policyDrift", "legalBasis"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "type": { "type": "string", "enum": ["cluster", "mesh"] },
+              "status": { "type": "string", "enum": ["running", "stopped", "pending", "failed"] },
+              "regionEnclave": { "type": "string", "minLength": 1 },
+              "dataClass": { "type": "string", "minLength": 1 },
+              "ownerRef": { "type": "string", "minLength": 1 },
+              "iamRoles": { "type": "array", "items": { "type": "string" } },
+              "attestation": {
+                "type": "object", "additionalProperties": false, "required": ["tpmVerified", "firmwareHash"],
+                "properties": { "tpmVerified": { "type": "boolean" }, "firmwareHash": { "type": "string", "minLength": 1 } }
+              },
+              "policyDrift": {
+                "type": "object", "additionalProperties": false, "required": ["compliant", "residencyPolicyRef"],
+                "properties": { "compliant": { "type": "boolean" }, "residencyPolicyRef": { "type": "string", "minLength": 1 } }
+              },
+              "legalBasis": {
+                "type": "object", "additionalProperties": false, "required": ["kind", "ref"],
+                "properties": { "kind": { "type": "string" }, "ref": { "type": "string", "minLength": 1 } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_project_compute_setting.py
+++ b/scripts/validate_project_compute_setting.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate ProjectComputeSetting — fail-closed governed compute (cluster + mesh).
+
+Schema conformance + the governance invariants the cockpit's Compute tab depends on:
+  1. NO UNGOVERNED COMPUTE — every deployment is policy-drift COMPLIANT and carries a legal basis;
+     a mesh deployment MUST be TPM-attested (the inception-twin ATTEST phase).
+  2. A MESH PLANE MUST RIDE THE INCEPTION-TWIN — if planes.mesh.enabled, it names a twinRef, is
+     REVOCABLE (revocation.required == true), and every trusted node carries an attestationRef.
+
+Dependency-light CI guardrail (exit 2 on failure), matching this repo's validator convention.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "control-plane" / "project-compute-setting.schema.json"
+EX = ROOT / "examples" / "control-plane"
+VALID = EX / "project-compute-setting.example.json"
+INVALID = [
+    EX / "project-compute-setting.noncompliant-deploy.invalid.json",
+    EX / "project-compute-setting.mesh-not-revocable.invalid.json",
+    EX / "project-compute-setting.mesh-no-twin.invalid.json",
+]
+
+
+def load(p: Path):
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def governance_errors(doc: dict) -> list[str]:
+    errs = []
+    spec = doc.get("spec", {})
+    for d in spec.get("deployments", []):
+        who = d.get("name", "?")
+        # 1. no ungoverned compute
+        if not (d.get("policyDrift") or {}).get("compliant") is True:
+            errs.append(f"deployment {who}: policy-drift not compliant (ungoverned compute refused)")
+        if not (d.get("legalBasis") or {}).get("ref"):
+            errs.append(f"deployment {who}: missing legal basis")
+        if d.get("type") == "mesh" and not (d.get("attestation") or {}).get("tpmVerified") is True:
+            errs.append(f"deployment {who}: mesh compute must be TPM-attested (inception-twin ATTEST)")
+    # 2. a mesh plane must ride the inception-twin and be revocable
+    mesh = (spec.get("planes") or {}).get("mesh") or {}
+    if mesh.get("enabled"):
+        if not mesh.get("twinRef"):
+            errs.append("planes.mesh.enabled but no twinRef (mesh must ride the inception-twin)")
+        if not (mesh.get("revocation") or {}).get("required") is True:
+            errs.append("planes.mesh.enabled but revocation.required != true (mesh must be revocable)")
+        nodes = mesh.get("trustedNodes") or []
+        if not nodes:
+            errs.append("planes.mesh.enabled but no trustedNodes")
+        for n in nodes:
+            if not n.get("attestationRef"):
+                errs.append(f"trusted node {n.get('nodeRef','?')} has no attestationRef")
+    return errs
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    validator = jsonschema.Draft202012Validator(schema)
+    fails = []
+
+    doc = load(VALID)
+    for e in sorted(validator.iter_errors(doc), key=str):
+        fails.append(f"{VALID.name}: schema: {e.message}")
+    for g in governance_errors(doc):
+        fails.append(f"{VALID.name}: governance: {g}")
+
+    for path in INVALID:
+        d = load(path)
+        schema_ok = not list(validator.iter_errors(d))
+        gov = governance_errors(d)
+        if schema_ok and not gov:
+            fails.append(f"{path.name}: expected rejection (schema or governance) but it passed")
+
+    for m in fails:
+        print(f"FAIL: {m}", file=sys.stderr)
+    if fails:
+        return 2
+    print("OK: ProjectComputeSetting valid; 3 invalid rejected (governed compute + revocable mesh)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/socioprophet-web/client-vue/src/__tests__/StudioComputeSettings.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/StudioComputeSettings.smoke.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { flushPromises } from "@vue/test-utils";
+import StudioComputeSettings from "../pages/studio/StudioComputeSettings.vue";
+
+describe("StudioComputeSettings", () => {
+  it("renders the governed-deployment view + both planes from the stub", async () => {
+    const w = mount(StudioComputeSettings, { props: { project: "test-project" } });
+    await flushPromises();
+    const text = w.text();
+    // both planes
+    expect(text).toContain("Governed plane");
+    expect(text).toContain("Mesh plane");
+    // mesh rides the inception-twin and is revocable
+    expect(text).toContain("inception-twin");
+    // the governed-deployment columns (image 5)
+    expect(text).toContain("Data class");
+    expect(text).toContain("Legal basis");
+    expect(text).toContain("Attestation");
+    // a real deployment row
+    expect(text).toContain("FraudDetector-v2");
+  });
+});

--- a/socioprophet-web/client-vue/src/pages/Studio.vue
+++ b/socioprophet-web/client-vue/src/pages/Studio.vue
@@ -9,6 +9,7 @@ import { useRoute, useRouter } from 'vue-router';
 import './studio/studio-tokens.css';
 import StudioNotebooks from './studio/StudioNotebooks.vue';
 import StudioCompute from './studio/StudioCompute.vue';
+import StudioComputeSettings from './studio/StudioComputeSettings.vue';
 import GraphExplorer from './studio/GraphExplorer.vue';
 import QueryConsole from './studio/QueryConsole.vue';
 import Analytics from './studio/Analytics.vue';
@@ -27,6 +28,7 @@ const GROUPS: { group: string; items: Sec[] }[] = [
   { group: 'Workbench', items: [
     { id: 'notebooks', label: 'Notebooks', ic: '⬢', comp: markRaw(StudioNotebooks), project: true, sub: 'Ray-backed governed notebooks — receipt per cell' },
     { id: 'compute', label: 'Compute Plane', ic: '⛩', comp: markRaw(StudioCompute), project: true, sub: 'Universal Compute Plane — one governed, proof-carrying door' },
+    { id: 'compute-settings', label: 'Compute', ic: '⚙', comp: markRaw(StudioComputeSettings), project: true, sub: 'Project compute setting — governed cluster + federated mesh, per-deployment governance' },
   ]},
   { group: 'Knowledge engineering', items: [
     { id: 'graph', label: 'Graph Explorer', ic: '⟡', comp: markRaw(GraphExplorer), sub: 'Force-directed graph + provenance inspector' },

--- a/socioprophet-web/client-vue/src/pages/studio/StudioComputeSettings.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/StudioComputeSettings.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from "vue";
+import { loadComputeSettings, type ComputeSettings } from "../../services/studioApi";
+
+// Project compute setting: governed cluster plane + federated volunteer-mesh (over the agent-machine
+// inception-twin) + the governed-deployment view (region/enclave, data-class, TPM attestation,
+// policy-drift, legal-basis). Governance is fail-closed — this surface only DISPLAYS; the
+// ProjectComputeSetting contract + validator enforce that no ungoverned compute exists.
+const props = defineProps<{ project: string }>();
+
+const cfg = ref<ComputeSettings | null>(null);
+const loading = ref(false);
+const err = ref("");
+
+async function load() {
+  loading.value = true;
+  err.value = "";
+  try {
+    cfg.value = await loadComputeSettings(props.project);
+  } catch (e) {
+    err.value = e instanceof Error ? e.message : "load failed";
+  } finally {
+    loading.value = false;
+  }
+}
+onMounted(load);
+watch(() => props.project, load);
+</script>
+
+<template>
+  <div class="cs studio-scope">
+    <header class="cs-head">
+      <h2>Compute</h2>
+      <span v-if="cfg?.degraded" class="chip warn" title="No BFF wired — showing the contract shape">degraded · stub</span>
+    </header>
+    <p v-if="err" class="err">{{ err }}</p>
+    <p v-else-if="loading" class="muted">Loading compute setting…</p>
+
+    <template v-else-if="cfg">
+      <!-- Two planes -->
+      <div class="grid">
+        <section class="kcard">
+          <h3>Governed plane <span class="chip" :class="cfg.planes.governed.enabled ? 'ok' : 'off'">{{ cfg.planes.governed.enabled ? 'on' : 'off' }}</span></h3>
+          <dl>
+            <div><dt>Cluster</dt><dd>{{ cfg.planes.governed.clusterRef || '—' }}</dd></div>
+            <div><dt>Region</dt><dd>{{ cfg.planes.governed.region || '—' }}</dd></div>
+            <div><dt>Default enclave</dt><dd>{{ cfg.planes.governed.defaultEnclave || '—' }}</dd></div>
+          </dl>
+        </section>
+        <section class="kcard">
+          <h3>Mesh plane <span class="chip" :class="cfg.planes.mesh.enabled ? 'ok' : 'off'">{{ cfg.planes.mesh.enabled ? 'on' : 'off' }}</span></h3>
+          <dl>
+            <div><dt>Inception-twin</dt><dd class="mono">{{ cfg.planes.mesh.twinRef || '—' }}</dd></div>
+            <div><dt>Revocable</dt><dd>{{ cfg.planes.mesh.revocation?.required ? `yes · ${cfg.planes.mesh.revocation?.propagationSeconds}s` : 'NO' }}</dd></div>
+            <div><dt>Min trust</dt><dd>{{ cfg.planes.mesh.minTrust ?? '—' }}</dd></div>
+          </dl>
+          <ul class="nodes" v-if="cfg.planes.mesh.trustedNodes?.length">
+            <li v-for="n in cfg.planes.mesh.trustedNodes" :key="n.nodeRef">
+              <span class="chip ok" title="attested">✓</span> {{ n.nodeRef }} <span class="muted">@ {{ n.hostRef }}</span>
+            </li>
+          </ul>
+        </section>
+      </div>
+
+      <p class="crypto muted">
+        transport <code>{{ cfg.cryptoProfileRef }}</code> · federation <code>{{ cfg.federationCryptoProfileRef }}</code>
+      </p>
+
+      <!-- Governed deployment view (image 5) -->
+      <h3 class="dep-h">Deployments</h3>
+      <div class="tbl-wrap">
+        <table class="tbl">
+          <thead>
+            <tr>
+              <th>Name</th><th>Type</th><th>Status</th><th>Region / Enclave</th><th>Data class</th>
+              <th>Owner</th><th>IAM</th><th>Attestation</th><th>Policy drift</th><th>Legal basis</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="d in cfg.deployments" :key="d.name">
+              <td>{{ d.name }}</td>
+              <td><span class="chip">{{ d.type }}</span></td>
+              <td>{{ d.status }}</td>
+              <td>{{ d.regionEnclave }}</td>
+              <td>{{ d.dataClass }}</td>
+              <td>{{ d.ownerRef }}</td>
+              <td>{{ d.iamRoles.join(', ') }}</td>
+              <td><span class="chip" :class="d.attestation.tpmVerified ? 'ok' : 'warn'">TPM {{ d.attestation.tpmVerified ? '✓' : '✗' }}</span></td>
+              <td><span class="chip" :class="d.policyDrift.compliant ? 'ok' : 'warn'">{{ d.policyDrift.compliant ? 'compliant' : 'DRIFT' }}</span></td>
+              <td>{{ d.legalBasis.kind }} · {{ d.legalBasis.ref }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.cs { padding: 16px; color: var(--text, #e7e7ea); }
+.cs-head { display: flex; align-items: center; gap: 10px; }
+.cs-head h2 { margin: 0; font-size: 18px; }
+.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 12px 0; }
+.kcard { border: 1px solid var(--hairline, #2a2a30); border-radius: var(--r-md, 10px); background: var(--surface, #16161a); padding: 12px; }
+.kcard h3 { margin: 0 0 8px; font-size: 14px; display: flex; align-items: center; gap: 8px; }
+dl { margin: 0; display: grid; gap: 4px; }
+dl > div { display: grid; grid-template-columns: 120px 1fr; gap: 8px; font-size: 13px; }
+dt { color: var(--muted, #9a9aa2); }
+.nodes { list-style: none; margin: 8px 0 0; padding: 0; font-size: 13px; display: grid; gap: 4px; }
+.crypto { margin: 6px 0 14px; font-size: 12px; }
+.dep-h { margin: 8px 0; font-size: 14px; }
+.tbl-wrap { overflow-x: auto; border: 1px solid var(--hairline, #2a2a30); border-radius: var(--r-md, 10px); }
+.tbl { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tbl th, .tbl td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--hairline, #2a2a30); white-space: nowrap; }
+.tbl th { color: var(--muted, #9a9aa2); font-weight: 600; }
+.chip { display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 11px; border: 1px solid var(--hairline, #2a2a30); }
+.chip.ok { color: #3fb950; border-color: #235a2c; }
+.chip.warn { color: #d29922; border-color: #6b5320; }
+.chip.off { color: var(--muted, #9a9aa2); }
+.mono, code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
+.muted { color: var(--muted, #9a9aa2); }
+.err { color: #f85149; }
+</style>

--- a/socioprophet-web/client-vue/src/services/studioApi.ts
+++ b/socioprophet-web/client-vue/src/services/studioApi.ts
@@ -946,3 +946,71 @@ export async function loadStudio(projectId?: string): Promise<StudioBundle> {
   if (!res.ok) throw new Error(`studio load failed: ${res.status}`);
   return (await res.json()) as StudioBundle;
 }
+
+// ── Project compute settings (governed cluster + federated volunteer-mesh) ──
+// Renders the Studio "Compute" tab. Governed-compute view (region/enclave, data-class, TPM
+// attestation, policy-drift, legal-basis) + the two planes; mesh rides the agent-machine
+// inception-twin. Contract: schemas/control-plane/project-compute-setting.schema.json.
+export interface ComputeDeployment {
+  name: string;
+  type: "cluster" | "mesh";
+  status: string;
+  regionEnclave: string;
+  dataClass: string;
+  ownerRef: string;
+  iamRoles: string[];
+  attestation: { tpmVerified: boolean; firmwareHash: string };
+  policyDrift: { compliant: boolean; residencyPolicyRef: string };
+  legalBasis: { kind: string; ref: string };
+}
+export interface ComputeTrustedNode { nodeRef: string; hostRef: string; attestationRef: string }
+export interface ComputeSettings {
+  projectRef: string;
+  planes: {
+    governed: { enabled: boolean; clusterRef?: string; region?: string; defaultEnclave?: string };
+    mesh: {
+      enabled: boolean;
+      twinRef?: string;
+      trustedNodes?: ComputeTrustedNode[];
+      minTrust?: number;
+      revocation?: { required: boolean; propagationSeconds: number };
+    };
+  };
+  cryptoProfileRef: string;
+  federationCryptoProfileRef: string;
+  deployments: ComputeDeployment[];
+  degraded?: boolean;
+}
+
+const STUB_COMPUTE_SETTINGS = (project: string): ComputeSettings => ({
+  projectRef: project,
+  planes: {
+    governed: { enabled: true, clusterRef: "cluster:us-east-gov-1", region: "us-east", defaultEnclave: "US-East-Gov-1" },
+    mesh: {
+      enabled: true,
+      twinRef: "urn:srcos:agent-machine:a2a-state-machine:inception-twin-default",
+      trustedNodes: [
+        { nodeRef: "node:edge-a-01", hostRef: "urn:srcos:agent-machine:m2-asahi-local", attestationRef: "attest:edge-a-01" },
+        { nodeRef: "node:twin-k8s", hostRef: "urn:srcos:agent-machine:twin-k8s", attestationRef: "attest:twin-k8s" },
+      ],
+      minTrust: 3,
+      revocation: { required: true, propagationSeconds: 5 },
+    },
+  },
+  cryptoProfileRef: "crypto://tritrpc/fips",
+  federationCryptoProfileRef: "fedcrypto://fips/ecdsa",
+  deployments: [
+    { name: "FraudDetector-v2", type: "cluster", status: "running", regionEnclave: "US-East-Gov-1", dataClass: "PII-restricted", ownerRef: "user:j-rivera", iamRoles: ["Users"], attestation: { tpmVerified: true, firmwareHash: "sha256:1c8437…" }, policyDrift: { compliant: true, residencyPolicyRef: "policy://residency/us-gov" }, legalBasis: { kind: "DPA", ref: "DPA-001324578" } },
+    { name: "BatchRiskScore", type: "mesh", status: "stopped", regionEnclave: "EU-Sovereign-2", dataClass: "Trusted-TPM", ownerRef: "user:s-lee", iamRoles: ["Trusted"], attestation: { tpmVerified: true, firmwareHash: "sha256:aa0011…" }, policyDrift: { compliant: true, residencyPolicyRef: "policy://residency/eu-sovereign" }, legalBasis: { kind: "DPA", ref: "DPA-001324579" } },
+  ],
+  degraded: true,
+});
+
+export async function loadComputeSettings(project: string): Promise<ComputeSettings> {
+  const b = nbBase();
+  if (!b) return STUB_COMPUTE_SETTINGS(project);
+  const r = await fetch(`${b}/api/studio/compute/settings?project=${encodeURIComponent(project)}`, { headers: { accept: "application/json" } }).catch(() => null);
+  if (!r || !r.ok) return STUB_COMPUTE_SETTINGS(project);
+  const d = await r.json();
+  return Array.isArray(d?.deployments) ? (d as ComputeSettings) : STUB_COMPUTE_SETTINGS(project);
+}


### PR DESCRIPTION
## The mesh WU pack, surfaced in the cockpit as a project compute setting (#25)

Implements the federated volunteer-mesh (Dual-Orchestration plane B) **via the agent-machine inception-twin** (`a2a-state-machine.inception-twin.json` — the shared mesh digital twin usable across trusted nodes), surfaced in **client-vue** (the canonical cockpit) as a per-project **Compute** setting. Learns from the reference screens — especially *Heller Personal Research → Deployments* (the governed-compute view).

### Contract (fail-closed) — `schemas/control-plane/project-compute-setting.schema.json`
- **Two planes**: governed cluster + volunteer **mesh over the inception-twin** (`twinRef`, trusted nodes, revocation).
- **WU defaults**: `schemaId` (SHA3), `proofMode` (redundant|spot_check|tee|zk), `sandbox` (docker|lightning|wasm|kata), `policyRef`.
- **Crypto**: transport + federation `CryptoProfile` refs (the FIPS gates #81/#85).
- **Deployment view** (image 5): `regionEnclave`, `dataClass`, **TPM attestation**, **policy-drift**, **legal-basis**.

`validate_project_compute_setting.py` enforces the governance invariants: **no ungoverned compute** (every deployment policy-compliant + legal-basis; a mesh deployment must be TPM-attested) and **a mesh plane must ride the inception-twin, be revocable, and have all nodes attested**. 3 negatives rejected (non-compliant deploy, non-revocable mesh, mesh without twin). CI workflow.

### Cockpit — `StudioComputeSettings.vue`
A **Compute** Studio tab rendering the two planes + the trusted-node twin + the governed deployments table (image-5 columns). `loadComputeSettings()` added to `studioApi.ts` with a stub fallback (honest "degraded · stub" state until a BFF is wired). **vue-tsc clean; smoke test passes.**

Ties SP-GATE attestation/epistemicLevel, purpose-bound consent, capability-membrane. What the other screens teach (reputation model for node admission, studio shell) is captured in memory for follow-ups.