### PR TITLE
feat(studio): wire project-scoped tabs to the active project store

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/StudioProjectWiring.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/StudioProjectWiring.smoke.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Studio ⇄ projects store wiring. Project-scoped tabs (compute setting, notebooks, …)
+ * must bind to the REAL active project from the Pinia store, not a hardcoded string.
+ */
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import Studio from '../pages/Studio.vue';
+import StudioComputeSettings from '../pages/studio/StudioComputeSettings.vue';
+import { useProjects } from '../stores/projects';
+
+const stub = { template: '<div />' };
+function routerAt(path: string) {
+  const r = createRouter({ history: createWebHashHistory(), routes: [{ path: '/:pathMatch(.*)*', component: stub }] });
+  r.push(path);
+  return r;
+}
+async function mountStudioAt(path: string) {
+  const router = routerAt(path);
+  await router.isReady();
+  const wrapper = mount(Studio, { global: { plugins: [router] } });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('Studio project wiring', () => {
+  it('passes the active project id from the store to project-scoped tabs', async () => {
+    const projects = useProjects();
+    const p = projects.create('KG demo');
+    const wrapper = await mountStudioAt('/studio?section=compute-settings');
+    const child = wrapper.findComponent(StudioComputeSettings);
+    expect(child.exists()).toBe(true);
+    expect(child.props('project')).toBe(p.id);
+  });
+
+  it('falls back to the demo project when none is selected', async () => {
+    const wrapper = await mountStudioAt('/studio?section=compute-settings');
+    const child = wrapper.findComponent(StudioComputeSettings);
+    expect(child.props('project')).toBe('demo');
+  });
+});

--- a/socioprophet-web/client-vue/src/pages/Studio.vue
+++ b/socioprophet-web/client-vue/src/pages/Studio.vue
@@ -6,6 +6,7 @@
 // canonical hellgraph-service / owl-reasoner / entity-resolution backends via /svc/*.
 import { ref, computed, watch, markRaw } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
+import { useProjects } from '../stores/projects';
 import './studio/studio-tokens.css';
 import StudioNotebooks from './studio/StudioNotebooks.vue';
 import StudioCompute from './studio/StudioCompute.vue';
@@ -53,7 +54,10 @@ const flat = GROUPS.flatMap((g) => g.items);
 
 const route = useRoute();
 const router = useRouter();
-const project = ref('Untitled project');
+const projects = useProjects();
+// Project-scoped tabs bind to the real active project from the store; fall back to the
+// stub 'demo' project when none is selected so the surface stays populated (fail-closed).
+const project = computed(() => projects.currentProjectId ?? 'demo');
 const current = ref(sectionFromQuery());
 function sectionFromQuery(): string {
   const s = (route.query.section as string) || (route.query.tab === 'compute' ? 'compute' : 'notebooks');

--- a/socioprophet-web/client-vue/src/stores/projects.ts
+++ b/socioprophet-web/client-vue/src/stores/projects.ts
@@ -33,6 +33,8 @@ export const useProjects = defineStore('projects', () => {
   }, { deep: true });
 
   const active = computed<Project | null>(() => projects.value.find((p) => p.id === activeId.value) ?? null);
+  // The active project's id — the string project-scoped surfaces (Studio compute/notebooks/…) bind to.
+  const currentProjectId = computed<string | null>(() => active.value?.id ?? null);
 
   function create(title: string): Project {
     const p: Project = {
@@ -53,5 +55,5 @@ export const useProjects = defineStore('projects', () => {
   }
   function setActive(id: string | null) { activeId.value = id; }
 
-  return { projects, activeId, active, create, rename, remove, setActive };
+  return { projects, activeId, active, currentProjectId, create, rename, remove, setActive };
 });


### PR DESCRIPTION
## What

`src/pages/Studio.vue` (the canonical `client-vue` cockpit) passed a **hardcoded** `'Untitled project'` string to every project-scoped tab (`project: true` entries in `GROUPS` — `StudioComputeSettings`, notebooks, ops, governance, commons, experiments). These components take a `project: string` prop and thread it to the project-scoped studio API.

This wires them to the **real active project** from the Pinia store at `src/stores/projects.ts`.

## How

- **store**: add a minimal `currentProjectId` computed getter (`active.value?.id ?? null`), consistent with the existing `active` getter's style; export it. No broader store API added.
- **Studio.vue**: replace `const project = ref('Untitled project')` with `const project = computed(() => projects.currentProjectId ?? 'demo')`. The template binding `v-bind="active.project ? { project } : {}"` is unchanged — refs auto-unwrap in template, so it now flows reactively from the store. Fallback `'demo'` matches the studioApi stub project so the surface stays populated when nothing is selected (fail-closed).

## Tests

- Existing `StudioComputeSettings.smoke.test.ts` still green.
- New `StudioProjectWiring.smoke.test.ts`: mounts `Studio.vue` at `section=compute-settings` and asserts the child's `project` prop equals the store's active project id, and falls back to `'demo'` when none is selected.
- `vue-tsc --noEmit` clean; full suite 518/518 pass.

Branched off `master` (repo default; there is no `main`).