### PR TITLE
feat(space-twin): quadrant 'cube of space' hologram — live USOL + initial data load

### DIFF
--- a/socioprophet-web/client-vue/public/space/quadrant.initial.json
+++ b/socioprophet-web/client-vue/public/space/quadrant.initial.json
@@ -1,0 +1,358 @@
+{
+  "source": "usol.nearby_stars",
+  "cube_ly": 40,
+  "systems": [
+    {
+      "id": "sol",
+      "name": "Sol",
+      "position": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "color": [
+        255,
+        236,
+        170
+      ],
+      "distLy": 0.0,
+      "spectral": "G"
+    },
+    {
+      "id": "alpha-centauri",
+      "name": "Alpha Centauri",
+      "position": [
+        -1.634,
+        -1.3663,
+        -3.8158
+      ],
+      "color": [
+        255,
+        236,
+        170
+      ],
+      "distLy": 4.37,
+      "spectral": "G"
+    },
+    {
+      "id": "barnard-s-star",
+      "name": "Barnard's Star",
+      "position": [
+        -0.0622,
+        -5.9397,
+        0.4873
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 5.96,
+      "spectral": "M"
+    },
+    {
+      "id": "wolf-359",
+      "name": "Wolf 359",
+      "position": [
+        -7.5028,
+        2.1372,
+        0.9593
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 7.86,
+      "spectral": "M"
+    },
+    {
+      "id": "lalande-21185",
+      "name": "Lalande 21185",
+      "position": [
+        -6.5229,
+        1.6384,
+        4.881
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 8.31,
+      "spectral": "M"
+    },
+    {
+      "id": "sirius",
+      "name": "Sirius",
+      "position": [
+        -1.6181,
+        8.1345,
+        -2.4914
+      ],
+      "color": [
+        202,
+        215,
+        255
+      ],
+      "distLy": 8.66,
+      "spectral": "A"
+    },
+    {
+      "id": "luyten-726-8",
+      "name": "Luyten 726-8",
+      "position": [
+        7.5513,
+        3.4572,
+        -2.6905
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 8.73,
+      "spectral": "M"
+    },
+    {
+      "id": "ross-154",
+      "name": "Ross 154",
+      "position": [
+        1.9088,
+        -8.6459,
+        -3.9125
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 9.68,
+      "spectral": "M"
+    },
+    {
+      "id": "ross-248",
+      "name": "Ross 248",
+      "position": [
+        7.3767,
+        -0.6,
+        7.1922
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 10.32,
+      "spectral": "M"
+    },
+    {
+      "id": "epsilon-eridani",
+      "name": "Epsilon Eridani",
+      "position": [
+        6.1852,
+        8.2829,
+        -1.7225
+      ],
+      "color": [
+        255,
+        210,
+        161
+      ],
+      "distLy": 10.48,
+      "spectral": "K"
+    },
+    {
+      "id": "lacaille-9352",
+      "name": "Lacaille 9352",
+      "position": [
+        8.4595,
+        -2.0544,
+        -6.29
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 10.74,
+      "spectral": "M"
+    },
+    {
+      "id": "ross-128",
+      "name": "Ross 128",
+      "position": [
+        -10.9923,
+        0.6049,
+        0.1537
+      ],
+      "color": [
+        255,
+        163,
+        120
+      ],
+      "distLy": 11.01,
+      "spectral": "M"
+    },
+    {
+      "id": "procyon",
+      "name": "Procyon",
+      "position": [
+        -4.8051,
+        10.3516,
+        1.0426
+      ],
+      "color": [
+        248,
+        247,
+        255
+      ],
+      "distLy": 11.46,
+      "spectral": "F"
+    },
+    {
+      "id": "61-cygni",
+      "name": "61 Cygni",
+      "position": [
+        6.4651,
+        -6.103,
+        7.1355
+      ],
+      "color": [
+        255,
+        210,
+        161
+      ],
+      "distLy": 11.4,
+      "spectral": "K"
+    },
+    {
+      "id": "tau-ceti",
+      "name": "Tau Ceti",
+      "position": [
+        10.2888,
+        5.0071,
+        -3.2681
+      ],
+      "color": [
+        255,
+        236,
+        170
+      ],
+      "distLy": 11.9,
+      "spectral": "G"
+    },
+    {
+      "id": "altair",
+      "name": "Altair",
+      "position": [
+        7.6966,
+        -14.6288,
+        2.5797
+      ],
+      "color": [
+        202,
+        215,
+        255
+      ],
+      "distLy": 16.73,
+      "spectral": "A"
+    },
+    {
+      "id": "eta-cassiopeiae",
+      "name": "Eta Cassiopeiae",
+      "position": [
+        10.1053,
+        2.2033,
+        16.4367
+      ],
+      "color": [
+        255,
+        236,
+        170
+      ],
+      "distLy": 19.42,
+      "spectral": "G"
+    },
+    {
+      "id": "vega",
+      "name": "Vega",
+      "position": [
+        3.1545,
+        -19.2635,
+        15.6833
+      ],
+      "color": [
+        202,
+        215,
+        255
+      ],
+      "distLy": 25.04,
+      "spectral": "A"
+    },
+    {
+      "id": "fomalhaut",
+      "name": "Fomalhaut",
+      "position": [
+        21.0413,
+        -5.8748,
+        -12.4204
+      ],
+      "color": [
+        202,
+        215,
+        255
+      ],
+      "distLy": 25.13,
+      "spectral": "A"
+    },
+    {
+      "id": "pollux",
+      "name": "Pollux",
+      "position": [
+        -13.258,
+        26.708,
+        15.8744
+      ],
+      "color": [
+        255,
+        210,
+        161
+      ],
+      "distLy": 33.78,
+      "spectral": "K"
+    },
+    {
+      "id": "denebola",
+      "name": "Denebola",
+      "position": [
+        -34.7069,
+        1.6367,
+        9.0311
+      ],
+      "color": [
+        202,
+        215,
+        255
+      ],
+      "distLy": 35.9,
+      "spectral": "A"
+    },
+    {
+      "id": "arcturus",
+      "name": "Arcturus",
+      "position": [
+        -28.7706,
+        -19.333,
+        12.0573
+      ],
+      "color": [
+        255,
+        210,
+        161
+      ],
+      "distLy": 36.7,
+      "spectral": "K"
+    }
+  ]
+}

--- a/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
+++ b/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
@@ -2,12 +2,13 @@
   <section class="st" aria-label="Space digital twin">
     <SurfaceHeader title="Space Twin" eyebrow="Digital twinning · solar system &amp; galaxy">
       <template #badge>
-        <ProvenanceBadge :p="mode === 'solar' ? solarProv : galaxyProv" compact />
+        <ProvenanceBadge :p="mode === 'solar' ? solarProv : mode === 'galaxy' ? galaxyProv : quadrantProv" compact />
       </template>
       <template #actions>
         <div class="st-modes" role="tablist" aria-label="Twin scale">
           <button role="tab" :aria-selected="mode === 'solar'" :class="{ on: mode === 'solar' }" @click="setMode('solar')">☉ Solar System</button>
           <button role="tab" :aria-selected="mode === 'galaxy'" :class="{ on: mode === 'galaxy' }" @click="setMode('galaxy')">✦ Galaxy</button>
+          <button role="tab" :aria-selected="mode === 'quadrant'" :class="{ on: mode === 'quadrant' }" @click="setMode('quadrant')">⬢ Quadrant</button>
         </div>
         <label v-if="mode === 'solar'" class="st-lens" title="Interpretive overlay — annotates, never alters the ephemeris">
           <input type="checkbox" v-model="lensOn" /> ✴ Ecliptic lens
@@ -32,10 +33,16 @@
           </li>
         </ul>
       </div>
-      <div class="st-readout" v-else>
+      <div class="st-readout" v-else-if="mode === 'galaxy'">
         <div class="st-date">Procedural galaxy</div>
         <div class="st-epi">epistemic <b>{{ epistemic }}</b></div>
         <p class="st-note">{{ galaxyStars.length.toLocaleString() }} generated stars · {{ arms }} spiral arms</p>
+      </div>
+      <div class="st-readout st-readout--quad" v-else>
+        <div class="st-date">Cube of space · Sol sector</div>
+        <div class="st-epi">epistemic <b>{{ epistemic }}</b> · <span class="st-src">{{ quadrantSourceLabel }}</span></div>
+        <div class="st-center">⌖ center <b>{{ centerName }}</b> <span class="st-hint">— click a system to recenter</span></div>
+        <p class="st-note">{{ quadrant.length }} systems · {{ mappedRegions }} / {{ REGIONS }} regions mapped · ±{{ CUBE_LY }} ly</p>
       </div>
     </div>
 
@@ -72,6 +79,7 @@ import ProvenanceBadge from '../components/ProvenanceBadge.vue';
 import { prov } from '../features/provenance/types';
 import { PLANETS, heliocentric, orbitPath } from '../space/ephemeris';
 import { generateGalaxy } from '../space/galaxy';
+import { loadQuadrant, cubeEdges, sectorGrid, mappedSectors, CUBE_LY, QUAD_SCALE, SECTORS, type StarSystem } from '../space/quadrant';
 
 // Honest provenance — the whole point of an epistemic surface is that it declares HOW it
 // was produced. The solar system is computed & replayable (Kepler); the galaxy is admitted
@@ -86,9 +94,32 @@ const galaxyProv = prov('generated', {
   note: 'Procedural logarithmic-spiral disk (seeded, reproducible). A structural stand-in — NOT a star catalogue.',
 });
 
-const mode = ref<'solar' | 'galaxy'>('solar');
+const mode = ref<'solar' | 'galaxy' | 'quadrant'>('solar');
 const canvasEl = ref<HTMLCanvasElement | null>(null);
 const deck = shallowRef<Deck<OrbitView[]> | null>(null);
+
+// ── quadrant "cube of space" — fed by live USOL plus an initial data load ──
+const quadrant = ref<StarSystem[]>([]);
+const quadrantSource = ref<'loading' | 'usol-live' | 'initial-load' | 'seed'>('loading');
+const REGIONS = SECTORS ** 3;
+const mappedRegions = computed(() => mappedSectors(quadrant.value));
+const quadrantSourceLabel = computed(() =>
+  quadrantSource.value === 'usol-live' ? 'live USOL'
+  : quadrantSource.value === 'initial-load' ? 'initial data load'
+  : quadrantSource.value === 'seed' ? 'seed (offline)'
+  : 'loading…');
+const quadrantProv = computed(() =>
+  quadrantSource.value === 'usol-live'
+    ? prov('computed', { verifier: 'live USOL service (/api/space/quadrant)', sources: ['USOL nearby-star astrometry'], note: 'Hydrated from the live USOL data plane.' })
+    : prov('fixture', { sources: ['nearby-star astrometry, public catalogs (factual)'], note: 'Initial data load (shipped bundle). Live USOL hydration via /api/space/quadrant when the service is up.' }));
+let quadrantLoaded = false;
+async function ensureQuadrant() {
+  if (quadrantLoaded) return;
+  quadrantLoaded = true;
+  const d = await loadQuadrant();
+  quadrant.value = d.systems;
+  quadrantSource.value = d.source;
+}
 
 // ── time (the 4th dimension) ──────────────────────────────────────────────
 const SPAN_DAYS = 55152;                 // ~1950 → 2100
@@ -127,7 +158,10 @@ const cart = COORDINATE_SYSTEM.CARTESIAN;
 // the generated galaxy is `speculative`, and a lens overlay is capped at `speculative` — never read as
 // ground truth. This is the usolspace projection discipline (typed, capped, graduatable) in the UI.
 const lensOn = ref(false);
-const epistemic = computed<'empirical' | 'speculative'>(() => (mode.value === 'solar' ? 'empirical' : 'speculative'));
+const epistemic = computed<'empirical' | 'speculative' | 'synthetic'>(() =>
+  mode.value === 'solar' ? 'empirical'
+  : mode.value === 'quadrant' ? (quadrantSource.value === 'usol-live' ? 'empirical' : 'synthetic')
+  : 'speculative');
 // "Center the universe on any point" — the observer origin. Default is heliocentric (the Sun).
 const centerId = ref<string>('sun');
 const centerName = ref<string>('Sun');
@@ -198,10 +232,46 @@ function galaxyLayers() {
   ];
 }
 
+function quadrantLayers() {
+  const nodes = quadrant.value.map((s) => ({
+    id: s.id, name: s.name,
+    position: [s.position[0] * QUAD_SCALE, s.position[1] * QUAD_SCALE, s.position[2] * QUAD_SCALE] as [number, number, number],
+    color: s.color,
+  }));
+  return [
+    new PathLayer({
+      id: 'quad-grid', data: sectorGrid(), coordinateSystem: cart,
+      getPath: (d: any) => d.path, getColor: [0, 180, 220, 40],
+      getWidth: 1, widthUnits: 'pixels', widthMinPixels: 1,
+    }),
+    new PathLayer({
+      id: 'quad-cube', data: cubeEdges(), coordinateSystem: cart,
+      getPath: (d: any) => d.path, getColor: [0, 224, 255, 170],
+      getWidth: 1.5, widthUnits: 'pixels', widthMinPixels: 1,
+    }),
+    new ScatterplotLayer({ // holographic glow halo
+      id: 'quad-halo', data: nodes, coordinateSystem: cart,
+      getPosition: (d: any) => d.position,
+      getFillColor: (d: any): [number, number, number, number] => [d.color[0], d.color[1], d.color[2], 38],
+      getRadius: 7, radiusUnits: 'pixels', radiusMinPixels: 6, radiusMaxPixels: 26, stroked: false,
+    }),
+    new ScatterplotLayer({ // bright core — pickable → recenter the cube on any system
+      id: 'quad-stars', data: nodes, coordinateSystem: cart,
+      getPosition: (d: any) => d.position, getFillColor: (d: any) => d.color,
+      getRadius: 2.5, radiusUnits: 'pixels', radiusMinPixels: 2, radiusMaxPixels: 6, stroked: false,
+      pickable: true, onClick: (info: any) => recenterOn(info.object),
+    }),
+  ];
+}
+
+function layersForMode(m: 'solar' | 'galaxy' | 'quadrant') {
+  return m === 'solar' ? solarLayers() : m === 'galaxy' ? galaxyLayers() : quadrantLayers();
+}
+
 function initialViewState(): OrbitViewState {
-  return mode.value === 'solar'
-    ? { target: [0, 0, 0], rotationX: 42, rotationOrbit: 30, zoom: -3.2, minZoom: -6, maxZoom: 4 }
-    : { target: [0, 0, 0], rotationX: 62, rotationOrbit: 0, zoom: -3.4, minZoom: -6, maxZoom: 4 };
+  if (mode.value === 'solar') return { target: [0, 0, 0], rotationX: 42, rotationOrbit: 30, zoom: -3.2, minZoom: -6, maxZoom: 4 };
+  if (mode.value === 'quadrant') return { target: [0, 0, 0], rotationX: 38, rotationOrbit: 24, zoom: -5.2, minZoom: -8, maxZoom: 4 };
+  return { target: [0, 0, 0], rotationX: 62, rotationOrbit: 0, zoom: -3.4, minZoom: -6, maxZoom: 4 };
 }
 
 // The camera is CONTROLLED — we own the view state. `initialViewState()` is only the per-mode DEFAULT;
@@ -233,17 +303,18 @@ function recenterSun() {
 
 function render() {
   if (!deck.value) return;
-  deck.value.setProps({ layers: mode.value === 'solar' ? solarLayers() : galaxyLayers() });
+  deck.value.setProps({ layers: layersForMode(mode.value) });
 }
 
-function setMode(m: 'solar' | 'galaxy') {
+function setMode(m: 'solar' | 'galaxy' | 'quadrant') {
   if (m === mode.value) return;
   mode.value = m;
   playing.value = false;
-  galaxyAngle = 0;                    // so re-entering galaxy mode does not resume mid-spin
+  galaxyAngle = 0;                    // so re-entering a spinning mode does not resume mid-spin
   recenterSun();                      // a mode switch resets the observer origin to heliocentric
+  if (m === 'quadrant') void ensureQuadrant();   // live USOL + initial data load, on first entry
   viewState = initialViewState();     // a mode switch DELIBERATELY reframes to the new mode's default
-  deck.value?.setProps({ viewState: { orbit: viewState }, layers: m === 'solar' ? solarLayers() : galaxyLayers() });
+  deck.value?.setProps({ viewState: { orbit: viewState }, layers: layersForMode(m) });
 }
 
 // ── animation loop (time or galaxy spin) ─────────────────────────────────
@@ -263,7 +334,7 @@ function tick(ts: number) {
   raf = requestAnimationFrame(tick);
 }
 
-watch([dayOffset, mode, lensOn], render);
+watch([dayOffset, mode, lensOn, quadrant], render);
 
 onMounted(() => {
   if (!canvasEl.value) return;
@@ -318,6 +389,10 @@ onUnmounted(() => {
 .st-reset { border: 1px solid rgba(120, 140, 180, 0.3); background: var(--surface-2, #11151c); color: var(--text-2, #9aa4b2);
   font: inherit; font-size: 0.8rem; padding: 5px 10px; border-radius: 6px; cursor: pointer; margin-left: 6px; }
 .st-reset:hover { color: #fff; border-color: var(--accent, #3a6df0); }
+/* quadrant hologram: cyan holo-cube styling */
+.st-readout--quad { border-color: rgba(0, 210, 255, 0.35); box-shadow: 0 0 24px rgba(0, 200, 255, 0.08) inset; }
+.st-readout--quad .st-date { color: #aef2ff; }
+.st-src { color: #4fd0e6; }
 .st-time { display: flex; align-items: center; gap: 12px; padding: 12px 4px 2px; }
 .st-time--galaxy { color: #8b97a8; font-size: 0.8rem; }
 .st-play, .st-now { border: 1px solid rgba(120, 140, 180, 0.3); background: var(--surface-2, #11151c);

--- a/socioprophet-web/client-vue/src/space/quadrant.ts
+++ b/socioprophet-web/client-vue/src/space/quadrant.ts
@@ -1,0 +1,119 @@
+/**
+ * quadrant.ts — the "cube of space" data plane for the Space Twin quadrant hologram.
+ *
+ * Fed by **live USOL plus an initial data load**, in that order of preference:
+ *   1. live USOL service — `GET /api/space/quadrant` (via the Vite `/api` proxy);
+ *   2. the initial data load — a shipped asset `/space/quadrant.initial.json`, EMITTED FROM USOL
+ *      (`usolspace.nearby_stars`), so the cube renders instantly and offline;
+ *   3. a minimal Sol-only seed — so the cube is never empty.
+ *
+ * The view owns no star catalogue: the data's canonical home is USOL. `loadQuadrant` never throws;
+ * `.source` declares which tier produced the frame so the surface stays honest about what it shows.
+ */
+
+export interface StarSystem {
+  id: string;
+  name: string;
+  position: [number, number, number]; // light-years, equatorial, Sol at origin
+  color: [number, number, number];
+  distLy: number;
+  spectral: string;
+}
+
+export interface QuadrantData {
+  source: 'usol-live' | 'initial-load' | 'seed';
+  systems: StarSystem[];
+}
+
+export const CUBE_LY = 40;      // half-extent of the mapped cube (Sol-centred)
+export const QUAD_SCALE = 5;    // scene units per light-year
+export const SECTORS = 4;       // subdivisions per axis → SECTORS³ regions
+
+const SEED: StarSystem[] = [
+  { id: 'sol', name: 'Sol', position: [0, 0, 0], color: [255, 236, 170], distLy: 0, spectral: 'G' },
+];
+
+function coerce(raw: unknown): StarSystem[] {
+  if (!Array.isArray(raw)) return [];
+  const out: StarSystem[] = [];
+  for (const s of raw as any[]) {
+    if (!s || typeof s.name !== 'string' || !Array.isArray(s.position) || s.position.length < 3) continue;
+    out.push({
+      id: String(s.id ?? s.name),
+      name: String(s.name),
+      position: [Number(s.position[0]), Number(s.position[1]), Number(s.position[2])],
+      color: (Array.isArray(s.color) && s.color.length >= 3 ? [Number(s.color[0]), Number(s.color[1]), Number(s.color[2])] : [200, 200, 210]) as [number, number, number],
+      distLy: Number(s.distLy ?? Math.hypot(s.position[0], s.position[1], s.position[2])),
+      spectral: String(s.spectral ?? '?'),
+    });
+  }
+  return out;
+}
+
+async function fetchJson(url: string, signal?: AbortSignal): Promise<any | null> {
+  try {
+    const res = await fetch(url, { signal, headers: { accept: 'application/json' } });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the quadrant: live USOL → shipped initial asset → seed. Never throws; the caller learns which
+ * tier produced the frame via `.source`.
+ */
+export async function loadQuadrant(signal?: AbortSignal): Promise<QuadrantData> {
+  const live = await fetchJson('/api/space/quadrant', signal);
+  const liveSystems = coerce(live?.systems);
+  if (liveSystems.length) return { source: 'usol-live', systems: liveSystems };
+
+  const initial = await fetchJson('/space/quadrant.initial.json', signal);
+  const initialSystems = coerce(initial?.systems);
+  if (initialSystems.length) return { source: 'initial-load', systems: initialSystems };
+
+  return { source: 'seed', systems: SEED };
+}
+
+/** The 12 edges of the mapped cube, in scene units. */
+export function cubeEdges(): { path: [number, number, number][] }[] {
+  const c = CUBE_LY * QUAD_SCALE;
+  const v: [number, number, number][] = [];
+  for (const z of [-c, c]) for (const y of [-c, c]) for (const x of [-c, c]) v.push([x, y, z]);
+  const E = [[0, 1], [0, 2], [0, 4], [1, 3], [1, 5], [2, 3], [2, 6], [3, 7], [4, 5], [4, 6], [5, 7], [6, 7]];
+  return E.map(([a, b]) => ({ path: [v[a]!, v[b]!] }));
+}
+
+/** A holographic sector grid: floor (z = −cube) plus two back walls, at sector boundaries. */
+export function sectorGrid(): { path: [number, number, number][] }[] {
+  const c = CUBE_LY * QUAD_SCALE;
+  const step = (2 * c) / SECTORS;
+  const at = Array.from({ length: SECTORS + 1 }, (_, i) => -c + i * step);
+  const lines: { path: [number, number, number][] }[] = [];
+  for (const g of at) { // floor z = -c
+    lines.push({ path: [[g, -c, -c], [g, c, -c]] });
+    lines.push({ path: [[-c, g, -c], [c, g, -c]] });
+  }
+  for (const g of at) { // back wall x = -c
+    lines.push({ path: [[-c, g, -c], [-c, g, c]] });
+    lines.push({ path: [[-c, -c, g], [-c, c, g]] });
+  }
+  for (const g of at) { // back wall y = -c
+    lines.push({ path: [[g, -c, -c], [g, -c, c]] });
+    lines.push({ path: [[-c, -c, g], [c, -c, g]] });
+  }
+  return lines;
+}
+
+/** How many of the SECTORS³ regions contain at least one catalogued system (the 5th axis: coverage). */
+export function mappedSectors(systems: StarSystem[]): number {
+  const c = CUBE_LY;
+  const idx = (v: number) => Math.max(0, Math.min(SECTORS - 1, Math.floor(((v + c) / (2 * c)) * SECTORS)));
+  const seen = new Set<string>();
+  for (const s of systems) {
+    const [x, y, z] = s.position;
+    if (Math.abs(x) <= c && Math.abs(y) <= c && Math.abs(z) <= c) seen.add(`${idx(x)},${idx(y)},${idx(z)}`);
+  }
+  return seen.size;
+}


### PR DESCRIPTION
A third Space Twin mode: a **holographic cube-of-space across the local quadrant** — the Star-Trek holo-map view you asked for — fed by **live USOL plus an initial data load**, not a hardcoded catalogue.

- **`src/space/quadrant.ts`** (view-only loader): `loadQuadrant()` = **live USOL** (`/api/space/quadrant`) → **initial-load asset** (`/space/quadrant.initial.json`, *emitted from* `usolspace.nearby_stars`) → Sol seed. Never throws; `.source` declares which tier produced the frame. Plus cube + holo sector-grid geometry and `mappedSectors()` coverage (the 5th axis).
- **`public/space/quadrant.initial.json`** — the initial data load, **USOL's own output** (22 real nearby stars; canonical owner = [usol#5](https://github.com/SocioProphet/usol-space-library/pull/5)). The UI owns no star catalogue.
- **`SpaceTwin.vue` quadrant mode**: wireframe cube + cyan holographic sector grid + glowing star nodes (halo + core, **pickable → recenter the cube on any system**), an epistemic chip (live = `empirical` / initial-load = `synthetic`) + source label, readout `<n> systems · <m>/64 regions mapped · ±40 ly`.

### Verification (real toolchain)
`vue-tsc --noEmit` → 0 errors · `vitest` routeRegistry+navScope → 8/8 · `vite build` → ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)