### PR TITLE
feat(space-twin): horoscope / observer orientation — Ascendant-oriented ecliptic (#44)

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/horoscope.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/horoscope.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ascendantLon, midheavenLon, lstHours, obliquityDeg, signOf, julianDay, SIGNS } from '../space/horoscope';
+
+describe('horoscope (empirical geocentric orientation)', () => {
+  const d = new Date(Date.UTC(2000, 0, 1, 12, 0, 0)); // J2000.0 epoch
+  it('julian day at J2000 epoch is 2451545.0', () => { expect(julianDay(d)).toBeCloseTo(2451545.0, 3); });
+  it('obliquity is ~23.44 deg near J2000', () => { expect(obliquityDeg(d)).toBeGreaterThan(23.0); expect(obliquityDeg(d)).toBeLessThan(23.9); });
+  it('ASC / MC / LST are in range', () => {
+    const asc = ascendantLon(d, 40.1, -75.1), mc = midheavenLon(d, -75.1), lst = lstHours(d, -75.1);
+    expect(asc).toBeGreaterThanOrEqual(0); expect(asc).toBeLessThan(360);
+    expect(mc).toBeGreaterThanOrEqual(0); expect(mc).toBeLessThan(360);
+    expect(lst).toBeGreaterThanOrEqual(0); expect(lst).toBeLessThan(24);
+  });
+  it('is deterministic for a fixed instant + place', () => { expect(ascendantLon(d, 40.1, -75.1)).toBe(ascendantLon(d, 40.1, -75.1)); });
+  it('ASC changes as the Earth turns', () => { const later = new Date(d.getTime() + 3 * 3600 * 1000); expect(ascendantLon(later, 40.1, -75.1)).not.toBe(ascendantLon(d, 40.1, -75.1)); });
+  it('signOf maps longitude to the 12 signs', () => {
+    expect(signOf(0).name).toBe('Aries'); expect(signOf(35).index).toBe(1);
+    expect(signOf(35).deg).toBeCloseTo(5, 6); expect(signOf(359.9).index).toBe(11); expect(SIGNS.length).toBe(12);
+  });
+});

--- a/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
+++ b/socioprophet-web/client-vue/src/pages/SpaceTwin.vue
@@ -15,6 +15,10 @@
         </label>
         <button v-if="mode === 'solar' && centerId !== 'sun'" class="st-reset" @click="recenterSun"
                 title="Recenter the universe on the Sun">⌖ Sun</button>
+        <span v-if="mode === 'solar' && lensOn" class="st-lens" title="Observer place (latitude °, longitude °)">@
+          <input class="st-obs" type="number" v-model.number="obsLat" step="0.5" aria-label="Observer latitude degrees" />
+          <input class="st-obs" type="number" v-model.number="obsLon" step="0.5" aria-label="Observer longitude degrees" />
+        </span>
       </template>
     </SurfaceHeader>
 
@@ -26,6 +30,7 @@
         <div class="st-date">{{ dateLabel }}</div>
         <div class="st-epi">epistemic <b>{{ epistemic }}</b><span v-if="lensOn" class="st-lens-tag"> · lens speculative</span></div>
         <div class="st-center">⌖ center <b>{{ centerName }}</b> <span class="st-hint">— click a body to recenter</span></div>
+        <div v-if="lensOn" class="st-epi">{{ horoLabel }} <span class="st-hint">@ {{ obsLat }}°, {{ obsLon }}°</span></div>
         <ul class="st-planets">
           <li v-for="p in planetReadout" :key="p.id">
             <span class="st-dot" :style="{ background: p.css }" />{{ p.name }}
@@ -86,6 +91,7 @@ import SurfaceHeader from '../components/SurfaceHeader.vue';
 import ProvenanceBadge from '../components/ProvenanceBadge.vue';
 import { prov } from '../features/provenance/types';
 import { PLANETS, heliocentric, orbitPath } from '../space/ephemeris';
+import { ascendantLon, midheavenLon, lstHours, signOf } from '../space/horoscope';
 import { generateGalaxy } from '../space/galaxy';
 import { loadQuadrant, cubeEdges, sectorGrid, mappedSectors, CUBE_LY, QUAD_SCALE, SECTORS, type StarSystem } from '../space/quadrant';
 
@@ -187,23 +193,58 @@ const epistemic = computed<'empirical' | 'speculative' | 'synthetic'>(() =>
 const centerId = ref<string>('sun');
 const centerName = ref<string>('Sun');
 
+// Horoscope / observer orientation — the EMPIRICAL geocentric skeleton (LST → Ascendant/MC) for a
+// place + the current sim time. The angles are computed; the sign NAMES are the interpretive lens.
+const obsLat = ref(40.1);
+const obsLon = ref(-75.1);
+const horo = computed(() => {
+  const dt = simDate.value;
+  const ascLon = ascendantLon(dt, obsLat.value, obsLon.value);
+  const mcLon = midheavenLon(dt, obsLon.value);
+  return { ascLon, mcLon, lst: lstHours(dt, obsLon.value), asc: signOf(ascLon), mc: signOf(mcLon) };
+});
+const lstLabel = computed(() => {
+  const h = Math.floor(horo.value.lst);
+  const m = Math.floor((horo.value.lst - h) * 60);
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+});
+const horoLabel = computed(() =>
+  `ASC ${horo.value.asc.glyph} ${Math.round(horo.value.asc.deg)}° · MC ${horo.value.mc.glyph} ${Math.round(horo.value.mc.deg)}° · LST ${lstLabel.value}`);
+
 const ECLIPTIC_AU = 34; // a reference ring just beyond the outer planets
 function eclipticLensLayers() {
   // The zodiac IS the ecliptic divided into twelve — an interpretive division of the plane, not a
-  // physical feature. Drawn in the z=0 ecliptic plane as a ring plus 12 sector spokes.
+  // physical feature. Drawn in the z=0 ecliptic plane, ORIENTED by the (empirical) Ascendant so the
+  // rising point sits on the +X horizon; the ASC (gold) and MC (teal) markers are computed geometry.
   const R = ECLIPTIC_AU * AU;
+  const rot = -horo.value.ascLon * (Math.PI / 180);
+  const pt = (ang: number, rad: number): [number, number, number] => [Math.cos(ang + rot) * rad, Math.sin(ang + rot) * rad, 0];
   const ring: [number, number, number][] = [];
-  for (let i = 0; i <= 96; i++) { const a = (i / 96) * Math.PI * 2; ring.push([Math.cos(a) * R, Math.sin(a) * R, 0]); }
+  for (let i = 0; i <= 96; i++) ring.push(pt((i / 96) * Math.PI * 2, R));
   const data: { path: [number, number, number][] }[] = [{ path: ring }];
   for (let k = 0; k < 12; k++) {
     const a = (k / 12) * Math.PI * 2;
-    data.push({ path: [[Math.cos(a) * R * 0.94, Math.sin(a) * R * 0.94, 0], [Math.cos(a) * R, Math.sin(a) * R, 0]] });
+    data.push({ path: [pt(a, R * 0.94), pt(a, R)] });
   }
+  const ascLine = { path: [pt(0, 0), pt(0, R)] as [number, number, number][] };                 // Ascendant → +X
+  const mcAng = (horo.value.mcLon - horo.value.ascLon) * (Math.PI / 180);
+  const mcLine = { path: [pt(mcAng, 0), pt(mcAng, R)] as [number, number, number][] };           // Midheaven
   return [
     new PathLayer({
       id: 'ecliptic-lens', data, coordinateSystem: cart,
       getPath: (d: any) => d.path, getColor: [154, 127, 208, 120],
       getWidth: 1, widthUnits: 'pixels', widthMinPixels: 1,
+      updateTriggers: { getPath: [horo.value.ascLon] },
+    }),
+    new PathLayer({
+      id: 'ecliptic-asc', data: [ascLine], coordinateSystem: cart,
+      getPath: (d: any) => d.path, getColor: [232, 184, 75, 220],
+      getWidth: 2, widthUnits: 'pixels', widthMinPixels: 1, updateTriggers: { getPath: [horo.value.ascLon] },
+    }),
+    new PathLayer({
+      id: 'ecliptic-mc', data: [mcLine], coordinateSystem: cart,
+      getPath: (d: any) => d.path, getColor: [63, 192, 182, 200],
+      getWidth: 1.5, widthUnits: 'pixels', widthMinPixels: 1, updateTriggers: { getPath: [horo.value.ascLon, horo.value.mcLon] },
     }),
   ];
 }
@@ -382,7 +423,7 @@ function tick(ts: number) {
   raf = requestAnimationFrame(tick);
 }
 
-watch([dayOffset, mode, lensOn, quadrant, horizonOn, lookbackLy, centerId], render);
+watch([dayOffset, mode, lensOn, quadrant, horizonOn, lookbackLy, centerId, obsLat, obsLon], render);
 
 onMounted(() => {
   if (!canvasEl.value) return;
@@ -441,6 +482,8 @@ onUnmounted(() => {
 .st-readout--quad { border-color: rgba(0, 210, 255, 0.35); box-shadow: 0 0 24px rgba(0, 200, 255, 0.08) inset; }
 .st-readout--quad .st-date { color: #aef2ff; }
 .st-src { color: #4fd0e6; }
+.st-obs { width: 58px; background: var(--surface-2, #11151c); border: 1px solid rgba(120, 140, 180, 0.3);
+  color: var(--text-1, #cfd8e6); border-radius: 5px; padding: 3px 5px; font: inherit; font-size: 0.78rem; }
 .st-time { display: flex; align-items: center; gap: 12px; padding: 12px 4px 2px; }
 .st-time--galaxy { color: #8b97a8; font-size: 0.8rem; }
 .st-play, .st-now { border: 1px solid rgba(120, 140, 180, 0.3); background: var(--surface-2, #11151c);

--- a/socioprophet-web/client-vue/src/space/horoscope.ts
+++ b/socioprophet-web/client-vue/src/space/horoscope.ts
@@ -1,0 +1,76 @@
+/**
+ * horoscope.ts — the EMPIRICAL skeleton of a horoscope: geocentric celestial orientation at a
+ * time and place. Real astronomy (sidereal time, obliquity, Ascendant, Midheaven) — the honest
+ * part of a chart. Zodiac *sign names* are an interpretive lens applied on top; the *angles* here
+ * are computed, not interpreted.
+ *
+ * Formulae are standard low-precision ecliptic geometry (arc-minute class), sufficient to orient the
+ * ecliptic lens and read out ASC/MC/LST. Not an ephemeris for the planets — see space/ephemeris.ts.
+ */
+
+const D2R = Math.PI / 180;
+const R2D = 180 / Math.PI;
+const norm360 = (d: number) => ((d % 360) + 360) % 360;
+
+export function julianDay(date: Date): number {
+  return date.getTime() / 86_400_000 + 2440587.5;
+}
+
+function centuriesSinceJ2000(date: Date): number {
+  return (julianDay(date) - 2451545.0) / 36525;
+}
+
+/** Mean obliquity of the ecliptic (degrees). */
+export function obliquityDeg(date: Date): number {
+  return 23.439291 - 0.0130042 * centuriesSinceJ2000(date);
+}
+
+/** Greenwich Mean Sidereal Time (degrees, 0..360). */
+export function gmstDeg(date: Date): number {
+  const d = julianDay(date) - 2451545.0;
+  return norm360(280.46061837 + 360.98564736629 * d);
+}
+
+/** Local Sidereal Time (degrees = RAMC), longitude east positive. */
+export function lstDeg(date: Date, lonDeg: number): number {
+  return norm360(gmstDeg(date) + lonDeg);
+}
+
+export function lstHours(date: Date, lonDeg: number): number {
+  return lstDeg(date, lonDeg) / 15;
+}
+
+/** Midheaven ecliptic longitude (degrees, 0..360). */
+export function midheavenLon(date: Date, lonDeg: number): number {
+  const th = lstDeg(date, lonDeg) * D2R;
+  const e = obliquityDeg(date) * D2R;
+  return norm360(Math.atan2(Math.sin(th), Math.cos(th) * Math.cos(e)) * R2D);
+}
+
+/** Ascendant ecliptic longitude (degrees, 0..360) — the sign rising on the eastern horizon. */
+export function ascendantLon(date: Date, latDeg: number, lonDeg: number): number {
+  const th = lstDeg(date, lonDeg) * D2R;
+  const e = obliquityDeg(date) * D2R;
+  const phi = latDeg * D2R;
+  const asc = Math.atan2(Math.cos(th), -(Math.sin(th) * Math.cos(e) + Math.tan(phi) * Math.sin(e))) * R2D;
+  return norm360(asc);
+}
+
+export const SIGNS = [
+  'Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo',
+  'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces',
+] as const;
+export const SIGN_GLYPHS = ['♈', '♉', '♊', '♋', '♌', '♍', '♎', '♏', '♐', '♑', '♒', '♓'] as const;
+
+export interface SignPosition {
+  index: number;   // 0..11
+  name: string;
+  glyph: string;
+  deg: number;     // 0..30 within the sign
+}
+
+export function signOf(lonDeg: number): SignPosition {
+  const l = norm360(lonDeg);
+  const index = Math.floor(l / 30);
+  return { index, name: SIGNS[index]!, glyph: SIGN_GLYPHS[index]!, deg: l - index * 30 };
+}


### PR DESCRIPTION
Completes **#44** — 'connect the dots from a horoscope and orientation, through time and space.' Adds the **empirical geocentric skeleton** and orients the ecliptic lens by it.

- **`src/space/horoscope.ts`** — LST / obliquity / **Ascendant** / **Midheaven** from date + lat/long (standard low-precision ecliptic geometry). The angles are computed; the zodiac *sign names* stay the interpretive lens.
- **SpaceTwin solar mode** — the ecliptic lens ring is oriented so the computed **Ascendant sits on the east horizon**, with gold **ASC** + teal **MC** markers; **observer lat/long inputs**; readout `ASC ♈12° · MC ♑3° · LST 14:22 @ 40.1°,-75.1°`. Time-driven — the rising sign moves as the clock runs.
- **6 unit tests** (ranges, determinism, Earth-turns-moves-ASC, signOf) in `src/__tests__/` (so they're actually gated by CI).

Honesty preserved: angles = empirical astronomy; sign meanings = the capped speculative lens (usolspace projection discipline).

### Verification (real toolchain)
`vitest` → **536/536** (6 new) · `vue-tsc` → 0 errors · `vite build` → ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)