### PR TITLE
feat(cockpit): ExecutionsLedger multi-agent handoff run-tree view

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/executionsRunTree.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/executionsRunTree.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { groupIntoRuns, demoLedger, type ExecutionRow } from '../features/executions-ledger/types';
+
+// Minimal row factory — only the fields groupIntoRuns reads.
+function row(id: string, run?: ExecutionRow['run'], over: Partial<ExecutionRow> = {}): ExecutionRow {
+  return {
+    executionReceiptId: id,
+    executedAt: over.executedAt ?? '2026-08-01T00:00:00Z',
+    agent: over.agent ?? { name: id, version: '1.0.0' },
+    input: { type: 'event' },
+    decision: { verdict: 'allow', authorityBand: 'observe' },
+    verdict: over.verdict ?? 'verified',
+    capabilitiesHeld: [],
+    capabilitiesUsed: [],
+    proofReplayable: true,
+    receiptHash: 'sha256:' + '0'.repeat(64),
+    run,
+    ...over,
+  };
+}
+
+describe('groupIntoRuns', () => {
+  it('separates standalone rows from runs', () => {
+    const { runs, ungrouped } = groupIntoRuns([row('a'), row('b')]);
+    expect(runs).toHaveLength(0);
+    expect(ungrouped.map((r) => r.executionReceiptId)).toEqual(['a', 'b']);
+  });
+
+  it('reconstructs a linear handoff chain in step order with increasing depth', () => {
+    const rows = [
+      row('c', { runId: 'R', step: 2, handoffFrom: 'b' }),
+      row('a', { runId: 'R', step: 0 }),
+      row('b', { runId: 'R', step: 1, handoffFrom: 'a' }),
+    ];
+    const { runs, ungrouped } = groupIntoRuns(rows);
+    expect(ungrouped).toHaveLength(0);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].nodes.map((n) => [n.row.executionReceiptId, n.depth])).toEqual([
+      ['a', 0], ['b', 1], ['c', 2],
+    ]);
+    expect(runs[0].count).toBe(3);
+  });
+
+  it('renders a fork: siblings share depth, ordered by step', () => {
+    const rows = [
+      row('root', { runId: 'R', step: 0 }),
+      row('child2', { runId: 'R', step: 2, handoffFrom: 'root' }),
+      row('child1', { runId: 'R', step: 1, handoffFrom: 'root' }),
+    ];
+    const { runs } = groupIntoRuns(rows);
+    expect(runs[0].nodes.map((n) => [n.row.executionReceiptId, n.depth])).toEqual([
+      ['root', 0], ['child1', 1], ['child2', 1],
+    ]);
+  });
+
+  it('rolls up the worst-case verdict (denied ≻ pending ≻ verified)', () => {
+    const rows = [
+      row('a', { runId: 'R', step: 0 }, { verdict: 'verified' }),
+      row('b', { runId: 'R', step: 1, handoffFrom: 'a' }, { verdict: 'pending' }),
+    ];
+    expect(groupIntoRuns(rows).runs[0].verdict).toBe('pending');
+    const rows2 = [...rows, row('c', { runId: 'R', step: 2, handoffFrom: 'b' }, { verdict: 'denied' })];
+    expect(groupIntoRuns(rows2).runs[0].verdict).toBe('denied');
+  });
+
+  it('treats a handoffFrom pointing outside the group as a root (no drop)', () => {
+    const rows = [row('x', { runId: 'R', step: 1, handoffFrom: 'ghost' })];
+    const { runs } = groupIntoRuns(rows);
+    expect(runs[0].nodes).toHaveLength(1);
+    expect(runs[0].nodes[0].depth).toBe(0);
+  });
+
+  it('is total under a cycle — every member appears exactly once', () => {
+    const rows = [
+      row('a', { runId: 'R', step: 0, handoffFrom: 'b' }),
+      row('b', { runId: 'R', step: 1, handoffFrom: 'a' }),
+    ];
+    const ids = groupIntoRuns(rows).runs[0].nodes.map((n) => n.row.executionReceiptId).sort();
+    expect(ids).toEqual(['a', 'b']);
+  });
+
+  it('groups the shipped fixture run and leaves the standalone rows ungrouped', () => {
+    const { runs, ungrouped } = groupIntoRuns(demoLedger);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].runId).toBe('run_incident_atlas_88231');
+    expect(runs[0].count).toBe(5);
+    expect(runs[0].verdict).toBe('pending'); // two steps await approval
+    expect(runs[0].nodes[0].row.executionReceiptId).toBe('exec_triage_router_atlas');
+    // every grouped row accounted for; the rest stay standalone
+    expect(runs[0].count + ungrouped.length).toBe(demoLedger.length);
+    expect(ungrouped.every((r) => !r.run)).toBe(true);
+  });
+});

--- a/socioprophet-web/client-vue/src/features/executions-ledger/types.ts
+++ b/socioprophet-web/client-vue/src/features/executions-ledger/types.ts
@@ -24,6 +24,10 @@ export interface ExecutionRow {
   proofReplayable: boolean;
   receiptHash: string; // ^sha256:
   blast?: { targetNode: string; reachableCount: number; hops: number };
+  // Multi-agent run linkage (dispatch-ledger DispatchEntry.prev): `runId` groups the
+  // handoff, `handoffFrom` = executionReceiptId of the parent that dispatched this step,
+  // `step` orders siblings. Absent on standalone executions.
+  run?: { runId: string; step: number; handoffFrom?: string };
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +95,83 @@ export function rowMatches(row: ExecutionRow, f: ParsedFilter): boolean {
 export function applyFilter(rows: ExecutionRow[], query: string): ExecutionRow[] {
   const f = parseFilter(query);
   return rows.filter((r) => rowMatches(r, f));
+}
+
+// ---------------------------------------------------------------------------
+// Run-tree grouping — a multi-agent run is a chain (or fork) of executions linked
+// by `run.handoffFrom` (the dispatch-ledger `prev`). This reconstructs the tree
+// from a flat ledger: rows without `run` stay ungrouped (standalone executions);
+// grouped rows are assembled per `runId` into a depth-annotated DFS order, so a
+// PM→frontend→{backend,tester} handoff reads as an indented tree, not flat rows.
+// Pure + total: cycles are broken, orphans (handoffFrom outside the group) become
+// additional roots, and any unreached member is appended rather than dropped.
+// ---------------------------------------------------------------------------
+
+export interface RunNode { row: ExecutionRow; depth: number; }
+export interface RunTree {
+  runId: string;
+  startedAt: string;     // earliest executedAt in the run
+  agents: string[];      // distinct agent names in handoff (DFS) order
+  nodes: RunNode[];      // DFS-ordered rows with indentation depth
+  verdict: VerdictState; // worst-case roll-up: denied ≻ pending ≻ verified
+  count: number;
+}
+
+const VERDICT_RANK: Record<VerdictState, number> = { verified: 0, pending: 1, denied: 2 };
+
+export function groupIntoRuns(rows: ExecutionRow[]): { runs: RunTree[]; ungrouped: ExecutionRow[] } {
+  const ungrouped: ExecutionRow[] = [];
+  const groups = new Map<string, ExecutionRow[]>();
+  for (const r of rows) {
+    if (!r.run) { ungrouped.push(r); continue; }
+    const g = groups.get(r.run.runId);
+    if (g) g.push(r); else groups.set(r.run.runId, [r]);
+  }
+
+  const byStep = (a: ExecutionRow, b: ExecutionRow) =>
+    (a.run!.step - b.run!.step) || a.executedAt.localeCompare(b.executedAt);
+
+  const runs: RunTree[] = [];
+  for (const [runId, members] of groups) {
+    const byId = new Map(members.map((m) => [m.executionReceiptId, m]));
+    const childrenOf = new Map<string, ExecutionRow[]>();
+    const roots: ExecutionRow[] = [];
+    for (const m of members) {
+      const from = m.run!.handoffFrom;
+      if (from && byId.has(from)) {
+        const arr = childrenOf.get(from);
+        if (arr) arr.push(m); else childrenOf.set(from, [m]);
+      } else {
+        roots.push(m); // no parent, or parent lives outside this group → a root
+      }
+    }
+    roots.sort(byStep);
+
+    const nodes: RunNode[] = [];
+    const seen = new Set<string>();
+    const walk = (row: ExecutionRow, depth: number) => {
+      if (seen.has(row.executionReceiptId)) return; // cycle guard
+      seen.add(row.executionReceiptId);
+      nodes.push({ row, depth });
+      for (const kid of (childrenOf.get(row.executionReceiptId) ?? []).slice().sort(byStep)) {
+        walk(kid, depth + 1);
+      }
+    };
+    for (const r of roots) walk(r, 0);
+    for (const m of members) if (!seen.has(m.executionReceiptId)) nodes.push({ row: m, depth: 0 });
+
+    const agents: string[] = [];
+    for (const n of nodes) if (!agents.includes(n.row.agent.name)) agents.push(n.row.agent.name);
+    const verdict = nodes.reduce<VerdictState>(
+      (worst, n) => (VERDICT_RANK[n.row.verdict] > VERDICT_RANK[worst] ? n.row.verdict : worst),
+      'verified',
+    );
+    const startedAt = members.reduce((min, m) => (m.executedAt < min ? m.executedAt : min), members[0].executedAt);
+    runs.push({ runId, startedAt, agents, nodes, verdict, count: members.length });
+  }
+
+  runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt)); // newest run first
+  return { runs, ungrouped };
 }
 
 // ---------------------------------------------------------------------------
@@ -166,5 +247,85 @@ export const demoLedger: ExecutionRow[] = [
     proofReplayable: true,
     receiptHash: 'sha256:93aa0e4fbb1122334455667788990011223344556677889900aabbccddeeff00',
     blast: { targetNode: 'endpoint://mbx-42', reachableCount: 1, hops: 1 },
+  },
+
+  // --- Multi-agent handoff run: one incident, five governed executions linked by
+  //     run.handoffFrom. Triage → Correlation → { Endpoint Containment, Mailbox
+  //     Containment }, and Endpoint Containment → Attestation. Renders as a tree
+  //     under "Group by run". Roll-up verdict = pending (two steps await approval).
+  {
+    executionReceiptId: 'exec_triage_router_atlas',
+    executedAt: '2026-08-01T09:14:02Z',
+    agent: { name: 'Triage Router Agent', version: '2.0.0', category: 'triage' },
+    input: { type: 'external_alert', ref: 'alert_atlas_9001' },
+    decision: { verdict: 'allow', authorityBand: 'recommend', latencyMs: 11 },
+    verdict: 'verified',
+    epistemicLevel: 'bounded',
+    capabilitiesHeld: ['cap_read_alerts_demo', 'cap_dispatch_agent_demo'],
+    capabilitiesUsed: ['cap_read_alerts_demo', 'cap_dispatch_agent_demo'],
+    proofReplayable: true,
+    receiptHash: 'sha256:aa01bb02cc03dd04ee05ff0611223344556677889900aabbccddeeff00112233',
+    blast: { targetNode: 'endpoint://vvv-648e9d56f1a', reachableCount: 7, hops: 3 },
+    run: { runId: 'run_incident_atlas_88231', step: 0 },
+  },
+  {
+    executionReceiptId: 'exec_correlation_atlas',
+    executedAt: '2026-08-01T09:14:19Z',
+    agent: { name: 'Correlation Agent', version: '1.4.0', category: 'investigation' },
+    input: { type: 'detection', ref: 'det_atlas_2' },
+    decision: { verdict: 'allow', authorityBand: 'recommend', latencyMs: 33 },
+    verdict: 'verified',
+    epistemicLevel: 'bounded',
+    capabilitiesHeld: ['cap_read_detections_demo', 'cap_read_baseline_demo', 'cap_dispatch_agent_demo'],
+    capabilitiesUsed: ['cap_read_detections_demo', 'cap_read_baseline_demo'],
+    proofReplayable: true,
+    receiptHash: 'sha256:bb11cc22dd33ee44ff556677889900aabbccddeeff0011223344556677889900',
+    blast: { targetNode: 'endpoint://vvv-648e9d56f1a', reachableCount: 9, hops: 4 },
+    run: { runId: 'run_incident_atlas_88231', step: 1, handoffFrom: 'exec_triage_router_atlas' },
+  },
+  {
+    executionReceiptId: 'exec_endpoint_containment_atlas',
+    executedAt: '2026-08-01T09:14:41Z',
+    agent: { name: 'Endpoint Containment Agent', version: '1.3.0', category: 'response' },
+    input: { type: 'detection', ref: 'det_atlas_2' },
+    decision: { verdict: 'require_approval', authorityBand: 'queue', latencyMs: 47 },
+    verdict: 'pending',
+    epistemicLevel: 'synthetic',
+    capabilitiesHeld: ['cap_read_detections_demo', 'cap_isolate_endpoint_demo'],
+    capabilitiesUsed: ['cap_read_detections_demo'],
+    proofReplayable: true,
+    receiptHash: 'sha256:cc22dd33ee44ff5566778899aabbccddeeff00112233445566778899aabbccdd',
+    blast: { targetNode: 'endpoint://vvv-648e9d56f1a', reachableCount: 14, hops: 5 },
+    run: { runId: 'run_incident_atlas_88231', step: 2, handoffFrom: 'exec_correlation_atlas' },
+  },
+  {
+    executionReceiptId: 'exec_mailbox_containment_atlas',
+    executedAt: '2026-08-01T09:14:43Z',
+    agent: { name: 'Mailbox Containment Agent', version: '1.1.0', category: 'email_security' },
+    input: { type: 'event', ref: 'event_atlas_5' },
+    decision: { verdict: 'allow', authorityBand: 'execute_local', latencyMs: 13 },
+    verdict: 'verified',
+    epistemicLevel: 'empirical',
+    capabilitiesHeld: ['cap_write_comment_demo', 'cap_quarantine_mail_demo'],
+    capabilitiesUsed: ['cap_quarantine_mail_demo'],
+    proofReplayable: true,
+    receiptHash: 'sha256:dd33ee44ff556677889900aabbccddeeff00112233445566778899aabbccddee',
+    blast: { targetNode: 'endpoint://mbx-42', reachableCount: 2, hops: 1 },
+    run: { runId: 'run_incident_atlas_88231', step: 2, handoffFrom: 'exec_correlation_atlas' },
+  },
+  {
+    executionReceiptId: 'exec_attestation_atlas',
+    executedAt: '2026-08-01T09:15:07Z',
+    agent: { name: 'Attestation Agent', version: '1.0.0', category: 'attestation' },
+    input: { type: 'event', ref: 'event_atlas_att' },
+    decision: { verdict: 'require_approval', authorityBand: 'queue', latencyMs: 22 },
+    verdict: 'pending',
+    epistemicLevel: 'synthetic',
+    capabilitiesHeld: ['cap_read_receipts_demo', 'cap_seal_attestation_demo'],
+    capabilitiesUsed: ['cap_read_receipts_demo'],
+    proofReplayable: true,
+    receiptHash: 'sha256:ee44ff556677889900aabbccddeeff00112233445566778899aabbccddeeff00',
+    blast: { targetNode: 'endpoint://vvv-648e9d56f1a', reachableCount: 14, hops: 5 },
+    run: { runId: 'run_incident_atlas_88231', step: 3, handoffFrom: 'exec_endpoint_containment_atlas' },
   },
 ];

--- a/socioprophet-web/client-vue/src/pages/ExecutionsLedger.vue
+++ b/socioprophet-web/client-vue/src/pages/ExecutionsLedger.vue
@@ -25,6 +25,9 @@
         placeholder="status:verified  input:external_alert|event  receipt:present  level:bounded"
         v-model="query"
       />
+      <label class="grp" title="Reconstruct multi-agent runs from handoff links (dispatch-ledger prev)">
+        <input type="checkbox" v-model="groupByRun" /> Group by run
+      </label>
       <span class="count">{{ filtered.length }} / {{ rows.length }}</span>
     </div>
 
@@ -36,61 +39,87 @@
           </tr>
         </thead>
         <tbody>
-          <template v-for="row in filtered" :key="row.executionReceiptId">
-            <tr class="exec-row" tabindex="0" role="button"
-              :aria-expanded="open.has(row.executionReceiptId)"
-              @click="toggle(row.executionReceiptId)"
-              @keydown.enter="toggle(row.executionReceiptId)"
-              @keydown.space.prevent="toggle(row.executionReceiptId)">
-              <td class="mono when">{{ fmt(row.executedAt) }}</td>
-              <td><div class="agent"><span class="an">{{ row.agent.name }}</span><span class="av mono">{{ row.agent.version }}</span></div></td>
-              <td><span class="in-tag mono">{{ inputLabel(row.input.type) }}</span></td>
+          <template v-for="item in displayItems" :key="item.kind === 'run-head' ? 'run:' + item.runId : item.row.executionReceiptId">
+            <tr v-if="item.kind === 'run-head'" class="run-head">
+              <td class="mono when">{{ fmt(item.run.startedAt) }}</td>
+              <td colspan="5">
+                <div class="run-line">
+                  <span class="run-id mono">⛓ {{ item.runId }}</span>
+                  <span class="run-chain">{{ item.run.agents.join(' → ') }}</span>
+                  <span class="chip" :class="verdictClass(item.run.verdict)">{{ item.run.verdict }}</span>
+                  <span class="run-n mono">{{ item.run.count }} step{{ item.run.count === 1 ? '' : 's' }}</span>
+                </div>
+              </td>
+            </tr>
+            <template v-else>
+            <tr class="exec-row" :class="{ 'is-child': item.depth > 0 }" tabindex="0" role="button"
+              :aria-expanded="open.has(item.row.executionReceiptId)"
+              @click="toggle(item.row.executionReceiptId)"
+              @keydown.enter="toggle(item.row.executionReceiptId)"
+              @keydown.space.prevent="toggle(item.row.executionReceiptId)">
+              <td class="mono when">{{ fmt(item.row.executedAt) }}</td>
               <td>
-                <span class="chip" :class="verdictClass(row.verdict)">{{ row.verdict }}</span>
-                <span v-if="row.epistemicLevel" class="lvl mono">{{ row.epistemicLevel }}</span>
+                <div class="agent" :style="item.depth ? { paddingLeft: item.depth * 16 + 'px' } : undefined">
+                  <span class="an"><span v-if="item.depth" class="branch mono">└─ </span>{{ item.row.agent.name }}</span>
+                  <span class="av mono">{{ item.row.agent.version }}</span>
+                </div>
+              </td>
+              <td><span class="in-tag mono">{{ inputLabel(item.row.input.type) }}</span></td>
+              <td>
+                <span class="chip" :class="verdictClass(item.row.verdict)">{{ item.row.verdict }}</span>
+                <span v-if="item.row.epistemicLevel" class="lvl mono">{{ item.row.epistemicLevel }}</span>
               </td>
               <td>
-                <span v-if="row.blast" class="mono blast">{{ row.blast.hops }} hop{{ row.blast.hops === 1 ? '' : 's' }} · {{ row.blast.reachableCount }}</span>
+                <span v-if="item.row.blast" class="mono blast">{{ item.row.blast.hops }} hop{{ item.row.blast.hops === 1 ? '' : 's' }} · {{ item.row.blast.reachableCount }}</span>
                 <span v-else class="mono muted">—</span>
               </td>
-              <td><span class="mono receipt"><span class="seal">✦</span>{{ shortHash(row.receiptHash) }}</span></td>
+              <td><span class="mono receipt"><span class="seal">✦</span>{{ shortHash(item.row.receiptHash) }}</span></td>
             </tr>
-            <tr v-show="open.has(row.executionReceiptId)" class="warrant-row">
+            <tr v-show="open.has(item.row.executionReceiptId)" class="warrant-row">
               <td colspan="6">
                 <div class="warrant">
                   <div class="wsec">
                     <div class="eyebrow">ExecutionDecision</div>
-                    <div class="decision" :class="{ pend: row.decision.verdict === 'require_approval', deny: row.decision.verdict === 'block' }">
-                      <b>{{ decisionLabel(row.decision.verdict) }}</b>
-                      <span class="mono">authority: {{ row.decision.authorityBand }}<template v-if="row.decision.latencyMs != null"> · {{ row.decision.latencyMs }}ms</template></span>
+                    <div class="decision" :class="{ pend: item.row.decision.verdict === 'require_approval', deny: item.row.decision.verdict === 'block' }">
+                      <b>{{ decisionLabel(item.row.decision.verdict) }}</b>
+                      <span class="mono">authority: {{ item.row.decision.authorityBand }}<template v-if="item.row.decision.latencyMs != null"> · {{ item.row.decision.latencyMs }}ms</template></span>
+                    </div>
+                  </div>
+                  <div v-if="item.row.run" class="wsec">
+                    <div class="eyebrow">Run handoff</div>
+                    <div class="mono handoff">
+                      run={{ item.row.run.runId }} · step {{ item.row.run.step }}<br />
+                      <template v-if="item.row.run.handoffFrom">↳ handed off from {{ item.row.run.handoffFrom }}</template>
+                      <template v-else>◆ run root (no prior handoff)</template>
                     </div>
                   </div>
                   <div class="wsec">
                     <div class="eyebrow">Capabilities held → used</div>
                     <div class="caps">
-                      <span v-for="c in row.capabilitiesHeld" :key="c" class="cap mono" :class="{ used: row.capabilitiesUsed.includes(c) }">
-                        <span v-if="row.capabilitiesUsed.includes(c)" class="dot">✓</span>{{ c }}
+                      <span v-for="c in item.row.capabilitiesHeld" :key="c" class="cap mono" :class="{ used: item.row.capabilitiesUsed.includes(c) }">
+                        <span v-if="item.row.capabilitiesUsed.includes(c)" class="dot">✓</span>{{ c }}
                       </span>
                     </div>
                   </div>
                   <div class="wsec">
                     <div class="eyebrow">ProofArtifact</div>
                     <div class="proof mono">
-                      {{ row.receiptHash }}<br />
-                      replayable={{ row.proofReplayable }} · epistemicLevel={{ row.epistemicLevel ?? 'n/a' }}
-                      <span v-if="row.verdict === 'verified' && !row.proofReplayable" class="warn">⊘ verified verdict requires a replayable artifact</span>
+                      {{ item.row.receiptHash }}<br />
+                      replayable={{ item.row.proofReplayable }} · epistemicLevel={{ item.row.epistemicLevel ?? 'n/a' }}
+                      <span v-if="item.row.verdict === 'verified' && !item.row.proofReplayable" class="warn">⊘ verified verdict requires a replayable artifact</span>
                     </div>
                   </div>
-                  <div v-if="row.blast" class="wsec">
+                  <div v-if="item.row.blast" class="wsec">
                     <div class="eyebrow">Blast (GBRG)</div>
                     <div class="mono">
-                      <RouterLink class="blink" :to="`/control-plane/containment?node=${encodeURIComponent(row.blast.targetNode)}`">{{ row.blast.targetNode }}</RouterLink>
-                      — {{ row.blast.reachableCount }} reachable · {{ row.blast.hops }} hops
+                      <RouterLink class="blink" :to="`/control-plane/containment?node=${encodeURIComponent(item.row.blast.targetNode)}`">{{ item.row.blast.targetNode }}</RouterLink>
+                      — {{ item.row.blast.reachableCount }} reachable · {{ item.row.blast.hops }} hops
                     </div>
                   </div>
                 </div>
               </td>
             </tr>
+            </template>
           </template>
           <tr v-if="filtered.length === 0"><td colspan="6" class="empty">No executions match the filter.</td></tr>
         </tbody>
@@ -102,15 +131,34 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue';
 import { RouterLink } from 'vue-router';
-import { applyFilter, demoLedger, type ExecutionRow, type InputType, type VerdictState, type DecisionVerdict } from '../features/executions-ledger/types';
+import { applyFilter, demoLedger, groupIntoRuns, type ExecutionRow, type RunTree, type InputType, type VerdictState, type DecisionVerdict } from '../features/executions-ledger/types';
 
 const rows = ref<ExecutionRow[]>(demoLedger);
 const query = ref('');
+const groupByRun = ref(false);
 const open = reactive(new Set<string>());
 
 const filtered = computed(() => applyFilter(rows.value, query.value));
 const verifiedCount = computed(() => rows.value.filter((r) => r.verdict === 'verified').length);
 const heldCount = computed(() => rows.value.filter((r) => r.verdict !== 'verified').length);
+
+// Flat rows by default (one .exec-row per filtered execution); when grouped, a
+// run-head precedes each run's depth-indented steps, with standalone rows after.
+type DisplayItem =
+  | { kind: 'run-head'; runId: string; run: RunTree }
+  | { kind: 'row'; row: ExecutionRow; depth: number };
+
+const displayItems = computed<DisplayItem[]>(() => {
+  if (!groupByRun.value) return filtered.value.map((row) => ({ kind: 'row', row, depth: 0 }));
+  const { runs, ungrouped } = groupIntoRuns(filtered.value);
+  const items: DisplayItem[] = [];
+  for (const run of runs) {
+    items.push({ kind: 'run-head', runId: run.runId, run });
+    for (const n of run.nodes) items.push({ kind: 'row', row: n.row, depth: n.depth + 1 });
+  }
+  for (const row of ungrouped) items.push({ kind: 'row', row, depth: 0 });
+  return items;
+});
 
 function toggle(id: string) {
   if (open.has(id)) open.delete(id);
@@ -148,6 +196,8 @@ function decisionLabel(v: DecisionVerdict) { return DECISION_LABELS[v]; }
 .kpi .k { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--cds-text-secondary, #6f6f6f); }
 .filterbar { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
 .q { flex: 1; font-family: var(--font-mono, monospace); font-size: 12.5px; padding: 9px 12px; border: 1px solid var(--cds-border-strong, #8d8d8d); border-radius: 2px; background: var(--cds-field, #f4f4f4); color: inherit; }
+.grp { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px; color: var(--cds-text-secondary, #6f6f6f); white-space: nowrap; cursor: pointer; user-select: none; }
+.grp input { accent-color: var(--sp-amber-70, #b28600); }
 .count { font-family: var(--font-mono, monospace); font-size: 11.5px; color: var(--cds-text-secondary, #6f6f6f); white-space: nowrap; }
 .tbl-scroll { overflow-x: auto; }
 table.ledger { width: 100%; border-collapse: collapse; font-size: 12.5px; min-width: 760px; }
@@ -155,6 +205,15 @@ table.ledger { width: 100%; border-collapse: collapse; font-size: 12.5px; min-wi
 .exec-row { cursor: pointer; border-bottom: 1px solid var(--cds-border-subtle, #e0e0e0); }
 .exec-row:hover { background: var(--cds-layer-hover, #e8e8e8); }
 .exec-row td { padding: 10px 12px; vertical-align: middle; }
+.exec-row.is-child { background: color-mix(in srgb, var(--cds-layer-01, #f4f4f4) 55%, transparent); }
+.exec-row.is-child:hover { background: var(--cds-layer-hover, #e8e8e8); }
+.branch { color: var(--cds-text-placeholder, #a8a8a8); }
+.run-head td { padding: 9px 12px 8px; border-top: 2px solid var(--sp-amber-70, #b28600); background: var(--cds-layer-01, #f4f4f4); }
+.run-line { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.run-id { font-size: 11px; font-weight: 600; color: var(--sp-amber-70, #b28600); }
+.run-chain { font-size: 11.5px; color: var(--cds-text-secondary, #4f4f4f); }
+.run-n { font-size: 10.5px; color: var(--cds-text-secondary, #6f6f6f); }
+.handoff { font-size: 10.5px; color: var(--cds-text-secondary, #6f6f6f); padding: 8px 10px; border: 1px dashed var(--cds-border-subtle, #e0e0e0); border-radius: 3px; }
 .mono { font-family: var(--font-mono, monospace); }
 .when { color: var(--cds-text-secondary, #6f6f6f); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .agent { display: flex; flex-direction: column; gap: 1px; }


### PR DESCRIPTION
The Executions Ledger was **flat** — a multi-agent run read as unrelated rows with no parent/handoff structure. This reconstructs the run tree from the handoff link the dispatch ledger already carries (`prev`).

- `ExecutionRow` gains optional `run:{ runId, step, handoffFrom }` (`handoffFrom` = dispatch-ledger `prev`).
- `groupIntoRuns(rows)` — **pure + total** run-tree builder: groups by `runId`, assembles a depth-annotated DFS order (linear chains **and forks**), rolls up the worst-case verdict (`denied ≻ pending ≻ verified`). Cycle-safe; a `handoffFrom` pointing outside the group becomes a root; unreached members are appended, never dropped. Standalone (run-less) executions stay ungrouped.
- **'Group by run' toggle** — default view stays flat (one `.exec-row` per execution, existing tests intact); grouped view shows a run-head (agent chain + rolled-up verdict + step count) then indented steps. Warrant panel gains a **Run handoff** section. No new page — enhances the shipped surface.
- Fixture: a 5-execution incident run with a **fork** (Triage→Correlation→{Endpoint, Mailbox} Containment, Endpoint→Attestation), roll-up = pending.
- **7 run-tree unit tests.**

Verified locally (client-vue CI queues on shared runners): **vue-tsc 0 err · vitest 543 passed · vite build ✓**.

Closes the one real #43 gap (flat ledger had no handoff tree). Live `/svc/executions` remains infra-gated; this renders against the fixture as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)