### PR TITLE
feat(noetica): Reasoning Chain Inspector — governed vocabulary + variant scorer

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/ReasoningChainInspector.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/ReasoningChainInspector.smoke.test.ts
@@ -1,0 +1,56 @@
+// Smoke test for the Reasoning Chain Inspector surface: mounts, renders the four
+// stages, and proves the governed scorer is load-bearing in the UI — switching
+// example A to the dedup mode produces a clear top-1 (the raw tie is resolved).
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import { createPinia, setActivePinia } from 'pinia';
+import ReasoningChainInspector from '../pages/ReasoningChainInspector.vue';
+
+const stub = { template: '<div />' };
+const router = createRouter({ history: createWebHashHistory(), routes: [{ path: '/:pathMatch(.*)*', component: stub }] });
+
+function mountIt() {
+  setActivePinia(createPinia());
+  return mount(ReasoningChainInspector, { global: { plugins: [router] } });
+}
+
+describe('ReasoningChainInspector', () => {
+  it('renders the four stage tabs and three examples', () => {
+    const w = mountIt();
+    expect(w.findAll('.rci-stage').length).toBe(4);
+    expect(w.findAll('.rci-pill').length).toBe(3);
+  });
+
+  it('annotation stage renders concept tags with governed KIND labels', () => {
+    const w = mountIt();
+    const tags = w.findAll('.rci-tag');
+    expect(tags.length).toBeGreaterThan(0);
+    // KIND chip present on typed tags.
+    expect(w.findAll('.rci-tag-kind').length).toBeGreaterThan(0);
+  });
+
+  it('variants stage shows a clear governed top-1 for example A dedup mode', async () => {
+    const w = mountIt();
+    // switch to Variants stage
+    await w.findAll('.rci-stage')[2].trigger('click');
+    // example A defaults to raw mode → switch to the dedup mode
+    await w.findAll('.rci-mode')[1].trigger('click');
+    const ribbon = w.find('.rci-score-ribbon');
+    expect(ribbon.exists()).toBe(true);
+    expect(w.find('.rci-variant.top').exists()).toBe(true);
+    // governed margin is clearly > 0 after dedup + parsimony
+    expect(w.find('.rci-score-ribbon b.clear').text()).not.toBe('0.00');
+  });
+
+  it('authoring a concept records a governed, versioned, unsigned event', async () => {
+    const w = mountIt();
+    await w.findAll('.rci-tag')[0].trigger('click'); // select a concept
+    const promote = w.findAll('.rci-author-btns button')[0];
+    await promote.trigger('click');
+    const ledger = w.find('.rci-ledger');
+    expect(ledger.exists()).toBe(true);
+    expect(ledger.text()).toContain('unsigned');
+    expect(ledger.text()).toContain('human-authored');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/reasoningChainAuthorship.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/reasoningChainAuthorship.test.ts
@@ -1,0 +1,51 @@
+// KE authorship round-trip: promotions are versioned, receipted, learned (not
+// match rules), and human overrides supersede the learned value while retaining
+// the prior as a version.
+
+import { describe, expect, it } from 'vitest';
+import {
+  promoteConceptToDictionaryTerm,
+  overrideConcept,
+  defineRelationType,
+  useAuthorshipLedger,
+} from '../features/reasoning-chain/keAuthorship';
+
+const author = { author: 'charles.peterson@socioprophet.ai', ts: '2026-08-03T00:00:00.000Z' };
+
+describe('KE authorship', () => {
+  it('promotes an annotation to a VERSIONED dictionary term, not a match rule', () => {
+    const { event, draft } = promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORGANIZATION', author);
+    expect(event.target).toBe('dictionary_term');
+    expect(event.learned).toBe(true);
+    expect(event.matchRule).toBe(false); // learn, don't match dictionaries
+    expect(event.governed).toBe(true);
+    expect(event.version).toBeTruthy();
+    expect(event.receipt).toContain('unsigned'); // honest — sealed later by KE workbench
+    expect(draft.mappedType).toBe('ORGANIZATION');
+    expect(draft.terms).toBe(1);
+  });
+
+  it('a human override supersedes the learned value and retains the prior version', () => {
+    const event = overrideConcept(':OrgUnit', 'ENTITY_TYPE', ':Own', author);
+    expect(event.action).toBe('overwrite');
+    expect(event.provenanceClass).toBe('human_authored');
+    expect(event.priorVersion).toEqual({ value: ':Own', provenanceClass: 'learned', version: 'learned-v0' });
+  });
+
+  it('defines a relation type with subject/object typing', () => {
+    const { event, draft } = defineRelationType(':RollsUpTo', 'RELATION', 'OrgUnit', 'Organization', author);
+    expect(event.target).toBe('relation_type');
+    expect(draft.subject).toBe('OrgUnit');
+    expect(draft.object).toBe('Organization');
+  });
+
+  it('ledger records newest-first', () => {
+    const ledger = useAuthorshipLedger();
+    const a = promoteConceptToDictionaryTerm(':A', 'ENTITY_TYPE', 'ORG', author).event;
+    const b = promoteConceptToDictionaryTerm(':B', 'ENTITY_TYPE', 'ORG', author).event;
+    ledger.record(a);
+    ledger.record(b);
+    expect(ledger.events.value[0].term).toBe(':B');
+    expect(ledger.events.value.length).toBe(2);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/reasoningChainScorer.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/reasoningChainScorer.test.ts
@@ -1,0 +1,85 @@
+// Teeth for the governed variant scorer. These tests prove the owner's
+// dilution-risk fix actually bites: the raw 0.75/0.75 tie in example A collapses
+// to a clear top-1 under dedup + parsimony (margin > 0), and a redundant longer
+// chain never out-scores a shorter correct one. Maps to the counter-test gate.
+
+import { describe, expect, it } from 'vitest';
+import { scoreVariants, scoreChain, rawMargin, precisionAt1 } from '../features/reasoning-chain/scoreVariants';
+import { EXAMPLES, LOGGED_QUESTIONS } from '../features/reasoning-chain/examples';
+
+const exA = EXAMPLES[0];
+const rawVariants = exA.variants.raw;
+const ont = exA.scoring.raw;
+
+describe('scoreVariants — example A (org scoping)', () => {
+  it('the raw scorer leaves an exact tie (margin 0.00) — selection is noise', () => {
+    // At least two plan-equivalent variants share the top coverage.
+    expect(rawMargin(rawVariants, ont)).toBe(0);
+  });
+
+  it('dedup collapses plan-equivalent variants (6 raw → 4 canonical nodes)', () => {
+    const res = scoreVariants(rawVariants, ont);
+    expect(res.collapsedFrom).toBe(6);
+    expect(res.collapsedTo).toBe(4);
+  });
+
+  it('TEETH: the 0.75/0.75 tie collapses to a CLEAR top-1 (margin > 0)', () => {
+    const res = scoreVariants(rawVariants, ont);
+    expect(res.rawMargin).toBe(0); // was a tie
+    expect(res.margin).toBeGreaterThan(0); // now separated
+    expect(res.top?.key).toBe('common:ShowDataMessage|engage:GetContactLists');
+    expect(res.top?.text).toBe('Show me contact lists.');
+  });
+
+  it('TEETH: the canonical top-1 pruned the redundant Organization hop', () => {
+    const res = scoreVariants(rawVariants, ont);
+    expect(res.top?.prunedExecutors).toContain('engage:GetOrganization');
+    expect(res.top?.canonicalChain.map((h) => h.executor)).toEqual([
+      'common:ShowDataMessage',
+      'engage:GetContactLists',
+    ]);
+  });
+
+  it('TEETH: a redundant longer chain does NOT out-score the shorter correct one', () => {
+    // V1 = 3 hops (redundant Organization); V4 = 2 hops, minimal & correct.
+    const v1 = rawVariants[0];
+    const v4 = rawVariants[3];
+    const long = scoreChain(v1.chain, ont);
+    const short = scoreChain(v4.chain, ont);
+    expect(long.redundant).toBeGreaterThan(short.redundant);
+    expect(long.score).toBeLessThan(short.score);
+  });
+
+  it('flags the degenerate "Contains." plan for pattern-catalog review', () => {
+    const res = scoreVariants(rawVariants, ont);
+    const contains = res.ranked.find((r) => r.text === 'Contains.');
+    expect(contains?.note).toBe('flagged for pattern-catalog review');
+  });
+});
+
+describe('scoreVariants — tie-break is by DECLARED path, never scorer noise', () => {
+  it('an exact score tie is broken by declaredCanonicalPath, not input order', () => {
+    // Two single-hop plans with identical coverage/parsimony → exact tie.
+    const variants = [
+      { text: 'B first in input', chain: [{ concept: 'Beta', executor: 'x:Beta', weight: 1, cat: 'entity' }] },
+      { text: 'A first in declared path', chain: [{ concept: 'Alpha', executor: 'x:Alpha', weight: 1, cat: 'entity' }] },
+    ];
+    const tieOnt = { requestedCore: ['Alpha', 'Beta'], ambient: [], declaredCanonicalPath: ['Alpha', 'Beta'] };
+    const res = scoreVariants(variants, tieOnt);
+    expect(res.margin).toBe(0); // genuine tie on score
+    expect(res.top?.text).toBe('A first in declared path'); // declared path wins
+  });
+});
+
+describe('precisionAt1 — counter-test gate (seed set)', () => {
+  it('selects the gold plan for every seeded logged question', () => {
+    const p = precisionAt1(LOGGED_QUESTIONS);
+    expect(p.precisionAt1).toBe(1);
+    expect(p.misses).toEqual([]);
+  });
+
+  it('honestly reports the corpus is below the estate min-n bar (GKN#9)', () => {
+    const p = precisionAt1(LOGGED_QUESTIONS);
+    expect(p.meetsMinN).toBe(false); // seed set only; corpus must grow to n>=30
+  });
+});

--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -116,6 +116,27 @@ export const routeRegistry: RouteRegistryEntry[] = [
     primaryObject: 'chat surface',
     breadcrumbs: ['Noetica', 'Chat'],
     railLabel: '◇',
+    tabs: [
+      { label: 'Chat', to: '/noetica' },
+      { label: 'Reasoning Chain', to: '/noetica/reasoning-chain' },
+    ],
+  },
+  {
+    path: '/noetica/reasoning-chain',
+    label: 'Reasoning Chain Inspector',
+    domain: 'Noetica',
+    maturity: 'L2',
+    stateMode: 'fixture',
+    navTier: 'tab-only',
+    userJob: 'Inspect a conversation chain in four stages — Annotation → Concepts → Variants → Execution — with annotations bound to the governed semantic-role KIND vocabulary and candidate plans ranked by the governed variant scorer.',
+    ownerPlane: 'client-vue ReasoningChainInspector (seed fixtures); KINDs from regis-entity-graph#22; authorship into the KE/dictionary workbench contract',
+    boundary: 'Fixture-backed over three seed conversation chains; no live conversation-chain binding and no durable KE writeback yet — authorship events are held in an unsigned in-memory ledger.',
+    primaryObject: 'reasoning chain',
+    breadcrumbs: ['Noetica', 'Reasoning Chain Inspector'],
+    tabs: [
+      { label: 'Chat', to: '/noetica' },
+      { label: 'Reasoning Chain', to: '/noetica/reasoning-chain' },
+    ],
   },
   {
     path: '/weather/forecast',

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/examples.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/examples.ts
@@ -1,0 +1,193 @@
+// Reasoning Chain Inspector — faithful port of the three worked examples from the
+// reference component (A org-scoping, B best-mailings, C EMEA-rollup): token trees,
+// candidate plan variants, and execution outcomes. Data is verbatim from source;
+// the per-example `scoring` ontology binds each example to the governed scorer
+// (scoreVariants.ts), and `loggedQuestions` seeds the precision@1 gate.
+
+import type { SourceCat } from './kindVocabulary';
+import type { ProvenanceClass } from './kindVocabulary';
+import type { RawVariant, ScoringOntology, LoggedQuestion } from './scoreVariants';
+
+export interface TokenConcept {
+  /** Learned concept label. */
+  l: string;
+  /** Source CAT token. */
+  c: SourceCat;
+  /** Provenance class — labels are learned unless a human override supersedes. */
+  provenance?: ProvenanceClass;
+}
+export interface Token {
+  text: string;
+  pos: string;
+  dep: string;
+  depth: number;
+  parent: number | null;
+  concepts: TokenConcept[];
+}
+
+export interface ExecutionOutcome {
+  status: 'resolved' | 'gap';
+  note: string;
+  response: string;
+}
+export interface ExampleMode {
+  key: string;
+  label: string;
+}
+export interface Example {
+  id: string;
+  label: string;
+  question: string;
+  tokens: Token[];
+  modes: ExampleMode[];
+  variants: Record<string, RawVariant[]>;
+  execution: Record<string, ExecutionOutcome>;
+  /** Governed-scorer ontology per mode (keys match `modes`). */
+  scoring: Record<string, ScoringOntology>;
+}
+
+// Helper: source chains are [concept, executor, weight, cat] tuples.
+type Tuple = [string, string, string, string];
+const chain = (rows: Tuple[]): RawVariant['chain'] =>
+  rows.map(([concept, executor, weight, cat]) => ({ concept, executor, weight: Number(weight), cat }));
+
+const EX_A_TOKENS: Token[] = [
+  { text: 'show', pos: 'VB VERB', dep: 'ROOT', depth: 0, parent: null, concepts: [{ l: ':ActionShow', c: 'action' }] },
+  { text: 'me', pos: 'PRP PRON', dep: 'iobj', depth: 1, parent: 0, concepts: [{ l: ':ActionShow', c: 'action' }] },
+  { text: 'list', pos: 'NNS NOUN', dep: 'dobj', depth: 1, parent: 0, concepts: [{ l: ':ContactLists', c: 'entity' }, { l: ':Lists', c: 'entity' }] },
+  { text: 'all', pos: 'DT DET', dep: 'det', depth: 2, parent: 2, concepts: [] },
+  { text: 'contact', pos: 'NN NOUN', dep: 'nn', depth: 2, parent: 2, concepts: [{ l: ':ContactLists', c: 'entity' }] },
+  { text: 'in', pos: 'IN ADP', dep: 'prep', depth: 2, parent: 2, concepts: [{ l: ':Contains', c: 'relation' }, { l: ':Relation', c: 'relation' }] },
+  { text: 'org', pos: 'NN NOUN', dep: 'pobj', depth: 3, parent: 5, concepts: [{ l: ':Organization', c: 'entity' }] },
+  { text: 'my', pos: 'PRP$ PRON', dep: 'poss', depth: 4, parent: 6, concepts: [{ l: ':Own', c: 'relation' }] },
+];
+
+const EX_B_TOKENS: Token[] = [
+  { text: 'send', pos: 'VBN VERB', dep: 'ROOT', depth: 0, parent: null, concepts: [{ l: ':Sent', c: 'action' }] },
+  { text: 'what', pos: 'WP PRON', dep: 'dep', depth: 1, parent: 0, concepts: [{ l: ':What', c: 'modifier' }] },
+  { text: 'be', pos: 'VBP VERB', dep: 'auxpass', depth: 1, parent: 0, concepts: [{ l: ':What', c: 'modifier' }] },
+  { text: 'line', pos: 'NNS NOUN', dep: 'nsubjpass', depth: 1, parent: 0, concepts: [{ l: ':SubjectValues', c: 'entity' }] },
+  { text: 'positive', pos: 'JJ ADJ', dep: 'amod', depth: 2, parent: 3, concepts: [{ l: ':Positive', c: 'modifier' }] },
+  { text: 'subject', pos: 'JJ ADJ', dep: 'amod', depth: 2, parent: 3, concepts: [{ l: ':SubjectValues', c: 'entity' }] },
+  { text: 'of', pos: 'IN ADP', dep: 'prep', depth: 2, parent: 3, concepts: [{ l: ':Relation', c: 'relation' }] },
+  { text: 'mailing', pos: 'NNS NOUN', dep: 'pobj', depth: 3, parent: 6, concepts: [{ l: ':Mailings', c: 'entity' }] },
+  { text: 'best', pos: 'JJS ADJ', dep: 'amod', depth: 4, parent: 7, concepts: [{ l: ':TheBest', c: 'gap' }] },
+  { text: 'in', pos: 'IN ADP', dep: 'prep', depth: 1, parent: 0, concepts: [{ l: ':Relation', c: 'relation' }] },
+  { text: '2017', pos: 'CD NUM', dep: 'pobj', depth: 2, parent: 9, concepts: [{ l: ':Timeframe', c: 'temporal' }] },
+];
+
+const EX_C_TOKENS: Token[] = [
+  { text: 'send', pos: 'VBD VERB', dep: 'ROOT', depth: 0, parent: null, concepts: [{ l: ':Sent', c: 'action' }] },
+  { text: 'mailing', pos: 'NNS NOUN', dep: 'dobj', depth: 1, parent: 0, concepts: [{ l: ':Mailings', c: 'entity' }] },
+  { text: 'many', pos: 'JJ ADJ', dep: 'amod', depth: 2, parent: 1, concepts: [{ l: ':Count', c: 'modifier' }] },
+  { text: 'how', pos: 'WRB ADV', dep: 'advmod', depth: 3, parent: 2, concepts: [{ l: ':Count', c: 'modifier' }] },
+  { text: 'EMEA', pos: 'NNP PROPN', dep: 'nsubj', depth: 1, parent: 0, concepts: [{ l: ':OrgUnit', c: 'gap' }] },
+  { text: 'quarter', pos: 'NN NOUN', dep: 'tmod', depth: 1, parent: 0, concepts: [{ l: ':Timeframe', c: 'temporal' }] },
+  { text: 'last', pos: 'JJ ADJ', dep: 'amod', depth: 2, parent: 5, concepts: [{ l: ':Relation', c: 'relation' }] },
+];
+
+export const EXAMPLES: Example[] = [
+  {
+    id: 'A',
+    label: 'Org scoping',
+    question: 'show me all contact lists in my org',
+    tokens: EX_A_TOKENS,
+    modes: [
+      { key: 'raw', label: 'Raw scoring' },
+      { key: 'fixed', label: 'Dedup + parsimony' },
+    ],
+    variants: {
+      raw: [
+        { text: 'Show me contact lists.', parseScore: '0.75', chain: chain([['ActionShow', 'common:ShowDataMessage', '5.000', 'action'], ['ContactLists', 'engage:GetContactLists', '3.000', 'entity'], ['Organization', 'engage:GetOrganization', '2.000', 'entity']]) },
+        { text: 'Show me contact lists belonging to you.', parseScore: '0.75', chain: chain([['ActionShow', 'common:ShowDataMessage', '3.833', 'action'], ['ContactLists', 'engage:GetOwnLists', '1.833', 'entity'], ['ContactLists', 'engage:GetContactLists', '2.500', 'entity'], ['Organization', 'engage:GetOrganization', '1.000', 'entity']]) },
+        { text: 'Show me contact lists belonging to you.', parseScore: '0.625', chain: chain([['ActionShow', 'common:ShowDataMessage', '3.667', 'action'], ['ContactLists', 'engage:GetOwnLists', '1.667', 'entity'], ['ContactLists', 'engage:GetContactLists', '2.000', 'entity']]) },
+        { text: 'Show me contact lists.', parseScore: '0.5', chain: chain([['ActionShow', 'common:ShowDataMessage', '4.000', 'action'], ['ContactLists', 'engage:GetContactLists', '2.000', 'entity']]) },
+        { text: 'Show me organization belonging to you.', parseScore: '0.5', chain: chain([['ActionShow', 'common:ShowDataMessage', '2.667', 'action'], ['Organization', 'engage:GetOrganization', '2.000', 'entity']]) },
+        { text: 'Contains.', parseScore: '0.125', chain: chain([['Contains', 'data:FillConditionIn', '1.000', 'relation']]) },
+      ],
+      // The "fixed" mode is DERIVED live from scoreVariants(raw) in the component;
+      // this array is the reference target the scorer must reproduce (see tests).
+      fixed: [
+        { text: 'Show me contact lists.', parseScore: '0.75', chain: chain([['ActionShow', 'common:ShowDataMessage', '4.000', 'action'], ['ContactLists', 'engage:GetContactLists', '2.000', 'entity']]) },
+        { text: 'Show me contact lists belonging to you.', parseScore: '0.5', chain: chain([['ActionShow', 'common:ShowDataMessage', '3.667', 'action'], ['ContactLists', 'engage:GetOwnLists', '1.667', 'entity'], ['ContactLists', 'engage:GetContactLists', '2.000', 'entity']]) },
+        { text: 'Show me organization belonging to you.', parseScore: '0.42', chain: chain([['ActionShow', 'common:ShowDataMessage', '2.667', 'action'], ['Organization', 'engage:GetOrganization', '2.000', 'entity']]) },
+        { text: 'Contains.', parseScore: '0.10', chain: chain([['Contains', 'data:FillConditionIn', '1.000', 'relation']]) },
+      ],
+    },
+    execution: {
+      raw: { status: 'resolved', note: 'Top-1 margin: 0.00 — exact tie between #1 and #2. Selection depends on tie-break order, not signal.', response: 'I found the 12 contact lists in your org.' },
+      fixed: { status: 'resolved', note: 'Top-1 margin: clear separation after dedup + parsimony.', response: 'I found the 12 contact lists in your org.' },
+    },
+    scoring: {
+      raw: { requestedCore: ['ActionShow', 'ContactLists'], ambient: ['Organization', 'Contains'], declaredCanonicalPath: ['ActionShow', 'ContactLists', 'Organization', 'Contains'] },
+      fixed: { requestedCore: ['ActionShow', 'ContactLists'], ambient: ['Organization', 'Contains'], declaredCanonicalPath: ['ActionShow', 'ContactLists', 'Organization', 'Contains'] },
+    },
+  },
+  {
+    id: 'B',
+    label: 'Best mailings',
+    question: 'what are positive subject lines of best mailings sent in 2017',
+    tokens: EX_B_TOKENS,
+    modes: [
+      { key: 'current', label: 'Current primitives' },
+      { key: 'proposed', label: 'With reporting primitives' },
+    ],
+    variants: {
+      current: [
+        { text: 'Show me mailings sent in 2017.', parseScore: '0.42', chain: chain([['ActionShow', 'common:ShowDataMessage', '3.000', 'action'], ['Mailings', 'engage:GetMailingsByDates', '2.000', 'entity']]) },
+        { text: 'Show me subject lines.', parseScore: '0.18', chain: chain([['ActionShow', 'common:ShowDataMessage', '1.500', 'action']]) },
+      ],
+      proposed: [
+        { text: 'Show me the best mailings sent in 2017, ranked by open rate, with positive subject lines.', parseScore: '0.91', chain: chain([['ActionShow', 'common:ShowDataMessage', '4.000', 'action'], ['Mailings', 'engage:GetMailingsByDates', '3.000', 'entity'], ['TheBest', 'engage:RankByMetric(openRate)', '3.500', 'entity'], ['Positive', 'engage:FilterSubjectSentiment', '2.500', 'modifier']]) },
+      ],
+    },
+    execution: {
+      current: { status: 'gap', note: 'No primitive binds :TheBest or :Positive. Best available variant silently discards both — the answer looks complete but isn\'t.', response: 'Here are your mailings sent in 2017.' },
+      proposed: { status: 'resolved', note: 'TheBest resolves via an ontology-declared metric binding (openRate for this vertical).', response: 'Your top mailings from 2017 by open rate, with positive subject lines: ...' },
+    },
+    scoring: {
+      current: { requestedCore: ['ActionShow', 'Mailings', 'TheBest', 'Positive'], ambient: [], declaredCanonicalPath: ['ActionShow', 'Mailings', 'TheBest', 'Positive'] },
+      proposed: { requestedCore: ['ActionShow', 'Mailings', 'TheBest', 'Positive'], ambient: [], declaredCanonicalPath: ['ActionShow', 'Mailings', 'TheBest', 'Positive'] },
+    },
+  },
+  {
+    id: 'C',
+    label: 'EMEA rollup',
+    question: 'how many mailings did EMEA send last quarter',
+    tokens: EX_C_TOKENS,
+    modes: [
+      { key: 'current', label: 'Current primitives' },
+      { key: 'proposed', label: 'With org hierarchy primitive' },
+    ],
+    variants: {
+      current: [
+        { text: 'Show me the number of mailings.', parseScore: '0.38', chain: chain([['ActionShow', 'common:ShowDataMessage', '2.000', 'action'], ['Mailings', 'engage:GetOwnMailings', '2.000', 'entity']]) },
+      ],
+      proposed: [
+        { text: 'Show me the number of mailings sent by EMEA last quarter.', parseScore: '0.88', chain: chain([['ActionShow', 'common:ShowDataMessage', '3.000', 'action'], ['OrgUnit', 'engage:ResolveOrgUnit(EMEA)', '3.000', 'entity'], ['Mailings', 'engage:GetMailingsByDates(rollup:descendants)', '3.500', 'entity']]) },
+      ],
+    },
+    execution: {
+      current: { status: 'gap', note: 'Org scope is binary (:Own / :Others) — a named sub-org and hierarchy rollup are unrepresentable, so the scope silently defaults to "own," and the count is for the wrong org entirely.', response: 'You have 214 mailings.' },
+      proposed: { status: 'resolved', note: 'Org hierarchy traversal resolves EMEA as a descendant scope and rolls counts up.', response: 'EMEA sent 37 mailings last quarter.' },
+    },
+    scoring: {
+      current: { requestedCore: ['ActionShow', 'Mailings', 'OrgUnit'], ambient: [], declaredCanonicalPath: ['ActionShow', 'OrgUnit', 'Mailings'] },
+      proposed: { requestedCore: ['ActionShow', 'Mailings', 'OrgUnit'], ambient: [], declaredCanonicalPath: ['ActionShow', 'OrgUnit', 'Mailings'] },
+    },
+  },
+];
+
+// ---- precision@1 seed fixtures (counter-test gate) ----
+// SEED SET ONLY (n < MIN_N=30). The gate is wired; the logged-question corpus
+// must grow to n>=30 before any precision@1 claim is published (GKN#9). Follow-up
+// filed @mdheller to source real logged questions.
+const exA = EXAMPLES[0];
+const exB = EXAMPLES[1];
+const exC = EXAMPLES[2];
+
+export const LOGGED_QUESTIONS: LoggedQuestion[] = [
+  { id: 'A-org-scoping', question: exA.question, variants: exA.variants.raw, ontology: exA.scoring.raw, goldKey: 'common:ShowDataMessage|engage:GetContactLists' },
+  { id: 'B-best-mailings', question: exB.question, variants: exB.variants.proposed, ontology: exB.scoring.proposed, goldKey: 'common:ShowDataMessage|engage:FilterSubjectSentiment|engage:GetMailingsByDates|engage:RankByMetric(openRate)' },
+  { id: 'C-emea-rollup', question: exC.question, variants: exC.variants.proposed, ontology: exC.scoring.proposed, goldKey: 'common:ShowDataMessage|engage:GetMailingsByDates(rollup:descendants)|engage:ResolveOrgUnit(EMEA)' },
+];

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/keAuthorship.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/keAuthorship.ts
@@ -1,0 +1,176 @@
+// Knowledge-Engineering authorship round-trip for the Reasoning Chain Inspector.
+//
+// The inspector is not read-only: from the annotation view a user can add /
+// overwrite / annotate / define entity types, relation types, dictionary terms
+// and rules. Each action emits a GOVERNED authorship event — versioned,
+// author-attributed, and receipted — into the KE/dictionary workbench contract.
+//
+// Estate rules honored:
+//   - "learn, don't match dictionaries": a promoted term becomes a VERSIONED,
+//     provenance-carrying dictionary entry (learned + governed), never a static
+//     match rule. Every event carries `matchRule: false` + `learned: true`.
+//   - Human overrides SUPERSEDE the learned value; the prior is retained as a
+//     version (`priorVersion`), never discarded.
+//   - No fabricated cryptographic provenance (AGENTS.md): new human authorship is
+//     honestly UNSIGNED — the promotion gate / KE workbench seals it later.
+//
+// CONSUME-NOT-FORK: the event shapes mirror the live Knowledge Studio KE contract
+// (features/knowledge-studio/fixture.ts: EntityType, RelationType, Dictionary,
+// Version). The concurrent KE-workbench agent owns the durable authorship
+// contract; this module is the local emit surface + the exact hooks to rewire to
+// that contract when it lands (tracked follow-up @mdheller). No live/shared write
+// happens here — events are held in an in-memory ledger and surfaced in the UI.
+
+import { ref, type Ref } from 'vue';
+import type { Dictionary, EntityType, RelationType } from '../knowledge-studio/fixture';
+import type { AnnotationKind, ProvenanceClass } from './kindVocabulary';
+
+export type AuthorshipAction = 'add' | 'overwrite' | 'annotate' | 'define';
+export type AuthorshipTarget = 'entity_type' | 'relation_type' | 'dictionary_term' | 'rule';
+
+export interface AuthorshipVersionRef {
+  value: string;
+  provenanceClass: ProvenanceClass;
+  version: string;
+}
+
+export interface AuthorshipEvent {
+  id: string;
+  action: AuthorshipAction;
+  target: AuthorshipTarget;
+  /** The concept/term being authored, e.g. ':OrgUnit'. */
+  term: string;
+  /** Governed KIND the term is typed as. */
+  kind: AnnotationKind;
+  /** For dictionary terms / relations: the KE type it maps to (e.g. 'ORGANIZATION'). */
+  mappedType?: string;
+  author: string;
+  ts: string;
+  version: string;
+  /** Human authorship supersedes learned; the prior is retained here. */
+  priorVersion?: AuthorshipVersionRef;
+  provenanceClass: ProvenanceClass;
+  /** Governance flags — a term is LEARNED + versioned, never a match rule. */
+  governed: true;
+  learned: true;
+  matchRule: false;
+  /** Honest receipt: unsigned until the KE workbench / promotion gate seals it. */
+  receipt: string;
+  /** Free-text rationale captured from the author (annotate action). */
+  note?: string;
+}
+
+const UNSIGNED = 'unsigned — pending KE workbench seal';
+
+let seq = 0;
+function nextId(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}`;
+}
+
+export interface AuthorInput {
+  author: string;
+  /** ISO timestamp; injectable for deterministic tests. */
+  ts?: string;
+  note?: string;
+  /** The value being superseded, if this is a human override of a learned label. */
+  prior?: AuthorshipVersionRef;
+}
+
+/** Build a governed authorship event (pure — testable; no side effects). */
+export function buildAuthorshipEvent(
+  action: AuthorshipAction,
+  target: AuthorshipTarget,
+  term: string,
+  kind: AnnotationKind,
+  input: AuthorInput,
+  mappedType?: string,
+): AuthorshipEvent {
+  return {
+    id: nextId(target),
+    action,
+    target,
+    term,
+    kind,
+    mappedType,
+    author: input.author,
+    ts: input.ts ?? new Date().toISOString(),
+    version: 'v1-draft',
+    priorVersion: input.prior,
+    // Any authorship action taken by a person is human-authored provenance; a
+    // prior learned value (if superseded) is retained in `priorVersion`.
+    provenanceClass: 'human_authored',
+    governed: true,
+    learned: true,
+    matchRule: false,
+    receipt: UNSIGNED,
+    note: input.note,
+  };
+}
+
+/**
+ * Promote a learned annotation concept into a versioned dictionary term. Emits a
+ * Dictionary-shaped draft (mirroring the KE contract) plus the authorship event.
+ * The dictionary is a governed + learned + versioned term set, NOT a match rule.
+ */
+export function promoteConceptToDictionaryTerm(
+  concept: string,
+  kind: AnnotationKind,
+  mappedType: string,
+  input: AuthorInput,
+): { event: AuthorshipEvent; draft: Dictionary } {
+  const event = buildAuthorshipEvent('add', 'dictionary_term', concept, kind, input, mappedType);
+  const draft: Dictionary = {
+    name: `${concept} (authored)`,
+    terms: 1,
+    mappedType,
+    source: `reasoning-chain-inspector · ${input.author}`,
+    licence: 'owned',
+  };
+  return { event, draft };
+}
+
+/** Define a new entity type from an annotation (KE Assets → Entity Types). */
+export function defineEntityType(concept: string, kind: AnnotationKind, input: AuthorInput): { event: AuthorshipEvent; draft: EntityType } {
+  const event = buildAuthorshipEvent('define', 'entity_type', concept, kind, input);
+  const draft: EntityType = { name: concept, color: 'var(--accent)', mentions: 0, f1: null, valueKind: 'derived', roles: '' };
+  return { event, draft };
+}
+
+/** Define a new relation type from an annotation (KE Assets → Relation Types). */
+export function defineRelationType(concept: string, kind: AnnotationKind, subject: string, object: string, input: AuthorInput): { event: AuthorshipEvent; draft: RelationType } {
+  const event = buildAuthorshipEvent('define', 'relation_type', concept, kind, input);
+  const draft: RelationType = { name: concept, subject, object, instances: 0, f1: null };
+  return { event, draft };
+}
+
+/**
+ * Overwrite a learned concept label with a human-authored value. The learned
+ * value is retained as a prior version and the new event supersedes it.
+ */
+export function overrideConcept(
+  concept: string,
+  kind: AnnotationKind,
+  learnedPrior: string,
+  input: Omit<AuthorInput, 'prior'>,
+): AuthorshipEvent {
+  return buildAuthorshipEvent('overwrite', 'dictionary_term', concept, kind, {
+    ...input,
+    prior: { value: learnedPrior, provenanceClass: 'learned', version: 'learned-v0' },
+  });
+}
+
+/** In-memory authorship ledger for the inspector (surfaced in the UI). */
+export interface AuthorshipLedger {
+  events: Ref<AuthorshipEvent[]>;
+  record: (e: AuthorshipEvent) => void;
+  clear: () => void;
+}
+export function useAuthorshipLedger(): AuthorshipLedger {
+  const events = ref<AuthorshipEvent[]>([]);
+  return {
+    events,
+    record: (e) => { events.value = [e, ...events.value]; },
+    clear: () => { events.value = []; },
+  };
+}

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/kindVocabulary.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/kindVocabulary.ts
@@ -1,0 +1,120 @@
+// Governed semantic-role KIND vocabulary for the Reasoning Chain Inspector.
+//
+// The annotation layer is bound to the ESTATE's governed topic model, not to
+// hard-coded strings:
+//   - The closed set of KINDs is the Regis NLU Semantic Role Kind taxonomy
+//     (regis-entity-graph#22, schemas/nlu/semantic-role-kind.schema.json).
+//     Only the KIND is a closed vocabulary.
+//   - The role LABEL (:ActionShow, :ContactLists, :Organization…) is an OPEN,
+//     LEARNED vocabulary per the estate rule "learn, don't match dictionaries".
+//     This module governs how a learned label is TYPED, never which labels exist.
+//   - Entity/relation type labels resolve against the KE registries
+//     (regis NER entity-class + Knowledge Studio entity/relation types); see
+//     keAuthorship.ts for the authorship round-trip.
+//
+// The source component keyed color/label off a private CAT token map. Here the
+// color + display label are sourced from the KIND set, so the annotation and
+// concept-graph layers are bound to the governed vocabulary/topic model.
+
+/** Closed set — mirror of regis-entity-graph#22 SemanticRoleKind.$defs enum. */
+export const SEMANTIC_ROLE_KINDS = [
+  'ACTION',
+  'ENTITY_TYPE',
+  'RELATION',
+  'QUANTIFIER',
+  'POSSESSION',
+  'MODIFIER',
+  'CONTEXT',
+] as const;
+export type SemanticRoleKind = (typeof SEMANTIC_ROLE_KINDS)[number];
+
+// Two governance markers that are NOT semantic-role KINDs but must be rendered:
+//   DECLARED_UNRESOLVED — a parse concept the ontology cannot yet bind to a
+//     primitive (the "gap" the owner cares about; declared, never silently dropped).
+//   UNTYPED — a token carrying no resolved concept.
+export type AnnotationKind = SemanticRoleKind | 'DECLARED_UNRESOLVED' | 'UNTYPED';
+
+/** The source component's per-token category tokens (faithful port surface). */
+export type SourceCat = 'action' | 'entity' | 'relation' | 'modifier' | 'temporal' | 'gap' | 'neutral';
+
+/**
+ * Base CAT → governed KIND map (the point of the estate alignment):
+ *   action→ACTION, entity→ENTITY_TYPE, relation→RELATION,
+ *   modifier→MODIFIER (refined to QUANTIFIER for quantity terms below),
+ *   temporal→CONTEXT, gap→DECLARED_UNRESOLVED, neutral→UNTYPED.
+ */
+export const CAT_TO_KIND: Record<SourceCat, AnnotationKind> = {
+  action: 'ACTION',
+  entity: 'ENTITY_TYPE',
+  relation: 'RELATION',
+  modifier: 'MODIFIER',
+  temporal: 'CONTEXT',
+  gap: 'DECLARED_UNRESOLVED',
+  neutral: 'UNTYPED',
+};
+
+// Controlled-vocabulary refinements that use the FULL governed KIND set beyond a
+// 1:1 CAT map — quantity terms type as QUANTIFIER, ownership terms as POSSESSION.
+// These are learned-label → KIND typings, not a match dictionary: the label set
+// is illustrative and the resolver, not this table, decides membership at runtime.
+const QUANTIFIER_LABELS = new Set([':Count', ':All', ':Some', ':Number', ':HowMany']);
+const POSSESSION_LABELS = new Set([':Own', ':My', ':BelongsTo', ':Mine']);
+
+/** Type a learned concept label into the governed KIND, applying refinements. */
+export function kindForConcept(cat: SourceCat, label: string): AnnotationKind {
+  if (QUANTIFIER_LABELS.has(label)) return 'QUANTIFIER';
+  if (POSSESSION_LABELS.has(label)) return 'POSSESSION';
+  return CAT_TO_KIND[cat];
+}
+
+export interface KindPalette {
+  bg: string;
+  text: string;
+  ring: string;
+}
+export interface KindMeta {
+  /** Human label shown in the legend / tag KIND chip. */
+  label: string;
+  /** Short governed-vocabulary description (tooltip). */
+  gloss: string;
+  palette: KindPalette;
+}
+
+// Palette provenance: the exact tokens from the source component, re-attached to
+// the governed KIND they map to (visual fidelity preserved; binding governed).
+// QUANTIFIER shares the MODIFIER family and POSSESSION the RELATION family so the
+// refined typings do not change the rendered color, only the governed KIND label.
+const P = {
+  action: { bg: '#F3B27A', text: '#6B3D0F', ring: '#D98A3D' },
+  entity: { bg: '#A9CFB0', text: '#1F5C38', ring: '#4C8A62' },
+  relation: { bg: '#A7C2E0', text: '#1B4A73', ring: '#5C8AC0' },
+  modifier: { bg: '#DDB3D0', text: '#6B2A5C', ring: '#B36A9E' },
+  temporal: { bg: '#DFCB93', text: '#5C4A12', ring: '#B99A45' },
+  gap: { bg: '#D98267', text: '#FFFFFF', ring: '#B8563B' },
+  neutral: { bg: '#E7E5DF', text: '#4A4640', ring: '#B8B3A8' },
+} as const;
+
+export const KIND_META: Record<AnnotationKind, KindMeta> = {
+  ACTION: { label: 'Action', gloss: 'Verb frame / operation the utterance requests.', palette: P.action },
+  ENTITY_TYPE: { label: 'Entity type', gloss: 'A type/class of thing being referenced.', palette: P.entity },
+  RELATION: { label: 'Relation', gloss: 'A relation between references.', palette: P.relation },
+  QUANTIFIER: { label: 'Quantifier', gloss: 'Scope/quantity over a reference.', palette: P.modifier },
+  POSSESSION: { label: 'Possession', gloss: 'Ownership / attribution.', palette: P.relation },
+  MODIFIER: { label: 'Modifier', gloss: 'A qualifying attribute.', palette: P.modifier },
+  CONTEXT: { label: 'Context', gloss: 'A scope/sensitivity cue on the information structure.', palette: P.temporal },
+  DECLARED_UNRESOLVED: { label: 'Declared-unresolved', gloss: 'A parse concept the ontology cannot yet bind — declared, never silently dropped.', palette: P.gap },
+  UNTYPED: { label: 'Untyped', gloss: 'No resolved concept on this token.', palette: P.neutral },
+};
+
+export function paletteForConcept(cat: SourceCat, label: string): KindPalette {
+  return KIND_META[kindForConcept(cat, label)].palette;
+}
+
+// Provenance class shown on every concept tag: a learned label vs a
+// human-authored override. Human overrides supersede the learned value; the
+// prior is retained as a version (see keAuthorship.ts).
+export type ProvenanceClass = 'learned' | 'human_authored';
+export const PROVENANCE_META: Record<ProvenanceClass, { glyph: string; label: string }> = {
+  learned: { glyph: '◐', label: 'learned' },
+  human_authored: { glyph: '✎', label: 'human-authored' },
+};

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/scoreVariants.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/scoreVariants.ts
@@ -1,0 +1,269 @@
+// Governed variant scorer — the owner's dilution-risk fix, with teeth.
+//
+// The parse produces many candidate plan variants; a naive "coverage" score
+// leaves plan-equivalent variants tied, so selection falls to tie-break order
+// (scorer noise) rather than signal. This module encodes four governance rules:
+//
+//  (1) Collapse plan-equivalent variants (same output/scope → one node) BEFORE
+//      scoring. The canonical form of a collapsed node is the ontology default
+//      (declaredCanonicalPath / canonicalExecutor), never the most frequent shape.
+//  (2) Coverage is normalized per primitive-hop, plus an explicit PARSIMONY term
+//      that penalizes redundant hops (a hop that re-covers an already-covered
+//      concept, or re-asserts ambient/default scope).
+//  (3) Epsilon tie-break is resolved by the DECLARED canonical path, never by
+//      raw scorer float noise.
+//  (4) precisionAt1() checks the top-1 selection against a logged-question fixture
+//      set — the counter-test gate. Maps to the estate's min-n>=30 + Goodhart
+//      guards (GKN#9): the seed fixture set here is a gate stub; the corpus must
+//      grow to n>=30 before any precision@1 claim is made (tracked follow-up).
+//
+// This is the annotation→concept-graph→plan derivation's scoring stage: it maps
+// the token-tree→KG (regis NLU semantic-role head + span-alignment #27 + HellGraph)
+// candidate plans down to a governed, defensible top-1.
+
+export interface ChainStep {
+  /** Learned concept label, e.g. ':ContactLists' or 'ContactLists'. */
+  concept: string;
+  /** Bound primitive/executor, e.g. 'engage:GetContactLists'. */
+  executor: string;
+  /** Parse-derived hop weight, retained for provenance/display. */
+  weight: number;
+  /** Source CAT token (action/entity/relation/…). */
+  cat: string;
+}
+
+export interface RawVariant {
+  id?: string;
+  text: string;
+  chain: ChainStep[];
+  /** The parse scorer's own score, kept for faithful display alongside governed. */
+  parseScore?: string;
+}
+
+export interface ScoringOntology {
+  /** Core deliverable concepts — the coverage numerator target. */
+  requestedCore: string[];
+  /** Default-scope concepts; an explicit hop to one is a redundant (prunable) hop. */
+  ambient: string[];
+  /** Ontology-declared canonical concept order — canonical form + tie-break authority. */
+  declaredCanonicalPath: string[];
+  /** Ontology-default executor per concept (canonical form, NOT frequency-derived). */
+  canonicalExecutor?: Record<string, string>;
+  /** Per-redundant-hop parsimony penalty (default 0.15). */
+  parsimonyLambda?: number;
+}
+
+export interface ScoredVariant {
+  /** Canonical scope signature — the collapsed-group id. */
+  key: string;
+  /** Canonical member text. */
+  text: string;
+  coverage: number;
+  redundantHops: number;
+  /** clamp(coverage - lambda*redundantHops, 0, 1). */
+  score: number;
+  canonicalChain: ChainStep[];
+  /** How many raw variants collapsed into this node. */
+  collapsedFrom: number;
+  /** Executors pruned as redundant/ambient during canonicalization. */
+  prunedExecutors: string[];
+  note?: string;
+}
+
+export interface ScoreResult {
+  ranked: ScoredVariant[];
+  top: ScoredVariant | null;
+  /** top1.score - top2.score, after dedup + parsimony. */
+  margin: number;
+  /** Best-minus-next WITHOUT dedup/parsimony — exposes the raw tie. */
+  rawMargin: number;
+  collapsedFrom: number;
+  collapsedTo: number;
+}
+
+const EPS = 1e-9;
+const DEFAULT_LAMBDA = 0.15;
+
+const clamp01 = (n: number): number => Math.max(0, Math.min(1, n));
+const isAction = (h: ChainStep): boolean => h.cat === 'action';
+
+/**
+ * Prune hops that only re-assert ambient/default scope, UNLESS pruning would
+ * remove the sole entity hop (then the ambient concept IS the requested output).
+ */
+function pruneChain(chain: ChainStep[], ont: ScoringOntology): { pruned: ChainStep[]; prunedOut: ChainStep[] } {
+  const ambient = new Set(ont.ambient);
+  const nonAmbientEntity = chain.filter((h) => !isAction(h) && !ambient.has(h.concept));
+  const pruned: ChainStep[] = [];
+  const prunedOut: ChainStep[] = [];
+  for (const h of chain) {
+    if (!isAction(h) && ambient.has(h.concept) && nonAmbientEntity.length > 0) prunedOut.push(h);
+    else pruned.push(h);
+  }
+  return { pruned, prunedOut };
+}
+
+/** Coverage (per requestedCore concept) + count of redundant hops. */
+function coverageAndParsimony(chain: ChainStep[], ont: ScoringOntology): { coverage: number; redundant: number } {
+  const core = new Set(ont.requestedCore);
+  const covered = new Set<string>();
+  let redundant = 0;
+  for (const h of chain) {
+    if (core.has(h.concept) && !covered.has(h.concept)) covered.add(h.concept);
+    else redundant++;
+  }
+  const coverage = core.size === 0 ? 0 : covered.size / core.size;
+  return { coverage, redundant };
+}
+
+/**
+ * Score a single literal chain (coverage - lambda*redundant), WITHOUT dedup or
+ * pruning. Used to demonstrate that parsimony alone penalizes a redundant hop:
+ * a longer chain carrying a redundant hop scores strictly below the shorter one.
+ */
+export function scoreChain(chainSteps: ChainStep[], ont: ScoringOntology): { coverage: number; redundant: number; score: number } {
+  const { coverage, redundant } = coverageAndParsimony(chainSteps, ont);
+  const lambda = ont.parsimonyLambda ?? DEFAULT_LAMBDA;
+  return { coverage: +coverage.toFixed(4), redundant, score: +clamp01(coverage - lambda * redundant).toFixed(4) };
+}
+
+/** Scope signature of a pruned chain — the collapse key (executor set, ordered). */
+function signature(pruned: ChainStep[]): string {
+  return Array.from(new Set(pruned.map((h) => h.executor))).sort().join('|');
+}
+
+/** Declared-canonical rank of a signature's earliest concept (lower = earlier). */
+function declaredRank(chain: ChainStep[], ont: ScoringOntology): number {
+  let best = Number.POSITIVE_INFINITY;
+  for (const h of chain) {
+    const i = ont.declaredCanonicalPath.indexOf(h.concept);
+    if (i >= 0 && i < best) best = i;
+  }
+  return best;
+}
+
+/**
+ * Rank raw variants by coverage only — NO dedup, NO parsimony. Exposes the tie
+ * the governed scorer resolves (raw top-1 margin is 0 when plan-equivalent
+ * variants share coverage).
+ */
+export function rawRank(variants: RawVariant[], ont: ScoringOntology): { coverage: number; text: string }[] {
+  return variants
+    .map((v) => ({ coverage: coverageAndParsimony(v.chain, ont).coverage, text: v.text }))
+    .sort((a, b) => b.coverage - a.coverage);
+}
+
+/** Best-minus-next coverage without dedup/parsimony. */
+export function rawMargin(variants: RawVariant[], ont: ScoringOntology): number {
+  const r = rawRank(variants, ont);
+  if (r.length < 2) return r.length === 1 ? r[0].coverage : 0;
+  return +(r[0].coverage - r[1].coverage).toFixed(6);
+}
+
+/** The governed scorer: dedup → parsimony → declared-path tie-break. */
+export function scoreVariants(variants: RawVariant[], ont: ScoringOntology): ScoreResult {
+  const lambda = ont.parsimonyLambda ?? DEFAULT_LAMBDA;
+
+  // (1) collapse plan-equivalent variants by pruned scope signature.
+  const groups = new Map<string, { members: RawVariant[]; pruned: ChainStep[][]; prunedOut: ChainStep[][] }>();
+  for (const v of variants) {
+    const { pruned, prunedOut } = pruneChain(v.chain, ont);
+    const key = signature(pruned);
+    const g = groups.get(key) ?? { members: [], pruned: [], prunedOut: [] };
+    g.members.push(v);
+    g.pruned.push(pruned);
+    g.prunedOut.push(prunedOut);
+    groups.set(key, g);
+  }
+
+  const scored: ScoredVariant[] = [];
+  for (const [key, g] of groups) {
+    // Canonical member = fewest ORIGINAL hops (parsimony); canonical form from
+    // ontology default, not frequency.
+    let ci = 0;
+    for (let i = 1; i < g.members.length; i++) {
+      if (g.members[i].chain.length < g.members[ci].chain.length) ci = i;
+    }
+    let canonicalChain = g.pruned[ci];
+    if (ont.canonicalExecutor) {
+      // Rebuild in declared-path order using ontology-default executors where declared.
+      const seen = new Set<string>();
+      const rebuilt: ChainStep[] = [];
+      for (const h of canonicalChain) {
+        if (seen.has(h.concept)) continue;
+        seen.add(h.concept);
+        const declared = ont.canonicalExecutor[h.concept];
+        rebuilt.push(declared ? { ...h, executor: declared } : h);
+      }
+      canonicalChain = rebuilt;
+    }
+    const { coverage, redundant } = coverageAndParsimony(canonicalChain, ont);
+    const score = clamp01(coverage - lambda * redundant);
+    const prunedExecutors = Array.from(new Set(g.prunedOut.flat().map((h) => h.executor)));
+    let note: string | undefined;
+    if (prunedExecutors.length) note = `canonical — redundant ${prunedExecutors.join(', ')} hop pruned`;
+    if (score < 0.15) note = 'flagged for pattern-catalog review';
+    scored.push({
+      key,
+      text: g.members[ci].text,
+      coverage: +coverage.toFixed(4),
+      redundantHops: redundant,
+      score: +score.toFixed(4),
+      canonicalChain,
+      collapsedFrom: g.members.length,
+      prunedExecutors,
+      note,
+    });
+  }
+
+  // (2)/(3) rank by score; epsilon ties broken by DECLARED canonical path, never noise.
+  scored.sort((a, b) => {
+    if (Math.abs(a.score - b.score) > EPS) return b.score - a.score;
+    return declaredRank(a.canonicalChain, ont) - declaredRank(b.canonicalChain, ont);
+  });
+
+  const top = scored[0] ?? null;
+  const margin = scored.length >= 2 ? +(scored[0].score - scored[1].score).toFixed(6) : top ? top.score : 0;
+  return {
+    ranked: scored,
+    top,
+    margin,
+    rawMargin: rawMargin(variants, ont),
+    collapsedFrom: variants.length,
+    collapsedTo: scored.length,
+  };
+}
+
+// ---- (4) precision@1 counter-test gate ----
+
+export interface LoggedQuestion {
+  id: string;
+  question: string;
+  variants: RawVariant[];
+  ontology: ScoringOntology;
+  /** The canonical scope signature the governed scorer must select as top-1. */
+  goldKey: string;
+}
+
+export interface PrecisionResult {
+  n: number;
+  correct: number;
+  precisionAt1: number;
+  misses: string[];
+  /** True only once the corpus meets the estate min-n>=30 bar (GKN#9). */
+  meetsMinN: boolean;
+}
+
+export const MIN_N = 30;
+
+export function precisionAt1(fixtures: LoggedQuestion[]): PrecisionResult {
+  let correct = 0;
+  const misses: string[] = [];
+  for (const f of fixtures) {
+    const top = scoreVariants(f.variants, f.ontology).top;
+    if (top && top.key === f.goldKey) correct++;
+    else misses.push(f.id);
+  }
+  const n = fixtures.length;
+  return { n, correct, precisionAt1: n === 0 ? 0 : +(correct / n).toFixed(4), misses, meetsMinN: n >= MIN_N };
+}

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -36,6 +36,7 @@ import PeopleDirectory from './pages/PeopleDirectory.vue';
 import SocialSignals from './pages/SocialSignals.vue';
 import LawDocket from './pages/LawDocket.vue';
 import NoeticaChat from './pages/NoeticaChat.vue';
+import ReasoningChainInspector from './pages/ReasoningChainInspector.vue';
 import WeatherMonitor from './pages/WeatherMonitor.vue';
 import ControlPlaneLifecycle from './pages/ControlPlaneLifecycle.vue';
 import NoeticaControlPlane from './pages/NoeticaControlPlane.vue';
@@ -172,6 +173,7 @@ const explicitRoutes = [
   { path: '/people/social-networks', component: SocialSignals },
   { path: '/law/international-law', component: LawDocket },
   { path: '/noetica', component: NoeticaChat },
+  { path: '/noetica/reasoning-chain', component: ReasoningChainInspector },
   { path: '/weather/forecast', component: WeatherMonitor },
 ];
 

--- a/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
+++ b/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
@@ -1,0 +1,441 @@
+<script setup lang="ts">
+// Reasoning Chain Inspector — makes a conversation chain's reasoning legible in
+// four stages: Annotation → Concepts → Variants → Execution. Port of the
+// reference React component, aligned to the estate:
+//   - the annotation layer is bound to the governed semantic-role KIND vocabulary
+//     (regis-entity-graph#22) + the KE type/dictionary registries, not hard-coded
+//     strings (see features/reasoning-chain/kindVocabulary.ts);
+//   - candidate plans are ranked by the GOVERNED variant scorer with teeth
+//     (dedup + parsimony + declared-path tie-break; features/.../scoreVariants.ts);
+//   - annotations are AUTHORABLE: add/overwrite/define/promote emit governed,
+//     versioned, receipted authorship events into the KE loop (keAuthorship.ts).
+//
+// The annotation→concept-graph derivation IS the token-tree→KG: regis NLU
+// semantic-role head + span-alignment (regis-entity-graph#27) + HellGraph. This
+// surface augments the graph dock + reasoning trace per conversation chain
+// (cockpit context is set so the global Graph dock reflects the active example).
+import { computed, onMounted, ref, watch } from 'vue';
+import SurfaceHeader from '../components/SurfaceHeader.vue';
+import BoundaryNotice from '../components/BoundaryNotice.vue';
+import { useCockpit } from '../stores/cockpit';
+import { useAuth } from '../stores/auth';
+import { EXAMPLES, type Example, type Token, type TokenConcept } from '../features/reasoning-chain/examples';
+import {
+  KIND_META, PROVENANCE_META, kindForConcept, paletteForConcept,
+  type AnnotationKind, type ProvenanceClass,
+} from '../features/reasoning-chain/kindVocabulary';
+import { scoreVariants, type ScoredVariant } from '../features/reasoning-chain/scoreVariants';
+import {
+  useAuthorshipLedger, promoteConceptToDictionaryTerm, defineEntityType,
+  defineRelationType, overrideConcept, type AuthorshipEvent,
+} from '../features/reasoning-chain/keAuthorship';
+
+const cockpit = useCockpit();
+const auth = useAuth();
+const author = computed(() => auth.user?.email ?? 'operator');
+
+type StageKey = 'annotation' | 'concepts' | 'variants' | 'execution';
+const STAGES: { key: StageKey; label: string }[] = [
+  { key: 'annotation', label: '1 · Annotation' },
+  { key: 'concepts', label: '2 · Concepts' },
+  { key: 'variants', label: '3 · Variants' },
+  { key: 'execution', label: '4 · Execution' },
+];
+
+const exampleId = ref('A');
+const stage = ref<StageKey>('annotation');
+const example = computed<Example>(() => EXAMPLES.find((e) => e.id === exampleId.value) ?? EXAMPLES[0]);
+const mode = ref(example.value.modes[0].key);
+watch(example, (e) => { mode.value = e.modes[0].key; });
+
+// ---- authorship (human overrides supersede learned; prior retained) ----
+const ledger = useAuthorshipLedger();
+// Human overrides recorded this session, keyed by concept label.
+const overrides = ref<Record<string, string>>({});
+const selectedConcept = ref<{ label: string; kind: AnnotationKind } | null>(null);
+
+function provenanceOf(concept: TokenConcept): ProvenanceClass {
+  if (overrides.value[concept.l]) return 'human_authored';
+  return concept.provenance ?? 'learned';
+}
+function kindOf(concept: TokenConcept): AnnotationKind {
+  return kindForConcept(concept.c, concept.l);
+}
+function selectConcept(concept: TokenConcept) {
+  selectedConcept.value = { label: concept.l, kind: kindOf(concept) };
+}
+function record(e: AuthorshipEvent) {
+  ledger.record(e);
+  if (e.action === 'overwrite') overrides.value = { ...overrides.value, [e.term]: e.version };
+}
+function onPromote() {
+  const s = selectedConcept.value; if (!s) return;
+  record(promoteConceptToDictionaryTerm(s.label, s.kind, KIND_META[s.kind].label, { author: author.value }).event);
+}
+function onDefineType() {
+  const s = selectedConcept.value; if (!s) return;
+  const rel = s.kind === 'RELATION' || s.kind === 'POSSESSION';
+  const built = rel
+    ? defineRelationType(s.label, s.kind, 'SUBJECT', 'OBJECT', { author: author.value })
+    : defineEntityType(s.label, s.kind, { author: author.value });
+  record(built.event);
+}
+function onOverride() {
+  const s = selectedConcept.value; if (!s) return;
+  record(overrideConcept(s.label, s.kind, s.label, { author: author.value, note: 'human override of learned label' }));
+}
+
+// ---- governed scoring ----
+const variants = computed(() => example.value.variants[mode.value] ?? []);
+const scoring = computed(() => example.value.scoring[mode.value]);
+const scoreResult = computed(() => scoreVariants(variants.value, scoring.value));
+const rankedVariants = computed<ScoredVariant[]>(() => scoreResult.value.ranked);
+const executionOutcome = computed(() => example.value.execution[mode.value]);
+// The dedup story is meaningful when the raw scorer left a tie (example A).
+const showsDedup = computed(() => scoreResult.value.rawMargin === 0 && scoreResult.value.collapsedTo < scoreResult.value.collapsedFrom);
+
+// ---- concept-graph layout (token depth-grid + parent edges + concept satellites) ----
+interface GNode { i: number; x: number; y: number; token: Token }
+const graphNodes = computed<GNode[]>(() => {
+  const toks = example.value.tokens;
+  const n = toks.length;
+  const maxDepth = Math.max(1, ...toks.map((t) => t.depth));
+  return toks.map((t, i) => ({
+    i,
+    x: 12 + (t.depth / maxDepth) * 60,
+    y: n <= 1 ? 50 : 7 + (i * 86) / (n - 1),
+    token: t,
+  }));
+});
+const graphEdges = computed(() =>
+  graphNodes.value
+    .filter((g) => g.token.parent != null)
+    .map((g) => ({ a: g, b: graphNodes.value[g.token.parent as number] }))
+    .filter((e) => !!e.b),
+);
+interface Satellite { key: string; tx: number; ty: number; cx: number; cy: number; fill: string; ring: string; label: string; kind: AnnotationKind }
+const satellites = computed<Satellite[]>(() => {
+  const out: Satellite[] = [];
+  for (const g of graphNodes.value) {
+    g.token.concepts.forEach((c, ci) => {
+      const pal = paletteForConcept(c.c, c.l);
+      out.push({
+        key: `${g.i}-${ci}`,
+        tx: g.x, ty: g.y,
+        cx: Math.min(96, g.x + 14),
+        cy: Math.max(3, Math.min(97, g.y + (ci - (g.token.concepts.length - 1) / 2) * 5)),
+        fill: pal.bg, ring: pal.ring, label: c.l, kind: kindForConcept(c.c, c.l),
+      });
+    });
+  }
+  return out;
+});
+
+// Legend: only the KINDs actually present in this example (bound to vocabulary).
+const legendKinds = computed<AnnotationKind[]>(() => {
+  const set = new Set<AnnotationKind>();
+  for (const t of example.value.tokens) for (const c of t.concepts) set.add(kindForConcept(c.c, c.l));
+  return Array.from(set);
+});
+
+function setCockpitContext() {
+  cockpit.setContext({
+    surface: 'Reasoning Chain Inspector',
+    entityLabel: `Example ${example.value.id} · ${example.value.label}`,
+    detail: example.value.question,
+    route: '/noetica/reasoning-chain',
+  });
+}
+onMounted(setCockpitContext);
+watch([example, mode], setCockpitContext);
+</script>
+
+<template>
+  <section class="rci" aria-labelledby="rci-title">
+    <SurfaceHeader title="Reasoning Chain Inspector" eyebrow="Noetica · reasoning trace · governed vocabulary">
+      <template #badge>
+        <span class="rci-badge">L2</span>
+        <span class="rci-badge rci-badge--fixture">seed fixtures</span>
+      </template>
+    </SurfaceHeader>
+
+    <p id="rci-title" class="rci-lede">
+      Four stages make a conversation chain legible: <b>Annotation</b> (dep + governed semantic-role KIND),
+      <b>Concepts</b> (the token-tree → knowledge graph), <b>Variants</b> (candidate plans, ranked by the governed
+      scorer), and <b>Execution</b> (resolved vs a declared gap). The annotation → concept-graph derivation is the
+      token-tree → KG: regis NLU semantic-role head + span-alignment (#27) + HellGraph.
+    </p>
+
+    <BoundaryNotice
+      label="fixture · seed conversation chains"
+      tone="muted"
+      message="Fixture-backed over three seed conversation chains; live conversation-chain binding is a tracked follow-up. KINDs are bound to regis-entity-graph#22; authorship events are held in an in-memory ledger (unsigned) — the durable KE-workbench contract seals them."
+      aria-label="Reasoning Chain Inspector boundary"
+    />
+
+    <!-- example selector + question card -->
+    <div class="rci-picker" role="tablist" aria-label="Example">
+      <button
+        v-for="e in EXAMPLES" :key="e.id" type="button" class="rci-pill"
+        :class="{ on: exampleId === e.id }" role="tab" :aria-selected="exampleId === e.id"
+        @click="exampleId = e.id"
+      >{{ e.id }} · {{ e.label }}</button>
+    </div>
+
+    <div class="rci-q">
+      <span class="rci-q-k">question</span>
+      <span class="rci-q-text mono">"{{ example.question }}"</span>
+      <div class="rci-modes">
+        <button
+          v-for="m in example.modes" :key="m.key" type="button" class="rci-mode"
+          :class="{ on: mode === m.key }" @click="mode = m.key"
+        >{{ m.label }}</button>
+      </div>
+    </div>
+
+    <!-- stage tabs -->
+    <nav class="rci-stages" aria-label="Stages">
+      <button
+        v-for="s in STAGES" :key="s.key" type="button" class="rci-stage"
+        :class="{ on: stage === s.key }" @click="stage = s.key"
+      >{{ s.label }}</button>
+    </nav>
+
+    <div class="rci-body">
+      <!-- STAGE 1 · ANNOTATION -->
+      <div v-if="stage === 'annotation'" class="rci-annot">
+        <ol class="rci-tree">
+          <li
+            v-for="(t, i) in example.tokens" :key="i" class="rci-tok"
+            :style="{ paddingLeft: `${t.depth * 1.4 + 0.2}rem` }"
+          >
+            <span class="rci-tok-word">{{ t.text }}</span>
+            <span class="rci-tok-pos mono">{{ t.pos }}</span>
+            <span class="rci-tok-dep">{{ t.dep }}</span>
+            <span
+              v-for="(c, ci) in t.concepts" :key="ci" class="rci-tag"
+              :class="{ sel: selectedConcept?.label === c.l }"
+              :style="{ background: paletteForConcept(c.c, c.l).bg, color: paletteForConcept(c.c, c.l).text, boxShadow: `inset 0 0 0 1px ${paletteForConcept(c.c, c.l).ring}` }"
+              :title="`${KIND_META[kindOf(c)].label} — ${KIND_META[kindOf(c)].gloss} · ${PROVENANCE_META[provenanceOf(c)].label}`"
+              @click="selectConcept(c)"
+            >
+              <span class="rci-tag-prov" aria-hidden="true">{{ PROVENANCE_META[provenanceOf(c)].glyph }}</span>
+              {{ c.l }}
+              <span class="rci-tag-kind">{{ kindOf(c) }}</span>
+            </span>
+            <span v-if="!t.concepts.length" class="rci-tag rci-tag--untyped" title="Untyped — no resolved concept">untyped</span>
+          </li>
+        </ol>
+
+        <!-- authoring affordance: add / overwrite / define / promote -->
+        <aside class="rci-author" aria-label="Knowledge-engineering authoring">
+          <div class="rci-author-h">Author into the KE loop</div>
+          <p class="rci-author-hint">
+            Select a concept tag, then author it. Terms are learned + <b>versioned</b> (never a match rule); a human
+            override supersedes the learned value and keeps the prior as a version. Events are receipted (unsigned
+            until the KE workbench seals them).
+          </p>
+          <div v-if="selectedConcept" class="rci-author-sel">
+            selected <b class="mono">{{ selectedConcept.label }}</b>
+            <span class="rci-tag-kind">{{ selectedConcept.kind }}</span>
+          </div>
+          <div v-else class="rci-author-sel rci-dim">no concept selected</div>
+          <div class="rci-author-btns">
+            <button type="button" :disabled="!selectedConcept" @click="onPromote">＋ Promote → dictionary term</button>
+            <button type="button" :disabled="!selectedConcept" @click="onDefineType">◆ Define type</button>
+            <button type="button" :disabled="!selectedConcept" @click="onOverride">✎ Overwrite (human)</button>
+          </div>
+
+          <div v-if="ledger.events.value.length" class="rci-ledger">
+            <div class="rci-ledger-h">Authorship ledger · governed &amp; versioned</div>
+            <ul>
+              <li v-for="ev in ledger.events.value" :key="ev.id">
+                <span class="rci-led-act">{{ ev.action }}</span>
+                <span class="mono">{{ ev.term }}</span>
+                <span class="rci-tag-kind">{{ ev.kind }}</span>
+                <span class="rci-led-v">{{ ev.version }}</span>
+                <span class="rci-led-prov">{{ PROVENANCE_META[ev.provenanceClass].glyph }} {{ PROVENANCE_META[ev.provenanceClass].label }}</span>
+                <span class="rci-led-rcpt">{{ ev.receipt }}</span>
+                <span v-if="ev.priorVersion" class="rci-led-prior">supersedes {{ ev.priorVersion.value }} ({{ ev.priorVersion.version }})</span>
+              </li>
+            </ul>
+          </div>
+        </aside>
+      </div>
+
+      <!-- STAGE 2 · CONCEPTS (token-tree → KG) -->
+      <div v-else-if="stage === 'concepts'" class="rci-graph-wrap">
+        <svg class="rci-graph" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Concept graph derived from the token tree">
+          <line v-for="(e, i) in graphEdges" :key="`pe${i}`" :x1="e.a.x" :y1="e.a.y" :x2="e.b.x" :y2="e.b.y" class="rci-edge" />
+          <line v-for="s in satellites" :key="`se${s.key}`" :x1="s.tx" :y1="s.ty" :x2="s.cx" :y2="s.cy" class="rci-cedge" :stroke="s.ring" />
+          <g v-for="g in graphNodes" :key="`tn${g.i}`">
+            <circle :cx="g.x" :cy="g.y" r="1.7" class="rci-tnode" />
+            <text :x="g.x" :y="g.y - 2.4" text-anchor="middle" class="rci-tlabel">{{ g.token.text }}</text>
+          </g>
+          <g v-for="s in satellites" :key="`sn${s.key}`">
+            <circle :cx="s.cx" :cy="s.cy" r="1.5" :fill="s.fill" :stroke="s.ring" stroke-width="0.4" />
+            <text :x="s.cx + 2.2" :y="s.cy + 0.8" class="rci-clabel">{{ s.label }}</text>
+          </g>
+        </svg>
+        <div class="rci-legend">
+          <span v-for="k in legendKinds" :key="k" class="rci-legend-item">
+            <i class="rci-sw" :style="{ background: KIND_META[k].palette.bg, boxShadow: `inset 0 0 0 1px ${KIND_META[k].palette.ring}` }" />
+            {{ KIND_META[k].label }} <span class="rci-dim">· {{ k }}</span>
+          </span>
+        </div>
+        <p class="rci-note">
+          Nodes are tokens on a dependency depth-grid; grey edges are parse dependencies, colored edges bind each
+          token to its learned concept, typed by governed KIND. This derivation is the token-tree → knowledge graph.
+        </p>
+      </div>
+
+      <!-- STAGE 3 · VARIANTS (governed scorer) -->
+      <div v-else-if="stage === 'variants'" class="rci-variants">
+        <div class="rci-score-ribbon" :class="{ warn: scoreResult.rawMargin === 0 }">
+          <span><b>Governed scorer</b> · dedup + parsimony + declared-path tie-break</span>
+          <span>raw top-1 margin <b :class="{ tie: scoreResult.rawMargin === 0 }">{{ scoreResult.rawMargin.toFixed(2) }}</b></span>
+          <span>→ governed margin <b class="clear">{{ scoreResult.margin.toFixed(2) }}</b></span>
+          <span v-if="showsDedup" class="rci-dim">collapsed {{ scoreResult.collapsedFrom }} → {{ scoreResult.collapsedTo }} plans</span>
+        </div>
+        <p v-if="showsDedup" class="rci-note">
+          The raw scorer left an exact tie (margin 0.00) — selection would depend on tie-break order, not signal.
+          After collapsing plan-equivalent variants and penalizing redundant hops, the top-1 separates cleanly.
+        </p>
+
+        <ol class="rci-vlist">
+          <li v-for="(v, i) in rankedVariants" :key="v.key" class="rci-variant" :class="{ top: i === 0 }">
+            <div class="rci-v-head">
+              <span v-if="i === 0" class="rci-v-top">top-1</span>
+              <span class="rci-v-text">{{ v.text }}</span>
+              <span class="rci-v-score" :title="`coverage ${v.coverage} · redundant hops ${v.redundantHops}`">{{ v.score.toFixed(2) }}</span>
+              <span v-if="v.collapsedFrom > 1" class="rci-v-collapsed">×{{ v.collapsedFrom }} collapsed</span>
+            </div>
+            <div class="rci-chain">
+              <span
+                v-for="(h, hi) in v.canonicalChain" :key="hi" class="rci-hop"
+                :style="{ background: paletteForConcept(h.cat as any, h.concept).bg, color: paletteForConcept(h.cat as any, h.concept).text }"
+              >
+                <b>{{ h.concept }}</b>
+                <small class="mono">{{ h.executor }} · {{ h.weight.toFixed(3) }}</small>
+              </span>
+            </div>
+            <div v-if="v.note" class="rci-v-note">{{ v.note }}</div>
+          </li>
+        </ol>
+      </div>
+
+      <!-- STAGE 4 · EXECUTION -->
+      <div v-else class="rci-exec" :class="executionOutcome.status">
+        <div class="rci-exec-status">
+          <span class="rci-exec-badge" :class="executionOutcome.status">
+            {{ executionOutcome.status === 'resolved' ? 'RESOLVED' : 'UNRESOLVED · declared gap' }}
+          </span>
+        </div>
+        <p class="rci-exec-note">{{ executionOutcome.note }}</p>
+        <blockquote class="rci-exec-resp" :class="{ gap: executionOutcome.status === 'gap' }">
+          "{{ executionOutcome.response }}"
+        </blockquote>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.rci { padding: 1.25rem 1.75rem 2.5rem; color: var(--text); max-width: 1080px; }
+.rci-badge { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid var(--line-2); border-radius: 999px; padding: 0.08rem 0.5rem; color: var(--text-2); }
+.rci-badge--fixture { color: var(--text-3); }
+.rci-lede { color: var(--text-2); font-size: 0.9rem; line-height: 1.5; max-width: 72ch; margin: 0.6rem 0 0.9rem; }
+.rci-lede b { color: var(--text); font-weight: 600; }
+.mono { font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace; }
+.rci-dim { color: var(--text-3); }
+
+.rci-picker { display: flex; gap: 0.5rem; margin: 1rem 0 0.75rem; flex-wrap: wrap; }
+.rci-pill, .rci-mode, .rci-stage { background: var(--surface); border: 1px solid var(--line); color: var(--text-2); border-radius: 8px; padding: 0.32rem 0.7rem; font-size: 0.82rem; cursor: pointer; transition: color 0.15s, border-color 0.15s, background 0.15s; }
+.rci-pill.on { color: var(--text); border-color: var(--accent); background: var(--accent-soft); }
+.rci-pill:hover, .rci-mode:hover, .rci-stage:hover { color: var(--text); }
+
+.rci-q { display: flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 0.7rem 0.9rem; }
+.rci-q-k { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); }
+.rci-q-text { font-size: 0.95rem; color: var(--text); }
+.rci-modes { margin-left: auto; display: flex; gap: 0.4rem; }
+.rci-mode.on { color: var(--text); border-color: var(--accent); }
+
+.rci-stages { display: flex; gap: 0.4rem; margin: 1rem 0 0.75rem; border-bottom: 1px solid var(--line); padding-bottom: 0.6rem; flex-wrap: wrap; }
+.rci-stage.on { color: var(--text); border-color: var(--accent); background: var(--accent-soft); }
+
+.rci-body { margin-top: 0.5rem; }
+
+/* Stage 1 */
+.rci-annot { display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(260px, 0.9fr); gap: 1.25rem; }
+@media (max-width: 860px) { .rci-annot { grid-template-columns: 1fr; } }
+.rci-tree { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.3rem; }
+.rci-tok { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; padding: 0.18rem 0; border-bottom: 1px dotted var(--line); }
+.rci-tok-word { font-weight: 600; color: var(--text); min-width: 3.5rem; }
+.rci-tok-pos { font-size: 0.68rem; color: var(--text-3); }
+.rci-tok-dep { font-size: 0.68rem; color: var(--text-2); background: var(--surface-2); border-radius: 5px; padding: 0.02rem 0.35rem; }
+.rci-tag { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.72rem; border-radius: 6px; padding: 0.08rem 0.45rem; cursor: pointer; font-weight: 600; }
+.rci-tag.sel { outline: 2px solid var(--accent); outline-offset: 1px; }
+.rci-tag--untyped { background: #e7e5df; color: #4a4640; font-weight: 500; }
+.rci-tag-prov { font-size: 0.72rem; opacity: 0.85; }
+.rci-tag-kind { font-size: 0.56rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.72; }
+
+.rci-author { background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 0.85rem; align-self: start; }
+.rci-author-h { font-weight: 700; font-size: 0.82rem; margin-bottom: 0.35rem; }
+.rci-author-hint { font-size: 0.72rem; color: var(--text-2); line-height: 1.45; margin: 0 0 0.6rem; }
+.rci-author-sel { font-size: 0.78rem; margin-bottom: 0.5rem; }
+.rci-author-btns { display: flex; flex-direction: column; gap: 0.4rem; }
+.rci-author-btns button { background: var(--surface-2); border: 1px solid var(--line-2); color: var(--text); border-radius: 7px; padding: 0.38rem 0.6rem; font-size: 0.78rem; cursor: pointer; text-align: left; }
+.rci-author-btns button:disabled { opacity: 0.4; cursor: not-allowed; }
+.rci-author-btns button:not(:disabled):hover { border-color: var(--accent); }
+.rci-ledger { margin-top: 0.8rem; border-top: 1px solid var(--line); padding-top: 0.6rem; }
+.rci-ledger-h { font-size: 0.66rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-3); margin-bottom: 0.4rem; }
+.rci-ledger ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.35rem; }
+.rci-ledger li { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; font-size: 0.7rem; color: var(--text-2); }
+.rci-led-act { text-transform: uppercase; font-weight: 700; font-size: 0.6rem; color: var(--accent); }
+.rci-led-v { color: var(--text-3); }
+.rci-led-prov { color: var(--text-2); }
+.rci-led-rcpt { color: var(--text-3); font-style: italic; }
+.rci-led-prior { color: var(--text-3); }
+
+/* Stage 2 */
+.rci-graph-wrap { display: flex; flex-direction: column; gap: 0.6rem; }
+.rci-graph { width: 100%; aspect-ratio: 16 / 9; background: var(--surface); border: 1px solid var(--line); border-radius: 10px; }
+.rci-edge { stroke: var(--line-2); stroke-width: 0.3; }
+.rci-cedge { stroke-width: 0.25; opacity: 0.7; }
+.rci-tnode { fill: var(--text-2); }
+.rci-tlabel { fill: var(--text); font-size: 2.1px; font-weight: 600; }
+.rci-clabel { fill: var(--text-2); font-size: 1.9px; }
+.rci-legend { display: flex; flex-wrap: wrap; gap: 0.9rem; font-size: 0.72rem; color: var(--text-2); }
+.rci-legend-item { display: inline-flex; align-items: center; gap: 0.35rem; }
+.rci-sw { width: 0.75rem; height: 0.75rem; border-radius: 3px; display: inline-block; }
+.rci-note { font-size: 0.74rem; color: var(--text-2); line-height: 1.45; max-width: 74ch; }
+
+/* Stage 3 */
+.rci-variants { display: flex; flex-direction: column; gap: 0.7rem; }
+.rci-score-ribbon { display: flex; flex-wrap: wrap; gap: 0.9rem; align-items: center; background: var(--surface); border: 1px solid var(--line); border-radius: 8px; padding: 0.55rem 0.8rem; font-size: 0.78rem; color: var(--text-2); }
+.rci-score-ribbon.warn { border-color: var(--amber, #d9a63a); }
+.rci-score-ribbon b { color: var(--text); }
+.rci-score-ribbon b.tie { color: #d9a63a; }
+.rci-score-ribbon b.clear { color: #22c55e; }
+.rci-vlist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+.rci-variant { background: var(--surface); border: 1px solid var(--line); border-radius: 9px; padding: 0.6rem 0.75rem; }
+.rci-variant.top { border-color: #22c55e; box-shadow: inset 3px 0 0 #22c55e; }
+.rci-v-head { display: flex; align-items: center; gap: 0.55rem; flex-wrap: wrap; }
+.rci-v-top { font-size: 0.6rem; font-weight: 700; text-transform: uppercase; color: #22c55e; border: 1px solid #22c55e; border-radius: 999px; padding: 0.02rem 0.4rem; }
+.rci-v-text { color: var(--text); font-size: 0.86rem; }
+.rci-v-score { margin-left: auto; font-weight: 700; font-size: 0.95rem; color: var(--text); }
+.rci-v-collapsed { font-size: 0.64rem; color: var(--text-3); }
+.rci-chain { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 0.5rem; }
+.rci-hop { display: inline-flex; flex-direction: column; border-radius: 6px; padding: 0.2rem 0.5rem; font-size: 0.74rem; }
+.rci-hop small { font-size: 0.6rem; opacity: 0.85; }
+.rci-v-note { margin-top: 0.45rem; font-size: 0.72rem; color: #d9a63a; }
+
+/* Stage 4 */
+.rci-exec { background: var(--surface); border: 1px solid var(--line); border-radius: 10px; padding: 1rem 1.1rem; }
+.rci-exec-badge { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; border-radius: 999px; padding: 0.2rem 0.7rem; }
+.rci-exec-badge.resolved { color: #22c55e; border: 1px solid #22c55e; }
+.rci-exec-badge.gap { color: #ef4444; border: 1px solid #ef4444; }
+.rci-exec-note { color: var(--text-2); font-size: 0.86rem; line-height: 1.5; margin: 0.7rem 0; max-width: 76ch; }
+.rci-exec-resp { border-left: 3px solid var(--line-2); margin: 0; padding: 0.3rem 0 0.3rem 0.8rem; color: var(--text); }
+.rci-exec-resp.gap { font-style: italic; color: var(--text-2); border-left-color: #ef4444; }
+</style>


### PR DESCRIPTION
## What changed
Ports the reference Reasoning Chain Inspector to a **Vue 3 SFC in client-vue** (the canonical app) and aligns it to the estate — not just a framework swap.

- **Faithful 4-stage port** (Annotation → Concepts → Variants → Execution) over the three seed conversation chains (A org-scoping, B best-mailings, C EMEA-rollup), with example (A/B/C) and per-example mode toggles. Same data, same stages as source.
- **Annotation bound to the governed semantic-role KIND vocabulary** (regis-entity-graph#22, `schemas/nlu/semantic-role-kind.schema.json`). CAT → KIND: `action→ACTION`, `entity→ENTITY_TYPE`, `relation→RELATION`, `modifier→MODIFIER` (refined to `QUANTIFIER` for quantity terms), `temporal→CONTEXT`, `gap→DECLARED_UNRESOLVED` (declared, never silently dropped), `neutral→UNTYPED`; `:Own`→`POSSESSION`. Colors/labels are sourced from the KIND set (`kindVocabulary.ts`), not hard-coded strings, so the annotation layer is bound to the topic model. The annotation→concept-graph derivation is noted in-surface as the token-tree→KG (regis NLU semantic-role head + span-alignment #27 + HellGraph).
- **Governed variant scorer with teeth** (`scoreVariants.ts`): (1) collapse plan-equivalent variants (same output/scope → one node) *before* scoring, canonical form from ontology default not frequency; (2) coverage normalized per primitive-hop + explicit parsimony penalty on redundant hops; (3) epsilon tie-break by the **declared** canonical path, never scorer noise; (4) `precisionAt1()` counter-test gate.
- **KE / dictionary-engineering authoring round-trip** (`keAuthorship.ts`): from the annotation view a user can add / overwrite / define / promote entity types, relation types and dictionary terms. Each action emits a **governed, versioned, author-attributed, receipted** event mirroring the live Knowledge Studio KE contract (`features/knowledge-studio/fixture.ts`). Honors *learn, don't match dictionaries* — a promoted term is a learned + versioned entry (`matchRule: false`), never a static lookup; a **human override supersedes** the learned value and the prior is retained as a version; the **provenance class** (learned vs human-authored) is shown on every concept tag and ledger row.
- **Child-route surface** `/noetica/reasoning-chain` (a tab of Noetica), augmenting the graph dock + reasoning trace per conversation chain via cockpit context. Carbon/tufte density, dark theme via the shell CSS variables.

## How CAT maps to the governed KINDs
| source CAT | governed KIND | note |
|---|---|---|
| action | `ACTION` | |
| entity | `ENTITY_TYPE` | |
| relation | `RELATION` | `:Own` refined to `POSSESSION` |
| modifier | `MODIFIER` | quantity terms (`:Count`…) refined to `QUANTIFIER` |
| temporal | `CONTEXT` | |
| gap | `DECLARED_UNRESOLVED` | governance marker (not a KIND) — declared, never dropped |
| neutral | `UNTYPED` | governance marker |

## Dedup/parsimony teeth result (the 0.75 tie → clear top-1)
Example A's raw scorer leaves an **exact tie** between the top two variants (margin **0.00** — selection would depend on tie-break order, not signal). Under the governed scorer the six raw variants **collapse to four** canonical plans; the top-1 "Show me contact lists." wins with the **redundant `engage:GetOrganization` hop pruned**, at governed margin **0.85 > 0**. Scored standalone with parsimony, the redundant longer chain (**0.85**) does **not** out-score the shorter correct one (**1.00**). `precision@1 = 1.0` on the seed logged-question set. Proven in `reasoningChainScorer.test.ts` (counter-test gate + Goodhart guard, GKN#9).

## Exact commands run (in `socioprophet-web/client-vue`)
- `npx vue-tsc --noEmit` → clean
- `npx vitest run` → **109 files / 583 tests pass** (17 new; 1 pre-existing benign `ECONNREFUSED` log from a network-fallback test, not a failure)
- `npm run build` → succeeds (pre-existing chunk-size warning only)

## Known gaps / follow-ups (@mdheller)
- **Live conversation-chain binding** — currently three seed fixtures; wire to the real Noetica conversation-chain store/prop.
- **Topic-model term source** — labels are seed fixtures; source learned labels from the live resolver / KE registries.
- **KE authoring durable round-trip** — events are held in an unsigned in-memory ledger; wire add/overwrite/define/promote to the **concurrent KE-workbench contract** (consume it, don't fork) so promotions become durable, sealed dictionary/type versions. Exact hooks: `keAuthorship.ts` `buildAuthorshipEvent` / `promoteConceptToDictionaryTerm` / `defineEntityType` / `defineRelationType` / `overrideConcept`.
- **precision@1 corpus** — seed set is `n<30`; grow the logged-question corpus to `n>=30` before publishing a precision claim (`meetsMinN` gate wired).
- **Graph panel** — consumed the global GraphDock via cockpit context; the Stage-2 concept graph is a bespoke token-tree layout (the reference render spec) rather than the hub+satellite `PGraphCanvas`. Follow-up: evaluate a shared tree-graph primitive.

## Non-goals preserved
No live conversation-chain fetch, no durable KE writeback, no fabricated cryptographic provenance (authorship events are honestly unsigned), no changes outside the client-vue feature slice.

Refs regis-entity-graph#22, prophet-workspace#76 / #103.