### PR TITLE
feat(studio): Platform Explorer panel + Kiali-style runtime overlay in client-vue

### DIFF
--- a/socioprophet-web/client-vue/public/assets/surface-graph.json
+++ b/socioprophet-web/client-vue/public/assets/surface-graph.json
@@ -1,0 +1,2368 @@
+{
+  "version": 1,
+  "generated_at": "2026-03-26T14:37:22.140185+00:00",
+  "ui": {
+    "modes": [
+      "topology",
+      "vector",
+      "hybrid"
+    ],
+    "default_mode": "topology",
+    "similarity_threshold": 0.12,
+    "supports": {
+      "expandTopics": true,
+      "collapseTopics": true,
+      "showExternalSites": true,
+      "showVectorSimilarity": true
+    }
+  },
+  "nodes": [
+    {
+      "id": "academy",
+      "type": "surface",
+      "label": "Academy",
+      "category": "learning",
+      "status": "live",
+      "homepage_visible": true,
+      "graph_group": "core",
+      "map_priority": 10,
+      "landing_page": "/academy/",
+      "survey_page": "/academy/apply/",
+      "docs_path": "/documentation/guide/products/academy/",
+      "audiences": [
+        "learners",
+        "families",
+        "mentors",
+        "educators"
+      ],
+      "topic_constituents": [
+        "learning",
+        "family",
+        "mentorship",
+        "cybernetics",
+        "safeguarding"
+      ],
+      "normalized_topics": [
+        "learning",
+        "education",
+        "capability",
+        "trust",
+        "safeguarding"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "capability_compounding",
+        "value_drivers": [
+          "learner_retention",
+          "mentor_supply",
+          "cohort_completion",
+          "trust"
+        ],
+        "economic_profit_proxy": [
+          "retention_quality",
+          "conversion_readiness",
+          "trust_signal"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/academy/",
+        "https://socioprophet.com/documentation/guide/academy-safeguarding-and-minor-protection/"
+      ],
+      "description": "Learning, family, mentorship, and cybernetics education."
+    },
+    {
+      "id": "organizations",
+      "type": "surface",
+      "label": "Organizations",
+      "category": "deployment",
+      "status": "live",
+      "homepage_visible": true,
+      "graph_group": "core",
+      "map_priority": 20,
+      "landing_page": "/organizations/",
+      "survey_page": "/organizations/",
+      "docs_path": null,
+      "audiences": [
+        "schools",
+        "nonprofits",
+        "public-sector",
+        "employers"
+      ],
+      "topic_constituents": [
+        "deployment",
+        "institutions",
+        "governance",
+        "public-interest",
+        "secure-training"
+      ],
+      "normalized_topics": [
+        "deployment",
+        "institutions",
+        "governance",
+        "trust",
+        "capability"
+      ],
+      "related_surfaces": [
+        "academy",
+        "documentation",
+        "digital-trust",
+        "medical",
+        "law"
+      ],
+      "investor_overlay": {
+        "lens": "deployment_compounding",
+        "value_drivers": [
+          "institutional_conversion",
+          "deployment_retention",
+          "pipeline_value",
+          "trust"
+        ],
+        "economic_profit_proxy": [
+          "deployment_readiness",
+          "account_quality",
+          "trust_signal"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/surface-inventory/",
+        "https://socioprophet.com/documentation/guide/domain-surface/"
+      ],
+      "description": "Institutional deployment for schools, nonprofits, public-interest, and mission-aligned organizations."
+    },
+    {
+      "id": "documentation",
+      "type": "surface",
+      "label": "Documentation",
+      "category": "docs",
+      "status": "live",
+      "homepage_visible": true,
+      "graph_group": "core",
+      "map_priority": 30,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/",
+      "audiences": [
+        "builders",
+        "operators",
+        "researchers",
+        "partners"
+      ],
+      "topic_constituents": [
+        "architecture",
+        "products",
+        "trust",
+        "guides",
+        "reference"
+      ],
+      "normalized_topics": [
+        "architecture",
+        "reference",
+        "trust",
+        "platform",
+        "governance"
+      ],
+      "related_surfaces": [
+        "academy",
+        "organizations",
+        "ai",
+        "developer",
+        "cloud",
+        "live",
+        "medical",
+        "law",
+        "wiki",
+        "blog",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "discovery_compounding",
+        "value_drivers": [
+          "qualified_discovery",
+          "builder_activation",
+          "trust_signal"
+        ],
+        "economic_profit_proxy": [
+          "qualified_traffic",
+          "activation",
+          "reference_depth"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/",
+        "https://socioprophet.com/documentation/guide/canonical-platform-direction/"
+      ],
+      "description": "Architecture, products, trust model, and canonical direction."
+    },
+    {
+      "id": "entity-analytics",
+      "type": "surface",
+      "label": "Entity Analytics",
+      "category": "docs",
+      "status": "live",
+      "homepage_visible": true,
+      "graph_group": "core",
+      "map_priority": 30,
+      "landing_page": "/entity-analytics/",
+      "survey_page": "",
+      "docs_path": "/documentation/guide/entity-analytics-reference/",
+      "audiences": [
+        "builders",
+        "operators",
+        "researchers",
+        "partners"
+      ],
+      "topic_constituents": [
+        "architecture",
+        "products",
+        "trust",
+        "guides",
+        "reference"
+      ],
+      "normalized_topics": [
+        "architecture",
+        "reference",
+        "trust",
+        "platform",
+        "governance"
+      ],
+      "related_surfaces": [
+        "academy",
+        "organizations",
+        "ai",
+        "developer",
+        "cloud",
+        "live",
+        "medical",
+        "law",
+        "wiki",
+        "blog",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "discovery_compounding",
+        "value_drivers": [
+          "qualified_discovery",
+          "builder_activation",
+          "trust_signal"
+        ],
+        "economic_profit_proxy": [
+          "qualified_traffic",
+          "activation",
+          "reference_depth"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/",
+        "https://socioprophet.com/documentation/guide/canonical-platform-direction/"
+      ],
+      "description": "Identity-aware entity analytics with governed linkage, policy-constrained merging, proof artifacts, and marketer-safe outputs."
+    },
+    {
+      "id": "ai",
+      "type": "surface",
+      "label": "AI Platform",
+      "category": "technical",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "expanding",
+      "map_priority": 40,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/ai/",
+      "audiences": [
+        "builders",
+        "operators"
+      ],
+      "topic_constituents": [
+        "agents",
+        "models",
+        "automation",
+        "tooling"
+      ],
+      "normalized_topics": [
+        "intelligence",
+        "platform",
+        "automation",
+        "builders",
+        "trust"
+      ],
+      "related_surfaces": [
+        "developer",
+        "cloud",
+        "live",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "technical_optionality",
+        "value_drivers": [
+          "agent_capability",
+          "integration_relevance",
+          "trustability"
+        ],
+        "economic_profit_proxy": [
+          "technical_reuse",
+          "surface_pull",
+          "platform_option_value"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/ai/"
+      ],
+      "description": "Model, agent, orchestration, and trust-layer capabilities."
+    },
+    {
+      "id": "developer",
+      "type": "surface",
+      "label": "Developer",
+      "category": "technical",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "expanding",
+      "map_priority": 50,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/dev/",
+      "audiences": [
+        "builders",
+        "integrators"
+      ],
+      "topic_constituents": [
+        "apis",
+        "sdk",
+        "tooling",
+        "integration"
+      ],
+      "normalized_topics": [
+        "platform",
+        "builders",
+        "integration",
+        "capability",
+        "apis"
+      ],
+      "related_surfaces": [
+        "ai",
+        "cloud",
+        "live",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "developer_compounding",
+        "value_drivers": [
+          "integration_depth",
+          "sdk_adoption",
+          "builder_retention"
+        ],
+        "economic_profit_proxy": [
+          "adoption_quality",
+          "integration_count",
+          "reuse"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/dev/"
+      ],
+      "description": "SDKs, APIs, integration patterns, and developer workflows."
+    },
+    {
+      "id": "cloud",
+      "type": "surface",
+      "label": "Cloud Suite",
+      "category": "technical",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "expanding",
+      "map_priority": 60,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/cloud/",
+      "audiences": [
+        "operators",
+        "partners"
+      ],
+      "topic_constituents": [
+        "hosting",
+        "managed-services",
+        "deployment",
+        "operations"
+      ],
+      "normalized_topics": [
+        "platform",
+        "operations",
+        "deployment",
+        "trust",
+        "hosting"
+      ],
+      "related_surfaces": [
+        "ai",
+        "developer",
+        "live",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "managed_service_compounding",
+        "value_drivers": [
+          "operational_reuse",
+          "deployment_scale",
+          "service_trust"
+        ],
+        "economic_profit_proxy": [
+          "utilization",
+          "retention",
+          "deployment_efficiency"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/cloud/"
+      ],
+      "description": "Hosted and managed operational capabilities."
+    },
+    {
+      "id": "live",
+      "type": "surface",
+      "label": "Live Builds",
+      "category": "technical",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "expanding",
+      "map_priority": 70,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/live/",
+      "audiences": [
+        "builders",
+        "operators",
+        "partners"
+      ],
+      "topic_constituents": [
+        "demos",
+        "environments",
+        "rollouts",
+        "examples"
+      ],
+      "normalized_topics": [
+        "platform",
+        "operations",
+        "deployment",
+        "signal",
+        "demonstration"
+      ],
+      "related_surfaces": [
+        "ai",
+        "developer",
+        "cloud",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "signal_and_validation",
+        "value_drivers": [
+          "proof_signal",
+          "demo_conversion",
+          "release_visibility"
+        ],
+        "economic_profit_proxy": [
+          "validation_rate",
+          "engagement_quality",
+          "signal_strength"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/live/"
+      ],
+      "description": "Demonstrations, environments, and active build states."
+    },
+    {
+      "id": "medical",
+      "type": "surface",
+      "label": "Medical",
+      "category": "domain",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "high-trust",
+      "map_priority": 80,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/medical/",
+      "audiences": [
+        "providers",
+        "institutions",
+        "families"
+      ],
+      "topic_constituents": [
+        "health",
+        "care",
+        "higher-assurance",
+        "safeguarding"
+      ],
+      "normalized_topics": [
+        "trust",
+        "higher-assurance",
+        "care",
+        "safeguarding",
+        "institutions"
+      ],
+      "related_surfaces": [
+        "law",
+        "organizations",
+        "documentation",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "higher_trust_optionality",
+        "value_drivers": [
+          "assurance",
+          "care_relevance",
+          "safeguard_depth"
+        ],
+        "economic_profit_proxy": [
+          "trust_depth",
+          "risk_reduction",
+          "institutional_fit"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/medical/"
+      ],
+      "description": "Health, education, and support pathways requiring higher assurance."
+    },
+    {
+      "id": "law",
+      "type": "surface",
+      "label": "Law",
+      "category": "domain",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "high-trust",
+      "map_priority": 90,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/law/",
+      "audiences": [
+        "legal",
+        "policy",
+        "governance"
+      ],
+      "topic_constituents": [
+        "law",
+        "policy",
+        "governance",
+        "higher-assurance"
+      ],
+      "normalized_topics": [
+        "trust",
+        "higher-assurance",
+        "governance",
+        "policy",
+        "institutions"
+      ],
+      "related_surfaces": [
+        "medical",
+        "organizations",
+        "documentation",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "governance_optionality",
+        "value_drivers": [
+          "governance_relevance",
+          "policy_fit",
+          "trust_depth"
+        ],
+        "economic_profit_proxy": [
+          "institutional_fit",
+          "high_trust_signal",
+          "governance_pull"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/law/"
+      ],
+      "description": "Legal, governance, and jurisprudential workflows."
+    },
+    {
+      "id": "wiki",
+      "type": "surface",
+      "label": "Wiki",
+      "category": "content",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "content",
+      "map_priority": 100,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/wiki/",
+      "audiences": [
+        "readers",
+        "researchers"
+      ],
+      "topic_constituents": [
+        "knowledge",
+        "reference",
+        "taxonomy",
+        "glossary"
+      ],
+      "normalized_topics": [
+        "knowledge",
+        "reference",
+        "platform",
+        "taxonomy",
+        "trust"
+      ],
+      "related_surfaces": [
+        "blog",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "knowledge_compounding",
+        "value_drivers": [
+          "knowledge_density",
+          "reference_value",
+          "reuse"
+        ],
+        "economic_profit_proxy": [
+          "content_depth",
+          "internal_link_density",
+          "reusability"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/wiki/"
+      ],
+      "description": "Structured knowledge and reference surface."
+    },
+    {
+      "id": "blog",
+      "type": "surface",
+      "label": "Blog",
+      "category": "content",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "content",
+      "map_priority": 110,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/products/blog/",
+      "audiences": [
+        "readers",
+        "followers"
+      ],
+      "topic_constituents": [
+        "essays",
+        "updates",
+        "analysis",
+        "narrative"
+      ],
+      "normalized_topics": [
+        "knowledge",
+        "narrative",
+        "signal",
+        "trust",
+        "public-positioning"
+      ],
+      "related_surfaces": [
+        "wiki",
+        "documentation"
+      ],
+      "investor_overlay": {
+        "lens": "narrative_compounding",
+        "value_drivers": [
+          "narrative_clarity",
+          "trust_signal",
+          "audience_growth"
+        ],
+        "economic_profit_proxy": [
+          "qualified_attention",
+          "trust_lift",
+          "public_signal"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/blog/"
+      ],
+      "description": "Long-form writing, updates, and commentary."
+    },
+    {
+      "id": "digital-trust",
+      "type": "surface",
+      "label": "Digital / Trust",
+      "category": "trust",
+      "status": "stub",
+      "homepage_visible": true,
+      "graph_group": "trust",
+      "map_priority": 120,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": "/documentation/guide/domain-surface/",
+      "audiences": [
+        "operators",
+        "partners",
+        "public"
+      ],
+      "topic_constituents": [
+        "identity",
+        "trust",
+        "governance",
+        "public-positioning"
+      ],
+      "normalized_topics": [
+        "trust",
+        "governance",
+        "identity",
+        "platform",
+        "public-positioning"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "academy",
+        "law",
+        "medical"
+      ],
+      "investor_overlay": {
+        "lens": "trust_compounding",
+        "value_drivers": [
+          "identity_clarity",
+          "governance_signal",
+          "trustability"
+        ],
+        "economic_profit_proxy": [
+          "trust_signal",
+          "identity_coherence",
+          "partner_readiness"
+        ]
+      },
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/domain-surface/"
+      ],
+      "description": "Trust-first positioning, digital identity, and public-facing trust surfaces."
+    },
+    {
+      "id": "investor",
+      "type": "surface",
+      "label": "Investor",
+      "category": "governance",
+      "status": "stub",
+      "homepage_visible": false,
+      "graph_group": "support",
+      "map_priority": 130,
+      "landing_page": "/investor/",
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [
+        "investors",
+        "governance"
+      ],
+      "topic_constituents": [
+        "governance",
+        "capital",
+        "platform-direction"
+      ],
+      "normalized_topics": [
+        "capital",
+        "governance",
+        "value-creation",
+        "platform",
+        "trust"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "digital-trust"
+      ],
+      "investor_overlay": {
+        "lens": "economic_profit",
+        "value_drivers": [
+          "nopat",
+          "invested_capital",
+          "capital_charge",
+          "surface_contribution"
+        ],
+        "economic_profit_proxy": [
+          "value_creation_signal",
+          "platform_compounding",
+          "trust_quality"
+        ]
+      },
+      "related_sites": [
+        "/investor/",
+        "/map/",
+        "https://socioprophet.com/documentation/guide/surface-inventory/"
+      ],
+      "description": "Investor and governance-facing public materials."
+    },
+    {
+      "id": "topic:agents",
+      "type": "topic",
+      "label": "agents",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:analysis",
+      "type": "topic",
+      "label": "analysis",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:apis",
+      "type": "topic",
+      "label": "apis",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:architecture",
+      "type": "topic",
+      "label": "architecture",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:automation",
+      "type": "topic",
+      "label": "automation",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:capital",
+      "type": "topic",
+      "label": "capital",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:care",
+      "type": "topic",
+      "label": "care",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:cybernetics",
+      "type": "topic",
+      "label": "cybernetics",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:demos",
+      "type": "topic",
+      "label": "demos",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:deployment",
+      "type": "topic",
+      "label": "deployment",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:environments",
+      "type": "topic",
+      "label": "environments",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:essays",
+      "type": "topic",
+      "label": "essays",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:examples",
+      "type": "topic",
+      "label": "examples",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:family",
+      "type": "topic",
+      "label": "family",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:glossary",
+      "type": "topic",
+      "label": "glossary",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:governance",
+      "type": "topic",
+      "label": "governance",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:guides",
+      "type": "topic",
+      "label": "guides",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:health",
+      "type": "topic",
+      "label": "health",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:higher-assurance",
+      "type": "topic",
+      "label": "higher-assurance",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:hosting",
+      "type": "topic",
+      "label": "hosting",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:identity",
+      "type": "topic",
+      "label": "identity",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:institutions",
+      "type": "topic",
+      "label": "institutions",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:integration",
+      "type": "topic",
+      "label": "integration",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:knowledge",
+      "type": "topic",
+      "label": "knowledge",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:law",
+      "type": "topic",
+      "label": "law",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:learning",
+      "type": "topic",
+      "label": "learning",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:managed-services",
+      "type": "topic",
+      "label": "managed-services",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:mentorship",
+      "type": "topic",
+      "label": "mentorship",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:models",
+      "type": "topic",
+      "label": "models",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:narrative",
+      "type": "topic",
+      "label": "narrative",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:operations",
+      "type": "topic",
+      "label": "operations",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:platform-direction",
+      "type": "topic",
+      "label": "platform-direction",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:policy",
+      "type": "topic",
+      "label": "policy",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:products",
+      "type": "topic",
+      "label": "products",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:public-interest",
+      "type": "topic",
+      "label": "public-interest",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:public-positioning",
+      "type": "topic",
+      "label": "public-positioning",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:reference",
+      "type": "topic",
+      "label": "reference",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:rollouts",
+      "type": "topic",
+      "label": "rollouts",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:safeguarding",
+      "type": "topic",
+      "label": "safeguarding",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:sdk",
+      "type": "topic",
+      "label": "sdk",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:secure-training",
+      "type": "topic",
+      "label": "secure-training",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:taxonomy",
+      "type": "topic",
+      "label": "taxonomy",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:tooling",
+      "type": "topic",
+      "label": "tooling",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:trust",
+      "type": "topic",
+      "label": "trust",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    },
+    {
+      "id": "topic:updates",
+      "type": "topic",
+      "label": "updates",
+      "category": "topic",
+      "status": "derived",
+      "homepage_visible": false,
+      "graph_group": "topic",
+      "map_priority": 1000,
+      "landing_page": null,
+      "survey_page": null,
+      "docs_path": null,
+      "audiences": [],
+      "topic_constituents": [],
+      "normalized_topics": [],
+      "related_surfaces": [],
+      "investor_overlay": {},
+      "related_sites": [],
+      "description": "Topic constituent derived from configured surfaces."
+    }
+  ],
+  "links": {
+    "curated": [
+      {
+        "source": "academy",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "academy",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "academy",
+        "target": "digital-trust",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "medical",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "law",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "developer",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "live",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "medical",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "law",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "wiki",
+        "type": "curated"
+      },
+      {
+        "source": "blog",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "developer",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "cloud",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "live",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "developer",
+        "type": "curated"
+      },
+      {
+        "source": "developer",
+        "target": "live",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "live",
+        "type": "curated"
+      },
+      {
+        "source": "law",
+        "target": "medical",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "medical",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "law",
+        "type": "curated"
+      },
+      {
+        "source": "blog",
+        "target": "wiki",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "investor",
+        "type": "curated"
+      },
+      {
+        "source": "investor",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "investor",
+        "type": "curated"
+      },
+      {
+        "source": "academy",
+        "target": "entity-analytics",
+        "type": "curated"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "entity-analytics",
+        "type": "curated"
+      },
+      {
+        "source": "developer",
+        "target": "entity-analytics",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "entity-analytics",
+        "type": "curated"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "live",
+        "type": "curated"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "medical",
+        "type": "curated"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "law",
+        "type": "curated"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "wiki",
+        "type": "curated"
+      },
+      {
+        "source": "blog",
+        "target": "entity-analytics",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "entity-analytics",
+        "type": "curated"
+      }
+    ],
+    "constituent": [
+      {
+        "source": "academy",
+        "target": "topic:learning",
+        "type": "constituent"
+      },
+      {
+        "source": "academy",
+        "target": "topic:family",
+        "type": "constituent"
+      },
+      {
+        "source": "academy",
+        "target": "topic:mentorship",
+        "type": "constituent"
+      },
+      {
+        "source": "academy",
+        "target": "topic:cybernetics",
+        "type": "constituent"
+      },
+      {
+        "source": "academy",
+        "target": "topic:safeguarding",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:deployment",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:institutions",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:governance",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:public-interest",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:secure-training",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:architecture",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:products",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:trust",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:guides",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:reference",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:agents",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:models",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:automation",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:tooling",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:apis",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:sdk",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:tooling",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:integration",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:hosting",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:managed-services",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:deployment",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:operations",
+        "type": "constituent"
+      },
+      {
+        "source": "live",
+        "target": "topic:demos",
+        "type": "constituent"
+      },
+      {
+        "source": "live",
+        "target": "topic:environments",
+        "type": "constituent"
+      },
+      {
+        "source": "live",
+        "target": "topic:rollouts",
+        "type": "constituent"
+      },
+      {
+        "source": "live",
+        "target": "topic:examples",
+        "type": "constituent"
+      },
+      {
+        "source": "medical",
+        "target": "topic:health",
+        "type": "constituent"
+      },
+      {
+        "source": "medical",
+        "target": "topic:care",
+        "type": "constituent"
+      },
+      {
+        "source": "medical",
+        "target": "topic:higher-assurance",
+        "type": "constituent"
+      },
+      {
+        "source": "medical",
+        "target": "topic:safeguarding",
+        "type": "constituent"
+      },
+      {
+        "source": "law",
+        "target": "topic:law",
+        "type": "constituent"
+      },
+      {
+        "source": "law",
+        "target": "topic:policy",
+        "type": "constituent"
+      },
+      {
+        "source": "law",
+        "target": "topic:governance",
+        "type": "constituent"
+      },
+      {
+        "source": "law",
+        "target": "topic:higher-assurance",
+        "type": "constituent"
+      },
+      {
+        "source": "wiki",
+        "target": "topic:knowledge",
+        "type": "constituent"
+      },
+      {
+        "source": "wiki",
+        "target": "topic:reference",
+        "type": "constituent"
+      },
+      {
+        "source": "wiki",
+        "target": "topic:taxonomy",
+        "type": "constituent"
+      },
+      {
+        "source": "wiki",
+        "target": "topic:glossary",
+        "type": "constituent"
+      },
+      {
+        "source": "blog",
+        "target": "topic:essays",
+        "type": "constituent"
+      },
+      {
+        "source": "blog",
+        "target": "topic:updates",
+        "type": "constituent"
+      },
+      {
+        "source": "blog",
+        "target": "topic:analysis",
+        "type": "constituent"
+      },
+      {
+        "source": "blog",
+        "target": "topic:narrative",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:identity",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:trust",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:governance",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:public-positioning",
+        "type": "constituent"
+      },
+      {
+        "source": "investor",
+        "target": "topic:governance",
+        "type": "constituent"
+      },
+      {
+        "source": "investor",
+        "target": "topic:capital",
+        "type": "constituent"
+      },
+      {
+        "source": "investor",
+        "target": "topic:platform-direction",
+        "type": "constituent"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "topic:architecture",
+        "type": "constituent"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "topic:products",
+        "type": "constituent"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "topic:trust",
+        "type": "constituent"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "topic:guides",
+        "type": "constituent"
+      },
+      {
+        "source": "entity-analytics",
+        "target": "topic:reference",
+        "type": "constituent"
+      }
+    ],
+    "vector": [
+      {
+        "source": "academy",
+        "target": "organizations",
+        "type": "vector_similarity",
+        "score": 0.143
+      },
+      {
+        "source": "academy",
+        "target": "medical",
+        "type": "vector_similarity",
+        "score": 0.156
+      },
+      {
+        "source": "organizations",
+        "target": "documentation",
+        "type": "vector_similarity",
+        "score": 0.125
+      },
+      {
+        "source": "organizations",
+        "target": "law",
+        "type": "vector_similarity",
+        "score": 0.149
+      },
+      {
+        "source": "organizations",
+        "target": "digital-trust",
+        "type": "vector_similarity",
+        "score": 0.17
+      },
+      {
+        "source": "organizations",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.125
+      },
+      {
+        "source": "documentation",
+        "target": "ai",
+        "type": "vector_similarity",
+        "score": 0.137
+      },
+      {
+        "source": "documentation",
+        "target": "cloud",
+        "type": "vector_similarity",
+        "score": 0.137
+      },
+      {
+        "source": "documentation",
+        "target": "live",
+        "type": "vector_similarity",
+        "score": 0.135
+      },
+      {
+        "source": "documentation",
+        "target": "wiki",
+        "type": "vector_similarity",
+        "score": 0.12
+      },
+      {
+        "source": "documentation",
+        "target": "digital-trust",
+        "type": "vector_similarity",
+        "score": 0.2
+      },
+      {
+        "source": "documentation",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 1.0
+      },
+      {
+        "source": "ai",
+        "target": "developer",
+        "type": "vector_similarity",
+        "score": 0.231
+      },
+      {
+        "source": "ai",
+        "target": "cloud",
+        "type": "vector_similarity",
+        "score": 0.2
+      },
+      {
+        "source": "ai",
+        "target": "live",
+        "type": "vector_similarity",
+        "score": 0.195
+      },
+      {
+        "source": "ai",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.137
+      },
+      {
+        "source": "developer",
+        "target": "cloud",
+        "type": "vector_similarity",
+        "score": 0.143
+      },
+      {
+        "source": "developer",
+        "target": "live",
+        "type": "vector_similarity",
+        "score": 0.167
+      },
+      {
+        "source": "cloud",
+        "target": "live",
+        "type": "vector_similarity",
+        "score": 0.256
+      },
+      {
+        "source": "cloud",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.137
+      },
+      {
+        "source": "live",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.135
+      },
+      {
+        "source": "medical",
+        "target": "law",
+        "type": "vector_similarity",
+        "score": 0.25
+      },
+      {
+        "source": "law",
+        "target": "digital-trust",
+        "type": "vector_similarity",
+        "score": 0.133
+      },
+      {
+        "source": "law",
+        "target": "investor",
+        "type": "vector_similarity",
+        "score": 0.171
+      },
+      {
+        "source": "wiki",
+        "target": "blog",
+        "type": "vector_similarity",
+        "score": 0.158
+      },
+      {
+        "source": "wiki",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.12
+      },
+      {
+        "source": "digital-trust",
+        "target": "investor",
+        "type": "vector_similarity",
+        "score": 0.14
+      },
+      {
+        "source": "digital-trust",
+        "target": "entity-analytics",
+        "type": "vector_similarity",
+        "score": 0.2
+      }
+    ]
+  }
+}

--- a/socioprophet-web/client-vue/src/__tests__/GraphExplorerPanel.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/GraphExplorerPanel.smoke.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Component smoke test for the Studio Platform Explorer panel.
+ * Mounts the panel and asserts the teeth: the graph modes render + switch (vector edges appear),
+ * the similarity threshold filters edges, and the Kiali-style runtime overlay marks a down node
+ * (and can be toggled off).
+ */
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import GraphExplorerPanel from '../pages/studio/GraphExplorerPanel.vue';
+
+function mountPanel() {
+  return mount(GraphExplorerPanel, { attachTo: document.body });
+}
+
+describe('GraphExplorerPanel', () => {
+  it('renders the controls and both legends', () => {
+    const w = mountPanel();
+    expect(w.find('select.ge-mode-graph').exists()).toBe(true);
+    expect(w.find('select.ge-mode-explore').exists()).toBe(true);
+    expect(w.find('input.ge-threshold').exists()).toBe(true);
+    expect(w.find('input.ge-show-topics').exists()).toBe(true);
+    expect(w.find('input.ge-show-runtime').exists()).toBe(true);
+    // Category legend has the six palette entries.
+    expect(w.findAll('.legend').length).toBeGreaterThanOrEqual(2);
+    expect(w.findAll('.ge-node').length).toBeGreaterThan(0);
+  });
+
+  it('switching graph mode to Vector renders vector edges (none in Topology)', async () => {
+    const w = mountPanel();
+    expect(w.findAll('.ge-edge.link-vector').length).toBe(0);
+    await w.find('select.ge-mode-graph').setValue('vector');
+    expect(w.findAll('.ge-edge.link-vector').length).toBeGreaterThan(0);
+  });
+
+  it('raising the similarity threshold filters out vector edges', async () => {
+    const w = mountPanel();
+    await w.find('select.ge-mode-graph').setValue('vector');
+    const loose = w.findAll('.ge-edge.link-vector').length;
+    const range = w.find('input.ge-threshold');
+    (range.element as HTMLInputElement).value = '0.5';
+    await range.trigger('input');
+    const strict = w.findAll('.ge-edge.link-vector').length;
+    expect(strict).toBeLessThan(loose);
+  });
+
+  it('marks a down node when the runtime overlay is on, and clears it when off', async () => {
+    const w = mountPanel();
+    // Overlay is on by default; the fixture has one down node (cloud-broker).
+    expect(w.findAll('.ge-node.health-down').length).toBeGreaterThanOrEqual(1);
+    expect(w.findAll('.ge-node.health-degraded').length).toBeGreaterThanOrEqual(1);
+    await w.find('input.ge-show-runtime').setValue(false);
+    expect(w.findAll('.ge-node.health-down').length).toBe(0);
+  });
+
+  it('selecting a node opens the details pane with its runtime block', async () => {
+    const w = mountPanel();
+    // Click the first surface node group.
+    await w.find('.ge-node.type-surface').trigger('click');
+    expect(w.find('.det-title').exists()).toBe(true);
+    expect(w.find('.runtime-block').exists()).toBe(true);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/graphExplorerModel.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/graphExplorerModel.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the ported Graph Explorer model — the DOM-free logic behind the panel.
+ * Covers: the three graph modes produce distinct link sets, the similarity threshold filters
+ * vector edges, the explore modes scope the neighbourhood, and the Kiali-style runtime overlay
+ * marks a degraded / down node.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  applyRuntimeOverlay,
+  buildVectorLinks,
+  computeActiveGraph,
+  neighborIds,
+  runtimeSummary,
+} from '../features/graph-explorer/model';
+import { RUNTIME_TOPOLOGY_FIXTURE, SURFACE_GRAPH_FIXTURE } from '../features/graph-explorer/fixture';
+import type { ExplorerState } from '../features/graph-explorer/types';
+
+const baseState = (over: Partial<ExplorerState> = {}): ExplorerState => ({
+  viewMode: 'topology',
+  searchMode: 'global',
+  threshold: 0.12,
+  showTopics: false,
+  showExternal: true,
+  query: '',
+  selectedId: null,
+  expandedSurfaceId: null,
+  ...over,
+});
+
+const surfaces = SURFACE_GRAPH_FIXTURE.nodes.filter((n) => n.type === 'surface');
+
+describe('graph modes', () => {
+  it('topology mode yields only curated links (no vector edges)', () => {
+    const { links } = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ viewMode: 'topology' }));
+    expect(links.length).toBeGreaterThan(0);
+    expect(links.every((l) => l.type !== 'vector')).toBe(true);
+  });
+
+  it('vector mode yields vector links and no curated links', () => {
+    const { links } = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ viewMode: 'vector' }));
+    expect(links.some((l) => l.type === 'vector')).toBe(true);
+    expect(links.some((l) => l.type === 'curated')).toBe(false);
+  });
+
+  it('hybrid mode combines curated and vector links', () => {
+    const { links } = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ viewMode: 'hybrid' }));
+    expect(links.some((l) => l.type === 'curated')).toBe(true);
+    expect(links.some((l) => l.type === 'vector')).toBe(true);
+  });
+});
+
+describe('similarity threshold', () => {
+  it('a higher threshold produces fewer (or equal) vector edges', () => {
+    const loose = buildVectorLinks(surfaces, 0.05);
+    const strict = buildVectorLinks(surfaces, 0.4);
+    expect(loose.length).toBeGreaterThan(0);
+    expect(loose.length).toBeGreaterThanOrEqual(strict.length);
+    expect(strict.length).toBeLessThan(loose.length);
+  });
+
+  it('every emitted vector edge meets the threshold', () => {
+    const t = 0.2;
+    for (const l of buildVectorLinks(surfaces, t)) expect(l.score ?? 0).toBeGreaterThanOrEqual(t);
+  });
+
+  it('the threshold flows through computeActiveGraph in vector mode', () => {
+    const loose = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ viewMode: 'vector', threshold: 0.05 }));
+    const strict = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ viewMode: 'vector', threshold: 0.4 }));
+    expect(loose.links.length).toBeGreaterThan(strict.links.length);
+  });
+});
+
+describe('explore modes', () => {
+  it('local scoping keeps the selection and its immediate neighbours only', () => {
+    const global = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ selectedId: 'ai' }));
+    const local = computeActiveGraph(
+      SURFACE_GRAPH_FIXTURE,
+      baseState({ selectedId: 'ai', searchMode: 'local' }),
+    );
+    expect(local.nodes.length).toBeLessThan(global.nodes.length);
+    expect(local.nodes.some((n) => n.id === 'ai')).toBe(true);
+  });
+
+  it('drift-like scoping is at least as wide as local', () => {
+    const local = computeActiveGraph(
+      SURFACE_GRAPH_FIXTURE,
+      baseState({ selectedId: 'ai', searchMode: 'local' }),
+    );
+    const drift = computeActiveGraph(
+      SURFACE_GRAPH_FIXTURE,
+      baseState({ selectedId: 'ai', searchMode: 'drift' }),
+    );
+    expect(drift.nodes.length).toBeGreaterThanOrEqual(local.nodes.length);
+  });
+
+  it('neighborIds expands by depth', () => {
+    const curated = SURFACE_GRAPH_FIXTURE.links!.curated!;
+    const d1 = neighborIds(curated, 'academy', 1);
+    const d2 = neighborIds(curated, 'academy', 2);
+    expect(d1.has('academy')).toBe(true);
+    expect(d2.size).toBeGreaterThanOrEqual(d1.size);
+  });
+});
+
+describe('topic constituents', () => {
+  it('showTopics introduces topic nodes and constituent links', () => {
+    const off = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ showTopics: false }));
+    const on = computeActiveGraph(SURFACE_GRAPH_FIXTURE, baseState({ showTopics: true }));
+    expect(off.nodes.every((n) => n.type === 'surface')).toBe(true);
+    expect(on.nodes.some((n) => n.type === 'topic')).toBe(true);
+    expect(on.links.some((l) => l.type === 'constituent')).toBe(true);
+  });
+});
+
+describe('runtime overlay', () => {
+  it('marks a down node and a degraded node from the runtime topology', () => {
+    const annotated = applyRuntimeOverlay(surfaces, RUNTIME_TOPOLOGY_FIXTURE);
+    const cloud = annotated.find((n) => n.id === 'cloud');
+    const investor = annotated.find((n) => n.id === 'investor');
+    const academy = annotated.find((n) => n.id === 'academy');
+    expect(cloud?.runtime.health).toBe('down');
+    expect(investor?.runtime.health).toBe('degraded');
+    expect(academy?.runtime.health).toBe('healthy');
+    expect(cloud?.runtime.service).toBe('cloud-broker');
+  });
+
+  it('resolves to unknown when no runtime is supplied', () => {
+    const annotated = applyRuntimeOverlay(surfaces, null);
+    expect(annotated.every((n) => n.runtime.health === 'unknown')).toBe(true);
+  });
+
+  it('summarises health counts', () => {
+    const s = runtimeSummary(RUNTIME_TOPOLOGY_FIXTURE);
+    expect(s.down).toBeGreaterThanOrEqual(1);
+    expect(s.degraded).toBeGreaterThanOrEqual(1);
+    expect(s.healthy).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/socioprophet-web/client-vue/src/features/graph-explorer/d3.d.ts
+++ b/socioprophet-web/client-vue/src/features/graph-explorer/d3.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Minimal ambient shim for the d3 force functions used by the Graph Explorer layout.
+ *
+ * The estate depends on `d3` (v7) but does not vendor `@types/d3` (a large type package). Rather
+ * than pull that in, we declare only the handful of chainable force helpers this panel consumes.
+ * The graph model itself is fully typed in features/graph-explorer/*; only the force layout is d3.
+ */
+declare module 'd3' {
+  interface D3Force {
+    (): void;
+    id(fn: (d: unknown) => string): D3Force;
+    distance(v: number | ((l: unknown) => number)): D3Force;
+    strength(v: number | ((l: unknown) => number)): D3Force;
+    radius(v: number | ((d: unknown) => number)): D3Force;
+  }
+  interface D3Simulation {
+    force(name: string, force: D3Force): D3Simulation;
+    nodes(): unknown[];
+    tick(iterations?: number): D3Simulation;
+    stop(): D3Simulation;
+  }
+  export function forceSimulation(nodes?: unknown[]): D3Simulation;
+  export function forceLink(links?: unknown[]): D3Force;
+  export function forceManyBody(): D3Force;
+  export function forceCenter(x?: number, y?: number): D3Force;
+  export function forceCollide(radius?: number | ((d: unknown) => number)): D3Force;
+}

--- a/socioprophet-web/client-vue/src/features/graph-explorer/dataSource.ts
+++ b/socioprophet-web/client-vue/src/features/graph-explorer/dataSource.ts
@@ -1,0 +1,73 @@
+/**
+ * Data source for the Graph Explorer — data-driven, never hand-maintained prose.
+ *
+ * Ontology / topology plane, in preference order:
+ *   1. HellGraph surface-graph endpoint  (`/svc/hellgraph/api/surface-graph`) — the live graph.
+ *   2. Bundled generated payload         (`/assets/surface-graph.json`)       — same generator
+ *      as the marketing Platform Explorer, shipped with the app.
+ *   3. Compact TS fixture                                                     — offline / tests.
+ *
+ * Runtime plane, in preference order:
+ *   1. Catalog-gateway / telemetry topology (`/svc/catalog/api/runtime-topology`) — Kiali-style.
+ *   2. Runtime fixture                                                            — offline / tests.
+ *
+ * The live endpoints (1) are the follow-up @mdheller — until they exist, unreachable fetches fall
+ * through cleanly to the bundled / fixture data, so the panel is always populated.
+ */
+import { RUNTIME_TOPOLOGY_FIXTURE, SURFACE_GRAPH_FIXTURE } from './fixture';
+import type { RuntimeTopology, SurfaceGraph } from './types';
+
+const HELLGRAPH_SURFACE_GRAPH = '/svc/hellgraph/api/surface-graph';
+const BUNDLED_SURFACE_GRAPH = '/assets/surface-graph.json';
+const CATALOG_RUNTIME_TOPOLOGY = '/svc/catalog/api/runtime-topology';
+
+async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(url, { signal, headers: { accept: 'application/json' } });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+  return (await res.json()) as T;
+}
+
+function isSurfaceGraph(v: unknown): v is SurfaceGraph {
+  return !!v && typeof v === 'object' && Array.isArray((v as SurfaceGraph).nodes);
+}
+
+function isRuntimeTopology(v: unknown): v is RuntimeTopology {
+  return !!v && typeof v === 'object' && Array.isArray((v as RuntimeTopology).nodes);
+}
+
+export interface SurfaceGraphResult {
+  graph: SurfaceGraph;
+  source: 'live' | 'bundled' | 'fixture';
+}
+
+/** Load the surface ontology graph, degrading gracefully to bundled data then the fixture. */
+export async function loadSurfaceGraph(signal?: AbortSignal): Promise<SurfaceGraphResult> {
+  for (const [url, source] of [
+    [HELLGRAPH_SURFACE_GRAPH, 'live'],
+    [BUNDLED_SURFACE_GRAPH, 'bundled'],
+  ] as const) {
+    try {
+      const data = await fetchJson<unknown>(url, signal);
+      if (isSurfaceGraph(data)) return { graph: { ...data, source }, source };
+    } catch {
+      /* try the next source */
+    }
+  }
+  return { graph: { ...SURFACE_GRAPH_FIXTURE, source: 'fixture' }, source: 'fixture' };
+}
+
+export interface RuntimeTopologyResult {
+  runtime: RuntimeTopology;
+  source: 'live' | 'fixture';
+}
+
+/** Load the Kiali-style runtime topology, degrading gracefully to the fixture. */
+export async function loadRuntimeTopology(signal?: AbortSignal): Promise<RuntimeTopologyResult> {
+  try {
+    const data = await fetchJson<unknown>(CATALOG_RUNTIME_TOPOLOGY, signal);
+    if (isRuntimeTopology(data)) return { runtime: { ...data, source: 'live' }, source: 'live' };
+  } catch {
+    /* fall through to fixture */
+  }
+  return { runtime: { ...RUNTIME_TOPOLOGY_FIXTURE, source: 'fixture' }, source: 'fixture' };
+}

--- a/socioprophet-web/client-vue/src/features/graph-explorer/fixture.ts
+++ b/socioprophet-web/client-vue/src/features/graph-explorer/fixture.ts
@@ -1,0 +1,719 @@
+/**
+ * Offline / test fixture for the Graph Explorer.
+ *
+ * The surface graph is a faithful, compact subset of the generated Prophet Platform surface
+ * ontology (`marketing/public/assets/surface-graph.json`) — 8 core surfaces, their curated
+ * links, and a slice of topic constituents. It is the deterministic fallback used when neither
+ * HellGraph nor the bundled `/assets/surface-graph.json` is reachable, and the seed for tests.
+ *
+ * The runtime topology is a Kiali-style snapshot: per-surface health + traffic that the panel
+ * overlays onto the ontology nodes. `live` is intentionally degraded and `cloud` is down so the
+ * overlay has something to mark; wiring these to real telemetry is the follow-up (see PR body).
+ */
+import type { RuntimeTopology, SurfaceGraph } from './types';
+
+export const SURFACE_GRAPH_FIXTURE: SurfaceGraph = {
+  "version": 1,
+  "nodes": [
+    {
+      "id": "academy",
+      "type": "surface",
+      "label": "Academy",
+      "category": "learning",
+      "status": "live",
+      "graph_group": "core",
+      "description": "Learning, family, mentorship, and cybernetics education.",
+      "landing_page": "/academy/",
+      "docs_path": "/documentation/guide/products/academy/",
+      "audiences": [
+        "learners",
+        "families",
+        "mentors",
+        "educators"
+      ],
+      "topic_constituents": [
+        "learning",
+        "family",
+        "mentorship",
+        "cybernetics",
+        "safeguarding"
+      ],
+      "normalized_topics": [
+        "learning",
+        "education",
+        "capability",
+        "trust",
+        "safeguarding"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "digital-trust"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/academy/",
+        "https://socioprophet.com/documentation/guide/academy-safeguarding-and-minor-protection/"
+      ],
+      "investor_overlay": {
+        "lens": "capability_compounding",
+        "value_drivers": [
+          "learner_retention",
+          "mentor_supply",
+          "cohort_completion",
+          "trust"
+        ],
+        "economic_profit_proxy": [
+          "retention_quality",
+          "conversion_readiness",
+          "trust_signal"
+        ]
+      }
+    },
+    {
+      "id": "organizations",
+      "type": "surface",
+      "label": "Organizations",
+      "category": "deployment",
+      "status": "live",
+      "graph_group": "core",
+      "description": "Institutional deployment for schools, nonprofits, public-interest, and mission-aligned organizations.",
+      "landing_page": "/organizations/",
+      "docs_path": null,
+      "audiences": [
+        "schools",
+        "nonprofits",
+        "public-sector",
+        "employers"
+      ],
+      "topic_constituents": [
+        "deployment",
+        "institutions",
+        "governance",
+        "public-interest",
+        "secure-training"
+      ],
+      "normalized_topics": [
+        "deployment",
+        "institutions",
+        "governance",
+        "trust",
+        "capability"
+      ],
+      "related_surfaces": [
+        "academy",
+        "documentation",
+        "digital-trust",
+        "medical",
+        "law"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/surface-inventory/",
+        "https://socioprophet.com/documentation/guide/domain-surface/"
+      ],
+      "investor_overlay": {
+        "lens": "deployment_compounding",
+        "value_drivers": [
+          "institutional_conversion",
+          "deployment_retention",
+          "pipeline_value",
+          "trust"
+        ],
+        "economic_profit_proxy": [
+          "deployment_readiness",
+          "account_quality",
+          "trust_signal"
+        ]
+      }
+    },
+    {
+      "id": "documentation",
+      "type": "surface",
+      "label": "Documentation",
+      "category": "docs",
+      "status": "live",
+      "graph_group": "core",
+      "description": "Architecture, products, trust model, and canonical direction.",
+      "landing_page": null,
+      "docs_path": "/",
+      "audiences": [
+        "builders",
+        "operators",
+        "researchers",
+        "partners"
+      ],
+      "topic_constituents": [
+        "architecture",
+        "products",
+        "trust",
+        "guides",
+        "reference"
+      ],
+      "normalized_topics": [
+        "architecture",
+        "reference",
+        "trust",
+        "platform",
+        "governance"
+      ],
+      "related_surfaces": [
+        "academy",
+        "organizations",
+        "ai",
+        "developer",
+        "cloud",
+        "live",
+        "medical",
+        "law",
+        "wiki",
+        "blog",
+        "digital-trust"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/",
+        "https://socioprophet.com/documentation/guide/canonical-platform-direction/"
+      ],
+      "investor_overlay": {
+        "lens": "discovery_compounding",
+        "value_drivers": [
+          "qualified_discovery",
+          "builder_activation",
+          "trust_signal"
+        ],
+        "economic_profit_proxy": [
+          "qualified_traffic",
+          "activation",
+          "reference_depth"
+        ]
+      }
+    },
+    {
+      "id": "ai",
+      "type": "surface",
+      "label": "AI Platform",
+      "category": "technical",
+      "status": "stub",
+      "graph_group": "expanding",
+      "description": "Model, agent, orchestration, and trust-layer capabilities.",
+      "landing_page": null,
+      "docs_path": "/documentation/guide/products/ai/",
+      "audiences": [
+        "builders",
+        "operators"
+      ],
+      "topic_constituents": [
+        "agents",
+        "models",
+        "automation",
+        "tooling"
+      ],
+      "normalized_topics": [
+        "intelligence",
+        "platform",
+        "automation",
+        "builders",
+        "trust"
+      ],
+      "related_surfaces": [
+        "developer",
+        "cloud",
+        "live",
+        "documentation"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/ai/"
+      ],
+      "investor_overlay": {
+        "lens": "technical_optionality",
+        "value_drivers": [
+          "agent_capability",
+          "integration_relevance",
+          "trustability"
+        ],
+        "economic_profit_proxy": [
+          "technical_reuse",
+          "surface_pull",
+          "platform_option_value"
+        ]
+      }
+    },
+    {
+      "id": "developer",
+      "type": "surface",
+      "label": "Developer",
+      "category": "technical",
+      "status": "stub",
+      "graph_group": "expanding",
+      "description": "SDKs, APIs, integration patterns, and developer workflows.",
+      "landing_page": null,
+      "docs_path": "/documentation/guide/products/dev/",
+      "audiences": [
+        "builders",
+        "integrators"
+      ],
+      "topic_constituents": [
+        "apis",
+        "sdk",
+        "tooling",
+        "integration"
+      ],
+      "normalized_topics": [
+        "platform",
+        "builders",
+        "integration",
+        "capability",
+        "apis"
+      ],
+      "related_surfaces": [
+        "ai",
+        "cloud",
+        "live",
+        "documentation"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/dev/"
+      ],
+      "investor_overlay": {
+        "lens": "developer_compounding",
+        "value_drivers": [
+          "integration_depth",
+          "sdk_adoption",
+          "builder_retention"
+        ],
+        "economic_profit_proxy": [
+          "adoption_quality",
+          "integration_count",
+          "reuse"
+        ]
+      }
+    },
+    {
+      "id": "cloud",
+      "type": "surface",
+      "label": "Cloud Suite",
+      "category": "technical",
+      "status": "stub",
+      "graph_group": "expanding",
+      "description": "Hosted and managed operational capabilities.",
+      "landing_page": null,
+      "docs_path": "/documentation/guide/products/cloud/",
+      "audiences": [
+        "operators",
+        "partners"
+      ],
+      "topic_constituents": [
+        "hosting",
+        "managed-services",
+        "deployment",
+        "operations"
+      ],
+      "normalized_topics": [
+        "platform",
+        "operations",
+        "deployment",
+        "trust",
+        "hosting"
+      ],
+      "related_surfaces": [
+        "ai",
+        "developer",
+        "live",
+        "documentation"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/products/cloud/"
+      ],
+      "investor_overlay": {
+        "lens": "managed_service_compounding",
+        "value_drivers": [
+          "operational_reuse",
+          "deployment_scale",
+          "service_trust"
+        ],
+        "economic_profit_proxy": [
+          "utilization",
+          "retention",
+          "deployment_efficiency"
+        ]
+      }
+    },
+    {
+      "id": "digital-trust",
+      "type": "surface",
+      "label": "Digital / Trust",
+      "category": "trust",
+      "status": "stub",
+      "graph_group": "trust",
+      "description": "Trust-first positioning, digital identity, and public-facing trust surfaces.",
+      "landing_page": null,
+      "docs_path": "/documentation/guide/domain-surface/",
+      "audiences": [
+        "operators",
+        "partners",
+        "public"
+      ],
+      "topic_constituents": [
+        "identity",
+        "trust",
+        "governance",
+        "public-positioning"
+      ],
+      "normalized_topics": [
+        "trust",
+        "governance",
+        "identity",
+        "platform",
+        "public-positioning"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "academy",
+        "law",
+        "medical"
+      ],
+      "related_sites": [
+        "https://socioprophet.com/documentation/guide/domain-surface/"
+      ],
+      "investor_overlay": {
+        "lens": "trust_compounding",
+        "value_drivers": [
+          "identity_clarity",
+          "governance_signal",
+          "trustability"
+        ],
+        "economic_profit_proxy": [
+          "trust_signal",
+          "identity_coherence",
+          "partner_readiness"
+        ]
+      }
+    },
+    {
+      "id": "investor",
+      "type": "surface",
+      "label": "Investor",
+      "category": "governance",
+      "status": "stub",
+      "graph_group": "support",
+      "description": "Investor and governance-facing public materials.",
+      "landing_page": "/investor/",
+      "docs_path": null,
+      "audiences": [
+        "investors",
+        "governance"
+      ],
+      "topic_constituents": [
+        "governance",
+        "capital",
+        "platform-direction"
+      ],
+      "normalized_topics": [
+        "capital",
+        "governance",
+        "value-creation",
+        "platform",
+        "trust"
+      ],
+      "related_surfaces": [
+        "documentation",
+        "organizations",
+        "digital-trust"
+      ],
+      "related_sites": [
+        "/investor/",
+        "/map/"
+      ],
+      "investor_overlay": {
+        "lens": "economic_profit",
+        "value_drivers": [
+          "nopat",
+          "invested_capital",
+          "capital_charge",
+          "surface_contribution"
+        ],
+        "economic_profit_proxy": [
+          "value_creation_signal",
+          "platform_compounding",
+          "trust_quality"
+        ]
+      }
+    },
+    {
+      "id": "topic:agents",
+      "type": "topic",
+      "label": "agents",
+      "category": "topic"
+    },
+    {
+      "id": "topic:apis",
+      "type": "topic",
+      "label": "apis",
+      "category": "topic"
+    },
+    {
+      "id": "topic:architecture",
+      "type": "topic",
+      "label": "architecture",
+      "category": "topic"
+    },
+    {
+      "id": "topic:capital",
+      "type": "topic",
+      "label": "capital",
+      "category": "topic"
+    },
+    {
+      "id": "topic:deployment",
+      "type": "topic",
+      "label": "deployment",
+      "category": "topic"
+    },
+    {
+      "id": "topic:family",
+      "type": "topic",
+      "label": "family",
+      "category": "topic"
+    },
+    {
+      "id": "topic:governance",
+      "type": "topic",
+      "label": "governance",
+      "category": "topic"
+    },
+    {
+      "id": "topic:hosting",
+      "type": "topic",
+      "label": "hosting",
+      "category": "topic"
+    },
+    {
+      "id": "topic:identity",
+      "type": "topic",
+      "label": "identity",
+      "category": "topic"
+    },
+    {
+      "id": "topic:institutions",
+      "type": "topic",
+      "label": "institutions",
+      "category": "topic"
+    },
+    {
+      "id": "topic:learning",
+      "type": "topic",
+      "label": "learning",
+      "category": "topic"
+    },
+    {
+      "id": "topic:managed-services",
+      "type": "topic",
+      "label": "managed-services",
+      "category": "topic"
+    },
+    {
+      "id": "topic:models",
+      "type": "topic",
+      "label": "models",
+      "category": "topic"
+    },
+    {
+      "id": "topic:products",
+      "type": "topic",
+      "label": "products",
+      "category": "topic"
+    },
+    {
+      "id": "topic:sdk",
+      "type": "topic",
+      "label": "sdk",
+      "category": "topic"
+    },
+    {
+      "id": "topic:trust",
+      "type": "topic",
+      "label": "trust",
+      "category": "topic"
+    }
+  ],
+  "links": {
+    "curated": [
+      {
+        "source": "academy",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "academy",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "academy",
+        "target": "digital-trust",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "developer",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "documentation",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "developer",
+        "type": "curated"
+      },
+      {
+        "source": "ai",
+        "target": "cloud",
+        "type": "curated"
+      },
+      {
+        "source": "cloud",
+        "target": "developer",
+        "type": "curated"
+      },
+      {
+        "source": "documentation",
+        "target": "investor",
+        "type": "curated"
+      },
+      {
+        "source": "investor",
+        "target": "organizations",
+        "type": "curated"
+      },
+      {
+        "source": "digital-trust",
+        "target": "investor",
+        "type": "curated"
+      }
+    ],
+    "constituent": [
+      {
+        "source": "academy",
+        "target": "topic:learning",
+        "type": "constituent"
+      },
+      {
+        "source": "academy",
+        "target": "topic:family",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:deployment",
+        "type": "constituent"
+      },
+      {
+        "source": "organizations",
+        "target": "topic:institutions",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:architecture",
+        "type": "constituent"
+      },
+      {
+        "source": "documentation",
+        "target": "topic:products",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:agents",
+        "type": "constituent"
+      },
+      {
+        "source": "ai",
+        "target": "topic:models",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:apis",
+        "type": "constituent"
+      },
+      {
+        "source": "developer",
+        "target": "topic:sdk",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:hosting",
+        "type": "constituent"
+      },
+      {
+        "source": "cloud",
+        "target": "topic:managed-services",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:identity",
+        "type": "constituent"
+      },
+      {
+        "source": "digital-trust",
+        "target": "topic:trust",
+        "type": "constituent"
+      },
+      {
+        "source": "investor",
+        "target": "topic:governance",
+        "type": "constituent"
+      },
+      {
+        "source": "investor",
+        "target": "topic:capital",
+        "type": "constituent"
+      }
+    ]
+  }
+};
+
+export const RUNTIME_TOPOLOGY_FIXTURE: RuntimeTopology = {
+  source: "fixture",
+  nodes: [
+    { id: "academy", health: "healthy", service: "academy-web", rps: 42, errorRate: 0.002, p95Ms: 180 },
+    { id: "organizations", health: "healthy", service: "org-portal", rps: 28, errorRate: 0.004, p95Ms: 210 },
+    { id: "documentation", health: "healthy", service: "docs-site", rps: 65, errorRate: 0.001, p95Ms: 95 },
+    { id: "ai", health: "healthy", service: "hellgraph-service", rps: 120, errorRate: 0.006, p95Ms: 320 },
+    { id: "developer", health: "healthy", service: "catalog-gateway", rps: 34, errorRate: 0.003, p95Ms: 140 },
+    { id: "cloud", health: "down", service: "cloud-broker", rps: 0, errorRate: 1, p95Ms: 0 },
+    { id: "digital-trust", health: "healthy", service: "guardrail-fabric", rps: 18, errorRate: 0.005, p95Ms: 260 },
+    { id: "investor", health: "degraded", service: "economic-prophet", rps: 9, errorRate: 0.11, p95Ms: 940 },
+  ],
+  edges: [
+    { source: "ai", target: "developer", rps: 22, errorRate: 0.004 },
+    { source: "developer", target: "cloud", rps: 5, errorRate: 0.8 },
+    { source: "academy", target: "documentation", rps: 30, errorRate: 0.001 },
+    { source: "investor", target: "ai", rps: 6, errorRate: 0.09 },
+  ],
+};

--- a/socioprophet-web/client-vue/src/features/graph-explorer/model.ts
+++ b/socioprophet-web/client-vue/src/features/graph-explorer/model.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure graph-explorer model — ported from the marketing Platform Explorer
+ * (`marketing/public/map/index.html`) so the estate's canonical Vue app consumes the same
+ * logic rather than forking a second one. Everything here is DOM-free and deterministic so it
+ * can be unit-tested and reused by the panel component.
+ */
+import type {
+  ExplorerState,
+  GraphLink,
+  RuntimeHealth,
+  RuntimeTopology,
+  SurfaceGraph,
+  SurfaceNode,
+} from './types';
+
+export interface CategoryLegendEntry {
+  key: string;
+  label: string;
+  color: string;
+}
+
+/** Category legend + colours, matching the marketing Platform Explorer palette. */
+export const CATEGORY_LEGEND: CategoryLegendEntry[] = [
+  { key: 'docs', label: 'Docs / core', color: '#0f172a' },
+  { key: 'learning', label: 'Learning / deployment', color: '#1d4ed8' },
+  { key: 'technical', label: 'Technical', color: '#7c3aed' },
+  { key: 'trust', label: 'Trust / governance', color: '#0f766e' },
+  { key: 'domain', label: 'Domain / higher-trust', color: '#b45309' },
+  { key: 'content', label: 'Content / topic', color: '#64748b' },
+];
+
+/** Runtime (Kiali-style) health colours, drawn from the studio token vocabulary. */
+export const HEALTH_COLOR: Record<RuntimeHealth, string> = {
+  healthy: 'var(--good)',
+  degraded: 'var(--warn)',
+  down: 'var(--bad)',
+  unknown: 'var(--muted)',
+};
+
+export function slug(text: unknown): string {
+  return String(text ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export function colorForNode(node: SurfaceNode): string {
+  if (node.type === 'topic') return '#64748b';
+  switch (node.category) {
+    case 'learning':
+    case 'deployment':
+      return '#1d4ed8';
+    case 'technical':
+      return '#7c3aed';
+    case 'trust':
+    case 'governance':
+      return '#0f766e';
+    case 'domain':
+      return '#b45309';
+    case 'docs':
+      return '#0f172a';
+    case 'content':
+      return '#64748b';
+    default:
+      return '#64748b';
+  }
+}
+
+/** The feature bag used for vector similarity — categories, groups, topics, audiences, overlay. */
+export function featureSet(node: SurfaceNode): Set<string> {
+  const values: string[] = [];
+  values.push(`category:${slug(node.category ?? '')}`);
+  values.push(`group:${slug(node.graph_group ?? '')}`);
+  for (const t of node.topic_constituents ?? []) values.push(`topic:${slug(t)}`);
+  for (const t of node.normalized_topics ?? []) values.push(`norm:${slug(t)}`);
+  for (const a of node.audiences ?? []) values.push(`aud:${slug(a)}`);
+  for (const r of node.related_surfaces ?? []) values.push(`rel:${slug(r)}`);
+  const overlay = node.investor_overlay ?? {};
+  if (overlay.lens) values.push(`lens:${slug(overlay.lens)}`);
+  for (const d of overlay.value_drivers ?? []) values.push(`driver:${slug(d)}`);
+  for (const p of overlay.economic_profit_proxy ?? []) values.push(`proxy:${slug(p)}`);
+  return new Set(values.filter(Boolean));
+}
+
+export function jaccard(a: Iterable<string>, b: Iterable<string>): number {
+  const A = new Set(a);
+  const B = new Set(b);
+  let inter = 0;
+  for (const x of A) if (B.has(x)) inter += 1;
+  const uni = new Set([...A, ...B]).size;
+  return uni ? inter / uni : 0;
+}
+
+/** Vector-similarity edges: every surface pair whose jaccard >= threshold. */
+export function buildVectorLinks(surfaceNodes: SurfaceNode[], threshold: number): GraphLink[] {
+  const out: GraphLink[] = [];
+  for (let i = 0; i < surfaceNodes.length; i += 1) {
+    for (let j = i + 1; j < surfaceNodes.length; j += 1) {
+      const a = surfaceNodes[i];
+      const b = surfaceNodes[j];
+      const score = jaccard(featureSet(a), featureSet(b));
+      if (score >= threshold) out.push({ source: a.id, target: b.id, type: 'vector', score });
+    }
+  }
+  return out;
+}
+
+function endpointId(end: string | { id?: string }): string {
+  return typeof end === 'string' ? end : (end?.id ?? '');
+}
+
+/** N-hop neighbourhood of a root over a link set (used by Local / DRIFT-like explore modes). */
+export function neighborIds(links: GraphLink[], rootId: string, depth: number): Set<string> {
+  let frontier = new Set<string>([rootId]);
+  const seen = new Set<string>([rootId]);
+  for (let d = 0; d < depth; d += 1) {
+    const next = new Set<string>();
+    for (const l of links) {
+      const s = endpointId(l.source as never);
+      const t = endpointId(l.target as never);
+      if (frontier.has(s) && !seen.has(t)) next.add(t);
+      if (frontier.has(t) && !seen.has(s)) next.add(s);
+    }
+    for (const x of next) seen.add(x);
+    frontier = next;
+  }
+  return seen;
+}
+
+function curatedLinksOf(graph: SurfaceGraph): GraphLink[] {
+  if (Array.isArray(graph.links?.curated)) return graph.links!.curated!;
+  if (Array.isArray(graph.edges)) return graph.edges;
+  return [];
+}
+
+export interface ActiveGraph {
+  nodes: SurfaceNode[];
+  links: GraphLink[];
+}
+
+/**
+ * The heart of the explorer — resolves the visible node/link set from the full graph and the
+ * current control state. Mirrors the marketing `activeGraph()` exactly, minus DOM concerns.
+ */
+export function computeActiveGraph(graph: SurfaceGraph, state: ExplorerState): ActiveGraph {
+  const query = state.query.trim().toLowerCase();
+
+  let surfaces = graph.nodes
+    .filter((n) => n.type === 'surface')
+    .filter((n) => {
+      if (!query) return true;
+      const hay = [n.label, n.description, ...(n.topic_constituents ?? []), ...(n.audiences ?? [])]
+        .join(' ')
+        .toLowerCase();
+      return hay.includes(query);
+    });
+
+  const ids = new Set(surfaces.map((s) => s.id));
+
+  const curatedLinks: GraphLink[] = curatedLinksOf(graph)
+    .filter((l) => ids.has(endpointId(l.source as never)) && ids.has(endpointId(l.target as never)))
+    .map((l) => ({ ...l, type: l.type ?? 'curated' }));
+
+  const vectorLinks =
+    state.viewMode === 'topology' ? [] : buildVectorLinks(surfaces, state.threshold);
+
+  let constituentLinks: GraphLink[] = [];
+  let topics: SurfaceNode[] = [];
+  if (state.showTopics || state.expandedSurfaceId) {
+    const constituentSource = Array.isArray(graph.links?.constituent) ? graph.links!.constituent! : [];
+    const relevant = state.expandedSurfaceId
+      ? new Set([state.expandedSurfaceId])
+      : new Set(surfaces.map((s) => s.id));
+    constituentLinks = constituentSource
+      .filter((l) => relevant.has(endpointId(l.source as never)))
+      .map((l) => ({ ...l, type: l.type ?? 'constituent' }));
+    const topicIds = new Set(constituentLinks.map((l) => endpointId(l.target as never)));
+    topics = graph.nodes.filter((n) => n.type === 'topic' && topicIds.has(n.id));
+  }
+
+  let links: GraphLink[] = [];
+  if (state.viewMode === 'topology') links = [...curatedLinks, ...constituentLinks];
+  if (state.viewMode === 'vector') links = [...vectorLinks, ...constituentLinks];
+  if (state.viewMode === 'hybrid') links = [...curatedLinks, ...vectorLinks, ...constituentLinks];
+
+  if (state.selectedId && state.searchMode !== 'global') {
+    const depth = state.searchMode === 'local' ? 1 : 2;
+    const keep = neighborIds(links, state.selectedId, depth);
+    keep.add(state.selectedId);
+    if (state.expandedSurfaceId) keep.add(state.expandedSurfaceId);
+    surfaces = surfaces.filter((n) => keep.has(n.id));
+    topics = topics.filter((n) => keep.has(n.id));
+    links = links.filter(
+      (l) => keep.has(endpointId(l.source as never)) && keep.has(endpointId(l.target as never)),
+    );
+  }
+
+  return { nodes: [...surfaces, ...topics], links };
+}
+
+/** A surface node with its runtime overlay resolved. */
+export interface RuntimeAnnotatedNode extends SurfaceNode {
+  runtime: {
+    health: RuntimeHealth;
+    service?: string;
+    rps?: number;
+    errorRate?: number;
+    p95Ms?: number;
+  };
+}
+
+/**
+ * Overlay Kiali-style runtime health/traffic onto ontology nodes. Surface nodes with no runtime
+ * stat (and every topic node) resolve to `unknown`.
+ */
+export function applyRuntimeOverlay(
+  nodes: SurfaceNode[],
+  runtime: RuntimeTopology | null | undefined,
+): RuntimeAnnotatedNode[] {
+  const byId = new Map((runtime?.nodes ?? []).map((r) => [r.id, r]));
+  return nodes.map((n) => {
+    const stat = byId.get(n.id);
+    return {
+      ...n,
+      runtime: {
+        health: (stat?.health ?? 'unknown') as RuntimeHealth,
+        service: stat?.service,
+        rps: stat?.rps,
+        errorRate: stat?.errorRate,
+        p95Ms: stat?.p95Ms,
+      },
+    };
+  });
+}
+
+export function colorForHealth(health: RuntimeHealth): string {
+  return HEALTH_COLOR[health] ?? HEALTH_COLOR.unknown;
+}
+
+/** Roll-up counts for the runtime status strip. */
+export function runtimeSummary(runtime: RuntimeTopology | null | undefined): Record<RuntimeHealth, number> {
+  const acc: Record<RuntimeHealth, number> = { healthy: 0, degraded: 0, down: 0, unknown: 0 };
+  for (const r of runtime?.nodes ?? []) acc[r.health] = (acc[r.health] ?? 0) + 1;
+  return acc;
+}

--- a/socioprophet-web/client-vue/src/features/graph-explorer/types.ts
+++ b/socioprophet-web/client-vue/src/features/graph-explorer/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Types for the Studio Graph Explorer panel.
+ *
+ * Two data planes converge here:
+ *  1. The *ontology / topology* plane — the Prophet Platform surface graph, generated from
+ *     structured surface data (the same shape the marketing Platform Explorer consumes,
+ *     ultimately served by HellGraph). Nodes are `surface`s and their `topic` constituents.
+ *  2. The *runtime* plane — a Kiali-style live topology: per-node health and traffic, sourced
+ *     from the estate's telemetry / catalog-gateway. It is overlaid onto the ontology nodes.
+ */
+
+export type GraphMode = 'topology' | 'vector' | 'hybrid';
+export type ExploreMode = 'global' | 'local' | 'drift';
+export type SurfaceNodeType = 'surface' | 'topic';
+
+/** Runtime health of the service(s) backing a surface node — Kiali vocabulary. */
+export type RuntimeHealth = 'healthy' | 'degraded' | 'down' | 'unknown';
+
+export interface InvestorOverlay {
+  lens?: string;
+  value_drivers?: string[];
+  economic_profit_proxy?: string[];
+}
+
+export interface SurfaceNode {
+  id: string;
+  type: SurfaceNodeType;
+  label: string;
+  category?: string;
+  status?: string;
+  graph_group?: string;
+  description?: string;
+  landing_page?: string | null;
+  survey_page?: string | null;
+  docs_path?: string | null;
+  audiences?: string[];
+  topic_constituents?: string[];
+  normalized_topics?: string[];
+  related_surfaces?: string[];
+  related_sites?: string[];
+  investor_overlay?: InvestorOverlay;
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+  type?: string;
+  /** Present on vector links: the jaccard similarity that produced the edge. */
+  score?: number;
+}
+
+export interface SurfaceGraph {
+  version?: number;
+  generated_at?: string;
+  nodes: SurfaceNode[];
+  /** Canonical shape. Older payloads may use `edges` for curated links. */
+  links?: {
+    curated?: GraphLink[];
+    constituent?: GraphLink[];
+    vector?: GraphLink[];
+  };
+  edges?: GraphLink[];
+  source?: 'live' | 'bundled' | 'fixture';
+}
+
+/** The state driving {@link computeActiveGraph} — mirrors the marketing Platform Explorer controls. */
+export interface ExplorerState {
+  viewMode: GraphMode;
+  searchMode: ExploreMode;
+  threshold: number;
+  showTopics: boolean;
+  showExternal: boolean;
+  query: string;
+  selectedId: string | null;
+  expandedSurfaceId: string | null;
+}
+
+/** Kiali-style per-node runtime stat, keyed by surface id. */
+export interface RuntimeNodeStat {
+  id: string;
+  health: RuntimeHealth;
+  /** Backing service name (e.g. `hellgraph-service`) for the details pane. */
+  service?: string;
+  /** Requests per second. */
+  rps?: number;
+  /** Error rate in [0, 1]. */
+  errorRate?: number;
+  /** p95 latency in milliseconds. */
+  p95Ms?: number;
+}
+
+export interface RuntimeEdgeStat {
+  source: string;
+  target: string;
+  rps?: number;
+  errorRate?: number;
+}
+
+export interface RuntimeTopology {
+  generated_at?: string;
+  nodes: RuntimeNodeStat[];
+  edges?: RuntimeEdgeStat[];
+  source?: 'live' | 'fixture';
+}

--- a/socioprophet-web/client-vue/src/pages/Studio.vue
+++ b/socioprophet-web/client-vue/src/pages/Studio.vue
@@ -12,6 +12,7 @@ import StudioNotebooks from './studio/StudioNotebooks.vue';
 import StudioCompute from './studio/StudioCompute.vue';
 import StudioComputeSettings from './studio/StudioComputeSettings.vue';
 import GraphExplorer from './studio/GraphExplorer.vue';
+import GraphExplorerPanel from './studio/GraphExplorerPanel.vue';
 import QueryConsole from './studio/QueryConsole.vue';
 import Analytics from './studio/Analytics.vue';
 import GraphRAG from './studio/GraphRAG.vue';
@@ -33,6 +34,7 @@ const GROUPS: { group: string; items: Sec[] }[] = [
   ]},
   { group: 'Knowledge engineering', items: [
     { id: 'graph', label: 'Graph Explorer', ic: '⟡', comp: markRaw(GraphExplorer), sub: 'Force-directed graph + provenance inspector' },
+    { id: 'explorer', label: 'Platform Explorer', ic: '⊕', comp: markRaw(GraphExplorerPanel), sub: 'Ontology topology/vector/hybrid + Kiali-style runtime overlay' },
     { id: 'query', label: 'Query Console', ic: '⌘', comp: markRaw(QueryConsole), sub: 'SPARQL · Cypher · Gremlin over the live kernel' },
     { id: 'analytics', label: 'Analytics', ic: '📈', comp: markRaw(Analytics), sub: 'PageRank / components on the Rust kernel' },
     { id: 'graphrag', label: 'GraphRAG', ic: '✦', comp: markRaw(GraphRAG), sub: 'Ask the graph, cited answers' },

--- a/socioprophet-web/client-vue/src/pages/studio/GraphExplorerPanel.vue
+++ b/socioprophet-web/client-vue/src/pages/studio/GraphExplorerPanel.vue
@@ -1,0 +1,382 @@
+<script setup lang="ts">
+/**
+ * Graph Explorer — the marketing Platform Explorer feature set (Graph mode Topology/Vector/Hybrid,
+ * Explore mode Global/Local/DRIFT, similarity threshold, topic constituents, category legend, node
+ * details) brought into the canonical Vue app, PLUS a Kiali-style runtime overlay (per-node health
+ * + traffic from the estate's telemetry / catalog-gateway).
+ *
+ * Consume-not-fork: the graph logic is the ported, DOM-free model in features/graph-explorer.
+ * Data is loaded live-first (HellGraph + catalog-gateway) with a bundled/fixture fallback, so the
+ * panel is data-driven, never hand-maintained prose.
+ */
+import { computed, onBeforeUnmount, onMounted, reactive, ref, shallowRef, watch } from 'vue';
+import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from 'd3';
+import LiveToggle from '../../components/LiveToggle.vue';
+import {
+  applyRuntimeOverlay,
+  CATEGORY_LEGEND,
+  colorForHealth,
+  colorForNode,
+  computeActiveGraph,
+  runtimeSummary,
+} from '../../features/graph-explorer/model';
+import { loadRuntimeTopology, loadSurfaceGraph } from '../../features/graph-explorer/dataSource';
+import type {
+  ExplorerState,
+  GraphMode,
+  ExploreMode,
+  RuntimeTopology,
+  SurfaceGraph,
+} from '../../features/graph-explorer/types';
+import { SURFACE_GRAPH_FIXTURE } from '../../features/graph-explorer/fixture';
+import { RUNTIME_TOPOLOGY_FIXTURE } from '../../features/graph-explorer/fixture';
+
+const WIDTH = 1100;
+const HEIGHT = 720;
+
+/** Seed synchronously with the fixture so the panel (and tests) render immediately; live load overwrites. */
+const graph = shallowRef<SurfaceGraph>(SURFACE_GRAPH_FIXTURE);
+const runtime = shallowRef<RuntimeTopology>(RUNTIME_TOPOLOGY_FIXTURE);
+const graphSource = ref<'live' | 'bundled' | 'fixture'>('fixture');
+const runtimeSource = ref<'live' | 'fixture'>('fixture');
+const liveState = ref<'idle' | 'loading' | 'live' | 'error'>('idle');
+
+const state = reactive<ExplorerState>({
+  viewMode: 'topology',
+  searchMode: 'global',
+  threshold: 0.12,
+  showTopics: false,
+  showExternal: true,
+  query: '',
+  selectedId: null,
+  expandedSurfaceId: null,
+});
+
+const showRuntime = ref(true);
+
+const legend = CATEGORY_LEGEND;
+
+// ── Derived graph ─────────────────────────────────────────────────────────────
+const active = computed(() => computeActiveGraph(graph.value, state));
+const annotated = computed(() => applyRuntimeOverlay(active.value.nodes, showRuntime.value ? runtime.value : null));
+const summary = computed(() => runtimeSummary(showRuntime.value ? runtime.value : null));
+
+// ── Static force layout (settled synchronously — deterministic, no timers) ──────
+type PositionedNode = ReturnType<typeof applyRuntimeOverlay>[number] & { x: number; y: number };
+const positioned = ref<PositionedNode[]>([]);
+const posMap = computed(() => new Map(positioned.value.map((n) => [n.id, n])));
+
+function relayout() {
+  const nodes = annotated.value.map((n, i) => {
+    const angle = (i / Math.max(1, annotated.value.length)) * Math.PI * 2;
+    const radius = n.type === 'topic' ? 260 : 180;
+    return { ...n, x: WIDTH / 2 + Math.cos(angle) * radius, y: HEIGHT / 2 + Math.sin(angle) * radius };
+  });
+  const idset = new Set(nodes.map((n) => n.id));
+  const links = active.value.links
+    .filter((l) => idset.has(l.source) && idset.has(l.target))
+    .map((l) => ({ ...l }));
+
+  const sim = forceSimulation(nodes)
+    .force(
+      'link',
+      forceLink(links)
+        .id((d: unknown) => (d as { id: string }).id)
+        .distance((l: unknown) => {
+          const t = (l as { type?: string }).type;
+          return t === 'constituent' ? 70 : t === 'vector' ? 150 : 115;
+        })
+        .strength((l: unknown) => ((l as { type?: string }).type === 'vector' ? 0.2 : 0.45)),
+    )
+    .force('charge', forceManyBody().strength((d: unknown) => ((d as { type: string }).type === 'topic' ? -110 : -340)))
+    .force('center', forceCenter(WIDTH / 2, HEIGHT / 2))
+    .force('collision', forceCollide().radius((d: unknown) => ((d as { type: string }).type === 'topic' ? 16 : 34)))
+    .stop();
+
+  for (let i = 0; i < 300; i += 1) sim.tick();
+  for (const n of nodes as PositionedNode[]) {
+    n.x = Math.max(30, Math.min(WIDTH - 30, n.x));
+    n.y = Math.max(30, Math.min(HEIGHT - 30, n.y));
+  }
+  positioned.value = nodes as PositionedNode[];
+}
+
+const renderLinks = computed(() =>
+  active.value.links
+    .map((l) => {
+      const a = posMap.value.get(l.source);
+      const b = posMap.value.get(l.target);
+      return a && b ? { ...l, x1: a.x, y1: a.y, x2: b.x, y2: b.y } : null;
+    })
+    .filter((l): l is NonNullable<typeof l> => l !== null),
+);
+
+// Populate synchronously so the first render already has the settled layout (no empty first paint).
+relayout();
+watch([() => ({ ...state }), showRuntime, graph, runtime], relayout, { deep: true });
+
+// ── Selection / details ─────────────────────────────────────────────────────────
+const selectedNode = computed(() => {
+  if (!state.selectedId) return null;
+  return (
+    annotated.value.find((n) => n.id === state.selectedId) ??
+    applyRuntimeOverlay(
+      graph.value.nodes.filter((n) => n.id === state.selectedId),
+      showRuntime.value ? runtime.value : null,
+    )[0] ??
+    null
+  );
+});
+
+function selectNode(id: string) {
+  state.selectedId = state.selectedId === id ? null : id;
+}
+function toggleExpand(id: string) {
+  state.expandedSurfaceId = state.expandedSurfaceId === id ? null : id;
+}
+
+function isNeighbor(id: string): boolean {
+  if (!state.selectedId) return true;
+  if (id === state.selectedId) return true;
+  return active.value.links.some(
+    (l) =>
+      (l.source === state.selectedId && l.target === id) ||
+      (l.target === state.selectedId && l.source === id),
+  );
+}
+
+function docsHref(node: NonNullable<typeof selectedNode.value>): string | null {
+  const raw = String(node.docs_path ?? '');
+  if (!raw) return null;
+  if (raw.startsWith('http') || raw.startsWith('/documentation/')) return raw;
+  if (raw.startsWith('/guide/')) return `/documentation${raw.replace(/\/?$/, '/')}`;
+  return `/documentation/guide/${raw.replace(/^\/+/, '').replace(/\/?$/, '/')}`;
+}
+
+// ── Live data ─────────────────────────────────────────────────────────────────
+async function goLive() {
+  liveState.value = 'loading';
+  try {
+    const [g, r] = await Promise.all([loadSurfaceGraph(), loadRuntimeTopology()]);
+    graph.value = g.graph;
+    graphSource.value = g.source;
+    runtime.value = r.runtime;
+    runtimeSource.value = r.source;
+    // "live" only if at least one plane actually reached a live endpoint.
+    liveState.value = g.source === 'live' || r.source === 'live' ? 'live' : 'error';
+  } catch {
+    liveState.value = 'error';
+  }
+}
+
+onMounted(relayout);
+onBeforeUnmount(() => {
+  /* nothing to tear down — the simulation is settled synchronously */
+});
+
+const modes: { value: GraphMode; label: string }[] = [
+  { value: 'topology', label: 'Topology' },
+  { value: 'vector', label: 'Vector similarity' },
+  { value: 'hybrid', label: 'Hybrid' },
+];
+const exploreModes: { value: ExploreMode; label: string }[] = [
+  { value: 'global', label: 'Global' },
+  { value: 'local', label: 'Local' },
+  { value: 'drift', label: 'DRIFT-like' },
+];
+</script>
+
+<template>
+  <div class="ge">
+    <!-- Controls -->
+    <aside class="ge-controls card">
+      <h3>Controls</h3>
+
+      <label class="fld" for="ge-mode">Graph mode</label>
+      <select id="ge-mode" v-model="state.viewMode" class="ge-mode-graph">
+        <option v-for="m in modes" :key="m.value" :value="m.value">{{ m.label }}</option>
+      </select>
+      <p class="hint">Topology uses curated links. Vector computes similarity from the ontology. Hybrid combines both.</p>
+
+      <label class="fld" for="ge-explore">Explore mode</label>
+      <select id="ge-explore" v-model="state.searchMode" class="ge-mode-explore">
+        <option v-for="m in exploreModes" :key="m.value" :value="m.value">{{ m.label }}</option>
+      </select>
+      <p class="hint">Global = full topology · Local = immediate neighbours · DRIFT-like = wider neighbourhood.</p>
+
+      <label class="fld" for="ge-threshold">Similarity threshold <span class="mono">{{ state.threshold.toFixed(2) }}</span></label>
+      <input
+        id="ge-threshold"
+        v-model.number="state.threshold"
+        class="ge-threshold"
+        type="range"
+        min="0"
+        max="0.6"
+        step="0.01"
+      />
+
+      <label class="chk"><input v-model="state.showTopics" type="checkbox" class="ge-show-topics" /> Show topic constituents</label>
+      <label class="chk"><input v-model="state.showExternal" type="checkbox" /> Show external sites</label>
+      <label class="chk"><input v-model="showRuntime" type="checkbox" class="ge-show-runtime" /> Runtime overlay (health + traffic)</label>
+
+      <label class="fld" for="ge-query">Filter</label>
+      <input id="ge-query" v-model="state.query" type="search" class="ge-query" placeholder="academy, trust, governance…" />
+
+      <div class="legend">
+        <div class="legend-title">Category</div>
+        <div v-for="c in legend" :key="c.key" class="legend-item">
+          <span class="dot" :style="{ background: c.color }"></span>{{ c.label }}
+        </div>
+      </div>
+
+      <div v-if="showRuntime" class="legend">
+        <div class="legend-title">Runtime health</div>
+        <div class="legend-item"><span class="dot" :style="{ background: colorForHealth('healthy') }"></span>Healthy · {{ summary.healthy }}</div>
+        <div class="legend-item"><span class="dot" :style="{ background: colorForHealth('degraded') }"></span>Degraded · {{ summary.degraded }}</div>
+        <div class="legend-item"><span class="dot" :style="{ background: colorForHealth('down') }"></span>Down · {{ summary.down }}</div>
+      </div>
+    </aside>
+
+    <!-- Graph canvas -->
+    <section class="ge-canvas card">
+      <div class="ge-toolbar">
+        <span class="pill">{{ active.nodes.length }} nodes</span>
+        <span class="pill">{{ active.links.length }} edges</span>
+        <span class="pill" :class="graphSource === 'live' ? 'good' : ''">ontology: {{ graphSource }}</span>
+        <span v-if="showRuntime" class="pill" :class="runtimeSource === 'live' ? 'good' : ''">runtime: {{ runtimeSource }}</span>
+        <LiveToggle :state="liveState" label="Go live" live-text="Live" @click="goLive" />
+      </div>
+      <svg class="ge-svg" :viewBox="`0 0 ${WIDTH} ${HEIGHT}`" role="img" aria-label="Prophet Platform graph explorer">
+        <g class="ge-edges">
+          <line
+            v-for="(l, i) in renderLinks"
+            :key="`e${i}`"
+            class="ge-edge"
+            :class="`link-${l.type ?? 'curated'}`"
+            :x1="l.x1"
+            :y1="l.y1"
+            :x2="l.x2"
+            :y2="l.y2"
+          />
+        </g>
+        <g class="ge-nodes">
+          <g
+            v-for="n in positioned"
+            :key="n.id"
+            class="ge-node"
+            :class="[`type-${n.type}`, showRuntime ? `health-${n.runtime.health}` : '', n.id === state.selectedId ? 'selected' : '', isNeighbor(n.id) ? '' : 'dim']"
+            :transform="`translate(${n.x},${n.y})`"
+            @click="selectNode(n.id)"
+          >
+            <circle
+              :r="n.type === 'topic' ? 9 : 22"
+              :fill="colorForNode(n)"
+              :stroke="showRuntime && n.type === 'surface' ? colorForHealth(n.runtime.health) : '#ffffff'"
+              :stroke-width="showRuntime && n.type === 'surface' && n.runtime.health !== 'unknown' ? 4 : 2"
+            />
+            <text
+              v-if="n.type === 'surface' || state.showTopics || state.expandedSurfaceId"
+              class="ge-label"
+              :y="n.type === 'topic' ? -14 : 38"
+              text-anchor="middle"
+            >{{ n.label }}</text>
+          </g>
+        </g>
+      </svg>
+    </section>
+
+    <!-- Details -->
+    <aside class="ge-detail card">
+      <h3>Details</h3>
+      <p v-if="!selectedNode" class="desc">Select a node to inspect its description, routes, related surfaces, topic constituents — and its live runtime health.</p>
+      <template v-else>
+        <div class="det-title">{{ selectedNode.label }}</div>
+        <div class="small">
+          {{ selectedNode.type }}<template v-if="selectedNode.category"> · {{ selectedNode.category }}</template><template v-if="selectedNode.status"> · {{ selectedNode.status }}</template>
+        </div>
+        <p class="desc">{{ selectedNode.description || 'No description available.' }}</p>
+
+        <div v-if="showRuntime && selectedNode.type === 'surface'" class="runtime-block" :class="`health-${selectedNode.runtime.health}`">
+          <div class="kpi-l">Runtime</div>
+          <div class="rt-row">
+            <span class="rt-badge" :style="{ color: colorForHealth(selectedNode.runtime.health) }">● {{ selectedNode.runtime.health }}</span>
+            <span v-if="selectedNode.runtime.service" class="mono small">{{ selectedNode.runtime.service }}</span>
+          </div>
+          <div class="rt-metrics">
+            <span>{{ (selectedNode.runtime.rps ?? 0).toFixed(0) }} rps</span>
+            <span>{{ ((selectedNode.runtime.errorRate ?? 0) * 100).toFixed(1) }}% err</span>
+            <span>p95 {{ (selectedNode.runtime.p95Ms ?? 0).toFixed(0) }} ms</span>
+          </div>
+        </div>
+
+        <button v-if="selectedNode.type === 'surface'" class="btn ghost expand-btn" @click="toggleExpand(selectedNode.id)">
+          {{ state.expandedSurfaceId === selectedNode.id ? 'Collapse constituents' : 'Expand constituents' }}
+        </button>
+
+        <template v-if="(selectedNode.audiences ?? []).length">
+          <div class="kpi-l">Audiences</div>
+          <div class="badges"><span v-for="a in selectedNode.audiences" :key="a" class="pill">{{ a }}</span></div>
+        </template>
+        <template v-if="(selectedNode.topic_constituents ?? []).length">
+          <div class="kpi-l">Topic constituents</div>
+          <div class="badges"><span v-for="t in selectedNode.topic_constituents" :key="t" class="pill">{{ t }}</span></div>
+        </template>
+        <template v-if="(selectedNode.related_surfaces ?? []).length">
+          <div class="kpi-l">Related surfaces</div>
+          <ul class="rel"><li v-for="r in selectedNode.related_surfaces" :key="r">{{ r }}</li></ul>
+        </template>
+
+        <div class="kpi-l">Links</div>
+        <div class="det-links">
+          <a v-if="selectedNode.landing_page" :href="selectedNode.landing_page">Landing page</a>
+          <a v-if="docsHref(selectedNode)" :href="docsHref(selectedNode)!" target="_blank" rel="noopener">Documentation</a>
+          <template v-if="state.showExternal">
+            <a v-for="s in selectedNode.related_sites ?? []" :key="s" :href="s" target="_blank" rel="noopener">{{ s }}</a>
+          </template>
+        </div>
+      </template>
+    </aside>
+  </div>
+</template>
+
+<style scoped>
+.ge { display: grid; grid-template-columns: 260px minmax(0, 1fr) 320px; gap: 0.9rem; height: calc(100vh - 12rem); min-height: 560px; }
+.ge-controls, .ge-detail { overflow: auto; }
+.ge-canvas { display: flex; flex-direction: column; min-height: 0; padding: 0.6rem; }
+.ge h3 { margin: 0 0 0.7rem; font-size: 0.95rem; }
+.hint { color: var(--muted); font-size: 0.72rem; margin: 0.25rem 0 0.9rem; }
+.ge select, .ge input[type='search'] { width: 100%; margin-bottom: 0.2rem; }
+.ge input[type='range'] { width: 100%; margin: 0.2rem 0 0.9rem; }
+.chk { display: flex; align-items: center; gap: 0.45rem; font-size: 0.82rem; color: var(--text); margin: 0.35rem 0; cursor: pointer; }
+.chk input { width: auto; }
+.legend { margin-top: 1rem; display: grid; gap: 0.4rem; }
+.legend-title { color: var(--faint); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.legend-item { display: flex; align-items: center; gap: 0.5rem; font-size: 0.8rem; color: var(--muted); }
+.dot { width: 0.8rem; height: 0.8rem; border-radius: 999px; display: inline-block; }
+.ge-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 0.45rem; margin-bottom: 0.5rem; }
+.ge-svg { flex: 1; min-height: 0; width: 100%; background: var(--bg); border: 1px solid var(--border); border-radius: 10px; }
+.ge-edge { stroke: #64748b; stroke-width: 2; opacity: 0.7; }
+.ge-edge.link-vector { stroke: #94a3b8; stroke-width: 1.5; stroke-dasharray: 5 4; }
+.ge-edge.link-constituent { stroke: #475569; stroke-width: 1.3; opacity: 0.6; }
+.ge-node { cursor: pointer; }
+.ge-node.dim { opacity: 0.25; }
+.ge-node.selected circle { stroke: var(--accent); stroke-width: 4; }
+.ge-label { fill: var(--text); font-size: 12px; font-weight: 600; pointer-events: none; }
+.type-topic .ge-label { fill: var(--muted); font-size: 11px; font-weight: 500; }
+.det-title { font-size: 1.05rem; font-weight: 600; }
+.small { color: var(--muted); font-size: 0.78rem; margin: 0.15rem 0 0.4rem; }
+.badges { display: flex; flex-wrap: wrap; gap: 0.35rem; margin: 0.3rem 0 0.7rem; }
+.rel { margin: 0.3rem 0 0.7rem; padding-left: 1.1rem; color: var(--muted); font-size: 0.82rem; }
+.kpi-l { color: var(--faint); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em; margin-top: 0.6rem; }
+.det-links { display: grid; gap: 0.3rem; margin-top: 0.3rem; }
+.det-links a { color: var(--accent-ink, var(--accent)); font-size: 0.82rem; text-decoration: none; word-break: break-all; }
+.det-links a:hover { text-decoration: underline; }
+.runtime-block { border: 1px solid var(--border-2); border-left: 3px solid var(--muted); border-radius: 8px; padding: 0.5rem 0.6rem; margin: 0.6rem 0; }
+.runtime-block.health-healthy { border-left-color: var(--good); }
+.runtime-block.health-degraded { border-left-color: var(--warn); }
+.runtime-block.health-down { border-left-color: var(--bad); }
+.rt-row { display: flex; align-items: center; gap: 0.5rem; }
+.rt-badge { font-weight: 600; font-size: 0.82rem; text-transform: capitalize; }
+.rt-metrics { display: flex; gap: 0.7rem; margin-top: 0.35rem; color: var(--muted); font-size: 0.76rem; font-family: var(--mono, monospace); }
+.expand-btn { margin: 0.4rem 0 0.2rem; }
+</style>


### PR DESCRIPTION
## What

Closes the observability graph-view gap by bringing the **Platform Explorer** feature set (socioprophet.com/map) and a **Kiali-style runtime topology** into the estate's canonical Vue app (`client-vue`) as a new Studio child-section — **Studio → Knowledge engineering → Platform Explorer** (`?section=explorer`), augmenting the reasoning-trace / cockpit bench.

Cross-ref: prophet-workspace#76.

## Consume, not fork

The marketing Platform Explorer is a standalone vanilla-JS + d3 page (`marketing/public/map/index.html`). Its graph logic is **ported verbatim and DOM-free** into `src/features/graph-explorer/model.ts` (jaccard feature-set vector links, curated/constituent link assembly, `computeActiveGraph`, neighbourhood scoping) so there is one implementation, reused by the panel and the tests — not a second copy.

## Platform Explorer features (all landed)

- **Graph mode**: Topology / Vector similarity / Hybrid
- **Explore mode**: Global / Local / DRIFT-like (1-hop / 2-hop neighbourhood scoping)
- **Similarity threshold** slider (jaccard over the surface feature set)
- **Show topic constituents** + show external sites toggles
- **Category legend** + **node details pane** (description, audiences, topic constituents, related surfaces, routes/links)

## Kiali-style runtime overlay (landed)

- Per-node **health** (healthy / degraded / down / unknown) rendered as a health-coloured ring on each surface node, plus a **runtime health legend** with roll-up counts.
- Per-node **traffic** (rps, error rate, p95) and backing service shown in a runtime block in the details pane.
- Overlay is toggleable; degraded/down nodes are marked (`.ge-node.health-degraded` / `.health-down`).

## Data-driven, not hand-maintained

`features/graph-explorer/dataSource.ts` loads **live-first** and degrades gracefully:

- Ontology: `/svc/hellgraph/api/surface-graph` (live) → bundled `/assets/surface-graph.json` (the same generator as the marketing map, shipped with the app) → compact TS fixture (offline/tests).
- Runtime: `/svc/catalog/api/runtime-topology` (catalog-gateway / telemetry, live) → runtime fixture.

## Teeth (tests)

- `src/__tests__/graphExplorerModel.test.ts` — modes produce distinct link sets; the similarity threshold filters vector edges; Local/DRIFT scoping; the runtime overlay marks a degraded and a down node.
- `src/__tests__/GraphExplorerPanel.smoke.test.ts` — modes render + switch (vector edges appear); raising the threshold filters edges; the overlay marks a down node and clears when toggled off; the details pane opens with its runtime block.

Local verify: `npm run typecheck` clean · `npm test` **584 passing** (108 files, +18 new) · `npm run build` green.

## Follow-up @mdheller (live data binding)

Wire the two live endpoints to real infrastructure — `/svc/hellgraph/api/surface-graph` (HellGraph-generated surface ontology) and `/svc/catalog/api/runtime-topology` (catalog-gateway / receipt-telemetry health + traffic) — and add the `/svc/catalog` proxy in `vite.config.ts`. Until then the panel serves the bundled generated graph + fixture runtime. Tracked as follow-up; see prophet-workspace#76.