### PR TITLE
feat(noetica): wire Reasoning Chain Inspector to the live Noetica conversation chain

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/reasoningChainConceptResolver.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/reasoningChainConceptResolver.test.ts
@@ -1,0 +1,68 @@
+// Live concept-LABEL resolver for the Reasoning Chain Inspector (augments #516).
+// Proves labels are sourced from the LIVE learned surfaces (the induced ontology)
+// and the governed KE type registry, with KINDs left to kindVocabulary, and that
+// a miss degrades to the KIND rather than fabricating a label.
+import { describe, expect, it } from 'vitest';
+import {
+  createRegistryResolver, resolveConceptLabel, toConceptLabel, useConceptResolver,
+} from '../features/reasoning-chain/conceptResolver';
+import { useOntology } from '../stores/ontology';
+
+describe('toConceptLabel', () => {
+  it('normalizes to :PascalCase and preserves existing governed labels', () => {
+    expect(toConceptLabel('Organization')).toBe(':Organization');
+    expect(toConceptLabel('MONETARY_VALUE')).toBe(':MonetaryValue');
+    expect(toConceptLabel('issued by')).toBe(':IssuedBy');
+    expect(toConceptLabel(':AlreadyGoverned')).toBe(':AlreadyGoverned');
+  });
+});
+
+describe('createRegistryResolver — learned surfaces + governed KE registry', () => {
+  const resolver = createRegistryResolver({
+    classes: () => [{ label: 'Organization', instances: ['Acme Corp'] }],
+    predicates: () => ['issued by'],
+    topics: () => ['Markets'],
+  });
+
+  it('resolves a learned lexical instance to its induced class label', () => {
+    expect(resolver.resolveLabel('Acme Corp', 'ENTITY_TYPE')).toEqual({ label: ':Organization', provenance: 'learned' });
+  });
+
+  it('resolves a class label directly', () => {
+    expect(resolver.resolveLabel('organization', 'ENTITY_TYPE')?.label).toBe(':Organization');
+  });
+
+  it('resolves a learned relation predicate for relation-ish KINDs', () => {
+    expect(resolver.resolveLabel('issued by', 'RELATION')?.label).toBe(':IssuedBy');
+  });
+
+  it('resolves a learned/observed topic for CONTEXT', () => {
+    expect(resolver.resolveLabel('Markets', 'CONTEXT')?.label).toBe(':Markets');
+  });
+
+  it('falls through to the governed KE entity-type registry', () => {
+    // Empty induced classes → the governed registry (knowledge-studio fixture) resolves it.
+    const bare = createRegistryResolver({ classes: () => [], predicates: () => [], topics: () => [] });
+    expect(bare.resolveLabel('ORGANIZATION', 'ENTITY_TYPE')?.label).toBe(':Organization');
+    expect(bare.resolveLabel('ISSUED_BY', 'RELATION')?.label).toBe(':IssuedBy');
+  });
+
+  it('returns null for an unknown term (caller decides the fallback)', () => {
+    expect(resolver.resolveLabel('quux', 'ENTITY_TYPE')).toBeNull();
+    expect(resolveConceptLabel('quux', 'ENTITY_TYPE', resolver)).toMatchObject({
+      label: 'ENTITY_TYPE', resolved: false, provisional: true,
+    });
+  });
+});
+
+describe('useConceptResolver — bound to the live induced ontology', () => {
+  it('resolves a term the living ontology has learned from the corpus', () => {
+    const ont = useOntology();
+    // Induce a learned instance of the ORG class (the schema-on-the-fly loop).
+    ont.observe([{ text: 'Globex', class: 'org', confidence: 0.9 }], [], []);
+    const resolver = useConceptResolver();
+    expect(resolver.resolveLabel('Globex', 'ENTITY_TYPE')?.label).toBe(':Organization');
+    // An unseen term stays unresolved → caller falls back to KIND.
+    expect(resolveConceptLabel('nevermentioned', 'ENTITY_TYPE', resolver).provisional).toBe(true);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/reasoningChainLiveAdapter.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/reasoningChainLiveAdapter.test.ts
@@ -1,0 +1,149 @@
+// Live-chain adapter for the Reasoning Chain Inspector (augments PR #516).
+// Proves the ChatTurn → inspector-model transform:
+//   - a live turn's plan/retrieval/grounding populate tokens/variants/execution
+//     in the SAME Example shape the fixtures produce;
+//   - concept LABELS come from the injected live resolver (resolved wins), and a
+//     miss falls back gracefully to the KIND (never crashes, never fabricates);
+//   - the produced variant feeds the UNCHANGED governed scorer.
+import { describe, expect, it } from 'vitest';
+import { chatTurnToExample, liveChainsFromTurns, type LiveChain } from '../features/reasoning-chain/chatTurnAdapter';
+import { resolveConceptLabel, type ConceptResolver } from '../features/reasoning-chain/conceptResolver';
+import { scoreVariants } from '../features/reasoning-chain/scoreVariants';
+import type { ChatTurn } from '../composables/useNoeticaChat';
+
+// A mock resolver: only 'organization' resolves; everything else misses → fallback.
+const mockResolver: ConceptResolver = {
+  resolveLabel: (term) =>
+    term.trim().toLowerCase() === 'organization' ? { label: ':Organization', provenance: 'learned' } : null,
+};
+
+function assistantTurn(over: Partial<ChatTurn> = {}): ChatTurn {
+  return {
+    role: 'assistant',
+    content: 'I found the 12 contact lists in your org.',
+    intentName: 'show-contact-lists',
+    plan: {
+      capability: 'engage',
+      skill: 'GetContactLists',
+      steps: [
+        { id: 'GetContactLists', label: 'contact lists', status: 'done' },
+        { id: 'GetOrganization', label: 'organization', status: 'done' },
+      ],
+    },
+    grounding: { domain: 'engagement', terms: ['organization', 'widgets'], topics: ['Markets'] },
+    judgment: { verdict: 'grounded', notes: ['bound to engage primitives'] },
+    ...over,
+  };
+}
+
+const chainOf = (turn: ChatTurn, turnIndex = 1, question = 'show me all contact lists in my org'): LiveChain => ({
+  turnIndex,
+  question,
+  turn,
+});
+
+describe('resolveConceptLabel — live resolution + graceful fallback', () => {
+  it('resolved label wins (from the live resolver)', () => {
+    const r = resolveConceptLabel('organization', 'ENTITY_TYPE', mockResolver);
+    expect(r.label).toBe(':Organization');
+    expect(r.resolved).toBe(true);
+    expect(r.provisional).toBe(false);
+    expect(r.provenance).toBe('learned');
+  });
+
+  it('a miss falls back to the KIND (provisional, never fabricated)', () => {
+    const r = resolveConceptLabel('widgets', 'ENTITY_TYPE', mockResolver);
+    expect(r.label).toBe('ENTITY_TYPE'); // the KIND itself, shown as a provisional marker
+    expect(r.resolved).toBe(false);
+    expect(r.provisional).toBe(true);
+  });
+});
+
+describe('chatTurnToExample — ChatTurn → inspector Example', () => {
+  const ex = chatTurnToExample(chainOf(assistantTurn()), mockResolver);
+
+  it('carries the paired question and a live mode', () => {
+    expect(ex.id).toBe('L1');
+    expect(ex.question).toBe('show me all contact lists in my org');
+    expect(ex.modes).toEqual([{ key: 'live', label: 'Live plan' }]);
+  });
+
+  it('builds an annotation tree with an ACTION head + grounding concepts', () => {
+    expect(ex.tokens.length).toBeGreaterThanOrEqual(3);
+    const head = ex.tokens[0];
+    expect(head.dep).toBe('ROOT');
+    expect(head.parent).toBeNull();
+    expect(head.concepts[0].c).toBe('action');
+  });
+
+  it('resolves a known concept label and flags an unknown one as provisional', () => {
+    const labels = ex.tokens.flatMap((t) => t.concepts.map((c) => c.l));
+    expect(labels).toContain(':Organization');
+    // 'widgets' had no resolution → provisional entity concept typed by its KIND.
+    const provisionalEntity = ex.tokens
+      .flatMap((t) => t.concepts)
+      .find((c) => c.provisional === true && c.c === 'entity');
+    expect(provisionalEntity).toBeTruthy();
+    expect(provisionalEntity!.l).toBe('ENTITY_TYPE');
+  });
+
+  it('produces exactly one candidate variant from the real plan (no synthetic ties)', () => {
+    const variants = ex.variants.live;
+    expect(variants).toHaveLength(1);
+    expect(variants[0].chain[0].cat).toBe('action');
+    // plan steps become entity hops with capability:stepId executors.
+    expect(variants[0].chain.some((h) => h.executor === 'engage:GetContactLists')).toBe(true);
+  });
+
+  it('the produced variant feeds the UNCHANGED governed scorer', () => {
+    const res = scoreVariants(ex.variants.live, ex.scoring.live);
+    expect(res.top).toBeTruthy();
+    expect(res.top!.score).toBeGreaterThan(0);
+    expect(res.collapsedFrom).toBe(1);
+    // action + both resolved-or-provisional step concepts are the requested core.
+    expect(ex.scoring.live.requestedCore.length).toBeGreaterThanOrEqual(2);
+    expect(ex.scoring.live.ambient).toEqual([]);
+  });
+
+  it('maps judgment.verdict → execution status (grounded → resolved)', () => {
+    expect(ex.execution.live.status).toBe('resolved');
+    expect(ex.execution.live.response).toContain('contact lists');
+  });
+
+  it('maps a contradiction verdict to a declared gap', () => {
+    const gapEx = chatTurnToExample(
+      chainOf(assistantTurn({ judgment: { verdict: 'contradiction', contradictions: [{ statement: 'scope mismatch' }] } })),
+      mockResolver,
+    );
+    expect(gapEx.execution.live.status).toBe('gap');
+    expect(gapEx.execution.live.note).toContain('scope mismatch');
+  });
+
+  it('an errored turn is a gap; a plain answer with no judgment is resolved', () => {
+    const err = chatTurnToExample(chainOf(assistantTurn({ judgment: undefined, error: true, content: '' })), mockResolver);
+    expect(err.execution.live.status).toBe('gap');
+    const ok = chatTurnToExample(chainOf(assistantTurn({ judgment: undefined })), mockResolver);
+    expect(ok.execution.live.status).toBe('resolved');
+  });
+
+  it('falls back to plan step labels for tokens when grounding has no terms', () => {
+    const noGround = chatTurnToExample(chainOf(assistantTurn({ grounding: undefined })), mockResolver);
+    // still has the action head + one concept per plan step
+    expect(noGround.tokens.length).toBe(3);
+  });
+});
+
+describe('liveChainsFromTurns — pairing + streaming filter', () => {
+  it('pairs each finalized assistant turn with the preceding question and skips streaming', () => {
+    const turns: ChatTurn[] = [
+      { role: 'user', content: 'q1' },
+      { role: 'assistant', content: 'a1' },
+      { role: 'user', content: 'q2' },
+      { role: 'assistant', content: '', streaming: true }, // in-flight → excluded
+    ];
+    const chains = liveChainsFromTurns(turns);
+    expect(chains).toHaveLength(1);
+    expect(chains[0].turnIndex).toBe(1);
+    expect(chains[0].question).toBe('q1');
+  });
+});

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/chatTurnAdapter.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/chatTurnAdapter.ts
@@ -1,0 +1,215 @@
+// Live ChatTurn → Reasoning-Chain-Inspector model adapter.
+//
+// Augments PR #516: the inspector shipped over three seed fixtures (examples.ts).
+// This maps a LIVE Noetica conversation turn (useNoeticaChat ChatTurn — its
+// plan / retrieval / grounding / judgment) onto the SAME Example shape the
+// fixtures produce, so the four stages (Annotation → Concepts → Variants →
+// Execution) render the REAL active chain for the selected turn, scored by the
+// UNCHANGED governed scorer (scoreVariants.ts).
+//
+// Contract (ChatTurn → Example):
+//   • question   ← the user turn that produced this assistant turn
+//   • tokens     ← annotation tree: an ACTION head (intent / plan skill|capability),
+//                  then grounding.terms as ENTITY concepts and grounding.topics as
+//                  CONTEXT concepts (plan step labels stand in when grounding is
+//                  empty). Each concept's LABEL comes from the live resolver
+//                  (conceptResolver.ts); its KIND stays bound via kindVocabulary.
+//   • variants   ← ONE candidate plan built from plan.steps (executor = capability:
+//                  stepId, weight from step status). No synthetic ties are invented
+//                  — a single real plan yields a single variant.
+//   • scoring    ← requestedCore/declaredCanonicalPath derived from the plan's
+//                  concept order; ambient empty (fed verbatim to scoreVariants).
+//   • execution  ← judgment.verdict → resolved/gap; content is the response.
+//
+// Pure and resolver-injected: no store/composable/network coupling, so the
+// transform and its live-label resolution are unit-testable in isolation.
+
+import type { ChatTurn } from '../../composables/useNoeticaChat';
+import type { Example, Token, TokenConcept, ExecutionOutcome, ExampleMode } from './examples';
+import type { RawVariant, ChainStep, ScoringOntology } from './scoreVariants';
+import type { SourceCat, AnnotationKind } from './kindVocabulary';
+import { resolveConceptLabel, type ConceptResolver } from './conceptResolver';
+
+/** One inspectable live chain: an assistant turn + the question that drove it. */
+export interface LiveChain {
+  /** Index of the assistant turn within useNoeticaChat().turns. */
+  turnIndex: number;
+  /** The user question that produced this turn (empty string if none captured). */
+  question: string;
+  /** The assistant turn to inspect. */
+  turn: ChatTurn;
+}
+
+const LIVE_MODE: ExampleMode = { key: 'live', label: 'Live plan' };
+
+const uniq = (xs: string[]): string[] => Array.from(new Set(xs));
+const firstLine = (s: string): string => (s.split('\n').find((l) => l.trim().length > 0) ?? '').trim();
+const truncate = (s: string, n: number): string => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+/** Plan-step status → hop weight (provenance/display only; not a governed input). */
+function weightForStatus(status: string | undefined): number {
+  switch ((status ?? '').toLowerCase()) {
+    case 'done':
+    case 'complete':
+    case 'completed':
+    case 'ok':
+      return 1;
+    case 'running':
+    case 'active':
+    case 'in_progress':
+      return 0.6;
+    case 'failed':
+    case 'error':
+    case 'blocked':
+      return 0.2;
+    default:
+      return 0.5;
+  }
+}
+
+function makeConcept(
+  text: string,
+  cat: SourceCat,
+  kind: AnnotationKind,
+  resolver: ConceptResolver,
+): TokenConcept {
+  const rc = resolveConceptLabel(text, kind, resolver);
+  return { l: rc.label, c: cat, provenance: rc.provenance, provisional: rc.provisional };
+}
+
+function makeToken(
+  text: string,
+  dep: string,
+  depth: number,
+  parent: number | null,
+  cat: SourceCat,
+  kind: AnnotationKind,
+  resolver: ConceptResolver,
+): Token {
+  return { text, pos: '', dep, depth, parent, concepts: [makeConcept(text, cat, kind, resolver)] };
+}
+
+/** The action head text for a turn (intent → plan skill → plan capability). */
+function actionText(turn: ChatTurn): string {
+  return turn.intentName ?? turn.plan?.skill ?? turn.plan?.capability ?? 'respond';
+}
+
+function buildTokens(chain: LiveChain, resolver: ConceptResolver): Token[] {
+  const { turn } = chain;
+  const tokens: Token[] = [makeToken(actionText(turn), 'ROOT', 0, null, 'action', 'ACTION', resolver)];
+
+  const terms = turn.grounding?.terms ?? [];
+  const entitySources = terms.length ? terms : (turn.plan?.steps ?? []).map((s) => s.label);
+  for (const t of entitySources) {
+    if (t && t.trim()) tokens.push(makeToken(t, 'concept', 1, 0, 'entity', 'ENTITY_TYPE', resolver));
+  }
+
+  for (const tp of turn.grounding?.topics ?? []) {
+    if (tp && tp.trim()) tokens.push(makeToken(tp, 'context', 1, 0, 'temporal', 'CONTEXT', resolver));
+  }
+
+  return tokens;
+}
+
+function buildPlanVariant(chain: LiveChain, resolver: ConceptResolver): { variant: RawVariant; ontology: ScoringOntology } {
+  const { turn } = chain;
+  const cap = turn.plan?.capability ?? turn.plan?.skill ?? 'noetica';
+  const steps = turn.plan?.steps ?? [];
+
+  const chainSteps: ChainStep[] = [];
+  const path: string[] = [];
+
+  // Action head (part of requestedCore, mirroring the fixture convention).
+  const actionLabel = resolveConceptLabel(actionText(turn), 'ACTION', resolver).label;
+  chainSteps.push({ concept: actionLabel, executor: `${cap}:respond`, weight: 1, cat: 'action' });
+  path.push(actionLabel);
+
+  const coreConcepts: string[] = [];
+  const conceptSources: Array<{ label: string; executor: string; weight: number }> = steps.length
+    ? steps.map((s) => ({
+        label: resolveConceptLabel(s.label, 'ENTITY_TYPE', resolver).label,
+        executor: `${cap}:${s.id}`,
+        weight: weightForStatus(s.status),
+      }))
+    : (turn.grounding?.terms ?? []).map((t) => ({
+        label: resolveConceptLabel(t, 'ENTITY_TYPE', resolver).label,
+        executor: `${cap}:${t.replace(/\s+/g, '_')}`,
+        weight: 0.5,
+      }));
+
+  for (const c of conceptSources) {
+    chainSteps.push({ concept: c.label, executor: c.executor, weight: c.weight, cat: 'entity' });
+    coreConcepts.push(c.label);
+    path.push(c.label);
+  }
+
+  const text = firstLine(turn.content) || turn.plan?.skill || turn.plan?.capability || 'Executed plan';
+  const variant: RawVariant = { id: `live-${chain.turnIndex}`, text, chain: chainSteps };
+  const ontology: ScoringOntology = {
+    requestedCore: uniq([actionLabel, ...coreConcepts]),
+    ambient: [],
+    declaredCanonicalPath: uniq(path),
+  };
+  return { variant, ontology };
+}
+
+function buildExecution(chain: LiveChain): ExecutionOutcome {
+  const { turn } = chain;
+  const verdict = turn.judgment?.verdict;
+  const status: ExecutionOutcome['status'] =
+    verdict === 'grounded'
+      ? 'resolved'
+      : verdict === 'speculative' || verdict === 'contradiction'
+        ? 'gap'
+        : turn.error
+          ? 'gap'
+          : turn.content.trim()
+            ? 'resolved'
+            : 'gap';
+
+  const notes = turn.judgment?.notes?.filter(Boolean).join(' · ');
+  const contradictions = turn.judgment?.contradictions?.map((c) => c.statement).filter(Boolean).join('; ');
+  const note =
+    notes ||
+    (contradictions ? `Declared contradiction: ${contradictions}` : '') ||
+    (turn.grounding?.domain ? `Grounded in ${turn.grounding.domain}.` : '') ||
+    (status === 'resolved'
+      ? 'Resolved from the live chain (no explicit value judgment emitted for this turn).'
+      : 'No grounded answer produced for this turn.');
+
+  const response = truncate(turn.content.trim() || '—', 600);
+  return { status, note, response };
+}
+
+/** Map one live conversation chain onto the inspector's Example model. */
+export function chatTurnToExample(chain: LiveChain, resolver: ConceptResolver): Example {
+  const { variant, ontology } = buildPlanVariant(chain, resolver);
+  return {
+    id: `L${chain.turnIndex}`,
+    label: chain.turn.intentName ?? 'Live turn',
+    question: chain.question || '(no question captured for this turn)',
+    tokens: buildTokens(chain, resolver),
+    modes: [LIVE_MODE],
+    variants: { [LIVE_MODE.key]: [variant] },
+    execution: { [LIVE_MODE.key]: buildExecution(chain) },
+    scoring: { [LIVE_MODE.key]: ontology },
+  };
+}
+
+/**
+ * Derive the inspectable live chains from a chat turn list: each non-streaming
+ * assistant turn paired with the most recent preceding user question. Fan-out
+ * siblings (several assistant columns for one question) each reuse that question.
+ */
+export function liveChainsFromTurns(turns: ChatTurn[]): LiveChain[] {
+  const chains: LiveChain[] = [];
+  let pendingQuestion = '';
+  turns.forEach((t, i) => {
+    if (t.role === 'user') {
+      pendingQuestion = t.content;
+    } else if (t.role === 'assistant' && !t.streaming) {
+      chains.push({ turnIndex: i, question: pendingQuestion, turn: t });
+    }
+  });
+  return chains;
+}

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/conceptResolver.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/conceptResolver.ts
@@ -1,0 +1,143 @@
+// Live concept-LABEL resolver for the Reasoning Chain Inspector.
+//
+// The seed fixtures (examples.ts) carry hard-coded governed labels (:ActionShow,
+// :ContactLists…). When the inspector binds to a LIVE Noetica turn, those labels
+// must instead be sourced from the estate's learned resolver / KE registries, per
+// the estate rule "learn, don't match dictionaries":
+//   - the LIVE learned surface is the living ontology (stores/ontology.ts): the
+//     schema-on-the-fly loop that INDUCES concept classes, relation predicates and
+//     topics from the read corpus. That is the learned label source.
+//   - the governed KE type registry (features/knowledge-studio/fixture.ts:
+//     entityTypes / relationTypes — the Knowledge Studio entity/relation types)
+//     supplies canonical governed type labels.
+// KINDs are NOT resolved here — they stay bound to regis-entity-graph#22 via
+// kindVocabulary.ts. This module resolves only the open, LEARNED role LABEL.
+//
+// CONSUME-NOT-FORK: this reads the existing live surfaces; it neither forks nor
+// writes them. If a term has no live resolution, resolveConceptLabel() falls back
+// to the KIND (a provisional marker) — it never crashes and never fabricates a
+// governed label out of thin air.
+
+import { useOntology } from '../../stores/ontology';
+import { entityTypes as keEntityTypes, relationTypes as keRelationTypes } from '../knowledge-studio/fixture';
+import type { AnnotationKind, ProvenanceClass } from './kindVocabulary';
+
+export interface ResolvedLabel {
+  /** Governed/learned concept label, e.g. ':Organization'. */
+  label: string;
+  /** Where the label came from — learned (induced/registry) vs human override. */
+  provenance: ProvenanceClass;
+}
+
+/** A resolver maps a raw term + its KIND to a learned label, or null if unknown. */
+export interface ConceptResolver {
+  resolveLabel(term: string, kind: AnnotationKind): ResolvedLabel | null;
+}
+
+export interface ResolvedConcept {
+  label: string;
+  provenance: ProvenanceClass;
+  /** true when the live resolver produced the label. */
+  resolved: boolean;
+  /** true when the label is the graceful KIND fallback, not a live resolution. */
+  provisional: boolean;
+}
+
+/** ':' + PascalCase — the governed concept-label form (':MonetaryValue'). */
+export function toConceptLabel(name: string): string {
+  const s = (name ?? '').trim();
+  if (!s) return ':Concept';
+  if (s.startsWith(':')) return s;
+  const pascal = s
+    .replace(/[^A-Za-z0-9]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+  return ':' + (pascal || 'Concept');
+}
+
+const RELATIONISH: ReadonlySet<AnnotationKind> = new Set<AnnotationKind>(['RELATION', 'POSSESSION']);
+
+/** Live registry surfaces the resolver reads — injected so it stays testable. */
+export interface RegistrySources {
+  /** Induced entity classes with their learned lexical instances. */
+  classes: () => Array<{ label: string; instances: string[] }>;
+  /** Learned relation predicates. */
+  predicates: () => string[];
+  /** Learned/observed topics. */
+  topics: () => string[];
+}
+
+/**
+ * Build a resolver over the given live registry surfaces plus the governed KE
+ * type registry. Pure over its injected sources — no store/composable coupling,
+ * so tests can drive it directly.
+ */
+export function createRegistryResolver(sources: RegistrySources): ConceptResolver {
+  return {
+    resolveLabel(term: string, kind: AnnotationKind): ResolvedLabel | null {
+      const t = (term ?? '').trim().toLowerCase();
+      if (!t) return null;
+
+      // Learned relation predicates + governed relation-type registry.
+      if (RELATIONISH.has(kind)) {
+        const pred = sources.predicates().find((p) => p.toLowerCase() === t);
+        if (pred) return { label: toConceptLabel(pred), provenance: 'learned' };
+        const rt = keRelationTypes.find(
+          (r) => r.name.toLowerCase() === t || r.name.toLowerCase().replace(/_/g, ' ') === t,
+        );
+        if (rt) return { label: toConceptLabel(rt.name), provenance: 'learned' };
+      }
+
+      // Learned induced entity classes (instances) + governed entity-type registry.
+      const cls = sources
+        .classes()
+        .find((c) => c.label.toLowerCase() === t || c.instances.some((i) => i.toLowerCase() === t));
+      if (cls) return { label: toConceptLabel(cls.label), provenance: 'learned' };
+
+      const et = keEntityTypes.find(
+        (e) =>
+          e.name.toLowerCase() === t ||
+          e.name.toLowerCase().replace(/_/g, ' ') === t ||
+          e.roles
+            .toLowerCase()
+            .split(/[,\s]+/)
+            .filter(Boolean)
+            .includes(t),
+      );
+      if (et) return { label: toConceptLabel(et.name), provenance: 'learned' };
+
+      // Learned/observed topics → context concepts.
+      const topic = sources.topics().find((tp) => tp.toLowerCase() === t);
+      if (topic) return { label: toConceptLabel(topic), provenance: 'learned' };
+
+      return null;
+    },
+  };
+}
+
+/**
+ * Resolve a term to a concept, with a graceful fallback. On a live-resolution
+ * miss the label becomes the KIND itself (a provisional marker) — honest, never a
+ * fabricated governed label.
+ */
+export function resolveConceptLabel(term: string, kind: AnnotationKind, resolver: ConceptResolver): ResolvedConcept {
+  const hit = resolver.resolveLabel(term, kind);
+  if (hit) return { label: hit.label, provenance: hit.provenance, resolved: true, provisional: false };
+  return { label: kind, provenance: 'learned', resolved: false, provisional: true };
+}
+
+/**
+ * Live resolver bound to the estate surfaces: the living ontology (induced,
+ * learned) + the governed KE type registry. Must be called with an active Pinia
+ * (i.e. from a component/composable), like any store consumer.
+ */
+export function useConceptResolver(): ConceptResolver {
+  const ontology = useOntology();
+  return createRegistryResolver({
+    classes: () => ontology.classes.map((c) => ({ label: c.label, instances: c.instances })),
+    predicates: () => ontology.relations.map((r) => r.predicate),
+    topics: () => ontology.topics.map((t) => t.topic),
+  });
+}

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/examples.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/examples.ts
@@ -15,6 +15,12 @@ export interface TokenConcept {
   c: SourceCat;
   /** Provenance class — labels are learned unless a human override supersedes. */
   provenance?: ProvenanceClass;
+  /**
+   * True when the label is a graceful KIND fallback (no live label resolution),
+   * not a resolved governed label. Fixtures never set this; live-derived chains
+   * (chatTurnAdapter.ts) mark unresolved concepts so the UI can flag them.
+   */
+  provisional?: boolean;
 }
 export interface Token {
   text: string;

--- a/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
+++ b/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
@@ -29,10 +29,27 @@ import {
   useAuthorshipLedger, promoteConceptToDictionaryTerm, defineEntityType,
   defineRelationType, overrideConcept, type AuthorshipEvent,
 } from '../features/reasoning-chain/keAuthorship';
+import { useNoeticaChat } from '../composables/useNoeticaChat';
+import { useConceptResolver } from '../features/reasoning-chain/conceptResolver';
+import { chatTurnToExample, liveChainsFromTurns, type LiveChain } from '../features/reasoning-chain/chatTurnAdapter';
 
 const cockpit = useCockpit();
 const auth = useAuth();
 const author = computed(() => auth.user?.email ?? 'operator');
+
+// ---- data source: LIVE Noetica conversation chains vs demo seed fixtures ----
+// The live learned resolver sources concept LABELS (conceptResolver.ts); KINDs
+// stay bound to regis-entity-graph#22 (kindVocabulary.ts). The three fixtures
+// remain available as a demo/offline mode so the route renders with no live data.
+const chat = useNoeticaChat();
+const resolver = useConceptResolver();
+type SourceMode = 'live' | 'demo';
+const liveChains = computed<LiveChain[]>(() => liveChainsFromTurns(chat.turns.value));
+const liveExamples = computed<Example[]>(() => liveChains.value.map((c) => chatTurnToExample(c, resolver)));
+// Default to live when there is a live chain to inspect; otherwise demo fixtures.
+const source = ref<SourceMode>(liveChains.value.length ? 'live' : 'demo');
+const activeExamples = computed<Example[]>(() => (source.value === 'live' ? liveExamples.value : EXAMPLES));
+const hasLive = computed(() => liveExamples.value.length > 0);
 
 type StageKey = 'annotation' | 'concepts' | 'variants' | 'execution';
 const STAGES: { key: StageKey; label: string }[] = [
@@ -44,9 +61,17 @@ const STAGES: { key: StageKey; label: string }[] = [
 
 const exampleId = ref('A');
 const stage = ref<StageKey>('annotation');
-const example = computed<Example>(() => EXAMPLES.find((e) => e.id === exampleId.value) ?? EXAMPLES[0]);
+const example = computed<Example>(
+  () => activeExamples.value.find((e) => e.id === exampleId.value) ?? activeExamples.value[0] ?? EXAMPLES[0],
+);
 const mode = ref(example.value.modes[0].key);
 watch(example, (e) => { mode.value = e.modes[0].key; });
+
+// When the active example set changes (source toggle, a new live turn arrives),
+// keep the selection valid — snap to the first available example.
+watch(activeExamples, (list) => {
+  if (!list.some((e) => e.id === exampleId.value)) exampleId.value = list[0]?.id ?? 'A';
+}, { immediate: true });
 
 // ---- authorship (human overrides supersede learned; prior retained) ----
 const ledger = useAuthorshipLedger();
@@ -141,13 +166,15 @@ const legendKinds = computed<AnnotationKind[]>(() => {
 function setCockpitContext() {
   cockpit.setContext({
     surface: 'Reasoning Chain Inspector',
-    entityLabel: `Example ${example.value.id} · ${example.value.label}`,
+    entityLabel: source.value === 'live'
+      ? `Live · ${example.value.label}`
+      : `Example ${example.value.id} · ${example.value.label}`,
     detail: example.value.question,
     route: '/noetica/reasoning-chain',
   });
 }
 onMounted(setCockpitContext);
-watch([example, mode], setCockpitContext);
+watch([example, mode, source], setCockpitContext);
 </script>
 
 <template>
@@ -155,7 +182,8 @@ watch([example, mode], setCockpitContext);
     <SurfaceHeader title="Reasoning Chain Inspector" eyebrow="Noetica · reasoning trace · governed vocabulary">
       <template #badge>
         <span class="rci-badge">L2</span>
-        <span class="rci-badge rci-badge--fixture">seed fixtures</span>
+        <span v-if="source === 'live'" class="rci-badge rci-badge--live">live chain</span>
+        <span v-else class="rci-badge rci-badge--fixture">seed fixtures</span>
       </template>
     </SurfaceHeader>
 
@@ -167,16 +195,46 @@ watch([example, mode], setCockpitContext);
     </p>
 
     <BoundaryNotice
-      label="fixture · seed conversation chains"
+      v-if="source === 'live'"
+      label="live · active conversation chain"
       tone="muted"
-      message="Fixture-backed over three seed conversation chains; live conversation-chain binding is a tracked follow-up. KINDs are bound to regis-entity-graph#22; authorship events are held in an in-memory ledger (unsigned) — the durable KE-workbench contract seals them."
+      message="Bound to the live Noetica conversation chain (useNoeticaChat): the selected turn's plan / retrieval / grounding populate the four stages. Concept LABELS resolve against the live learned resolver / KE registries; KINDs stay bound to regis-entity-graph#22. Where a label has no live resolution the KIND is shown (provisional). The governed variant scorer is unchanged; authorship events are held in an in-memory ledger (unsigned) until the KE workbench seals them."
+      aria-label="Reasoning Chain Inspector boundary"
+    />
+    <BoundaryNotice
+      v-else
+      label="demo · seed conversation chains"
+      tone="muted"
+      message="Demo/offline mode over three seed conversation chains — shown when no live turn is selected. KINDs are bound to regis-entity-graph#22; authorship events are held in an in-memory ledger (unsigned) — the durable KE-workbench contract seals them."
       aria-label="Reasoning Chain Inspector boundary"
     />
 
-    <!-- example selector + question card -->
+    <!-- data source: live conversation chain vs demo fixtures -->
+    <div class="rci-source" role="group" aria-label="Data source">
+      <button
+        type="button" class="rci-src" :class="{ on: source === 'live' }"
+        :disabled="!hasLive" @click="source = 'live'"
+        :title="hasLive ? 'Inspect the live Noetica conversation chain' : 'No live turn yet — send a message in the Noetica chat'"
+      >Live chain<span v-if="hasLive" class="rci-src-n">{{ liveExamples.length }}</span></button>
+      <button
+        type="button" class="rci-src" :class="{ on: source === 'demo' }"
+        @click="source = 'demo'"
+      >Demo · seed fixtures</button>
+      <span v-if="source === 'live' && !hasLive" class="rci-dim rci-src-hint">no live conversation turn to inspect yet</span>
+    </div>
+
+    <!-- live-empty state: keep the route renderable with no live data -->
+    <div v-if="source === 'live' && !hasLive" class="rci-empty">
+      No live conversation turn is available to inspect. Ask Noetica something in the chat dock, then return here —
+      the active chain per turn will populate the four stages. Meanwhile, switch to
+      <button type="button" class="rci-link" @click="source = 'demo'">demo seed fixtures</button>.
+    </div>
+
+    <template v-else>
+    <!-- example / turn selector + question card -->
     <div class="rci-picker" role="tablist" aria-label="Example">
       <button
-        v-for="e in EXAMPLES" :key="e.id" type="button" class="rci-pill"
+        v-for="e in activeExamples" :key="e.id" type="button" class="rci-pill"
         :class="{ on: exampleId === e.id }" role="tab" :aria-selected="exampleId === e.id"
         @click="exampleId = e.id"
       >{{ e.id }} · {{ e.label }}</button>
@@ -222,6 +280,7 @@ watch([example, mode], setCockpitContext);
               <span class="rci-tag-prov" aria-hidden="true">{{ PROVENANCE_META[provenanceOf(c)].glyph }}</span>
               {{ c.l }}
               <span class="rci-tag-kind">{{ kindOf(c) }}</span>
+              <span v-if="c.provisional" class="rci-tag-prov-mark" title="Provisional — no live label resolution; showing the governed KIND">prov</span>
             </span>
             <span v-if="!t.concepts.length" class="rci-tag rci-tag--untyped" title="Untyped — no resolved concept">untyped</span>
           </li>
@@ -337,6 +396,7 @@ watch([example, mode], setCockpitContext);
         </blockquote>
       </div>
     </div>
+    </template>
   </section>
 </template>
 
@@ -344,6 +404,18 @@ watch([example, mode], setCockpitContext);
 .rci { padding: 1.25rem 1.75rem 2.5rem; color: var(--text); max-width: 1080px; }
 .rci-badge { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; border: 1px solid var(--line-2); border-radius: 999px; padding: 0.08rem 0.5rem; color: var(--text-2); }
 .rci-badge--fixture { color: var(--text-3); }
+.rci-badge--live { color: #22c55e; border-color: #22c55e; }
+
+/* data-source toggle + live-empty state */
+.rci-source { display: flex; align-items: center; gap: 0.5rem; margin: 0.8rem 0 0.2rem; flex-wrap: wrap; }
+.rci-src { background: var(--surface); border: 1px solid var(--line); color: var(--text-2); border-radius: 8px; padding: 0.3rem 0.7rem; font-size: 0.8rem; cursor: pointer; display: inline-flex; align-items: center; gap: 0.4rem; }
+.rci-src.on { color: var(--text); border-color: var(--accent); background: var(--accent-soft); }
+.rci-src:disabled { opacity: 0.45; cursor: not-allowed; }
+.rci-src-n { font-size: 0.62rem; background: var(--surface-2); border-radius: 999px; padding: 0.02rem 0.4rem; color: var(--text-2); }
+.rci-src-hint { font-size: 0.74rem; }
+.rci-empty { background: var(--surface); border: 1px dashed var(--line-2); border-radius: 10px; padding: 1rem 1.1rem; color: var(--text-2); font-size: 0.86rem; line-height: 1.5; margin-top: 0.8rem; }
+.rci-link { background: none; border: none; color: var(--accent); cursor: pointer; padding: 0; font: inherit; text-decoration: underline; }
+.rci-tag-prov-mark { font-size: 0.54rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--amber, #d9a63a); border: 1px solid currentColor; border-radius: 4px; padding: 0 0.25rem; }
 .rci-lede { color: var(--text-2); font-size: 0.9rem; line-height: 1.5; max-width: 72ch; margin: 0.6rem 0 0.9rem; }
 .rci-lede b { color: var(--text); font-weight: 600; }
 .mono { font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, monospace; }


### PR DESCRIPTION
## What

Augments the Reasoning Chain Inspector shipped in **#516** (build-on, not rebuild). The inspector now binds to the **live Noetica conversation source** so it inspects the *real active chain per selected turn*, while the three seed fixtures remain as a demo/offline mode. The governed `scoreVariants` pipeline is untouched.

Route: `/noetica/reasoning-chain`. Scope stays within `src/features/reasoning-chain/`, `ReasoningChainInspector.vue`, and the two new modules.

## Adapter contract (ChatTurn → inspector Example)

`src/features/reasoning-chain/chatTurnAdapter.ts` maps a live `useNoeticaChat` `ChatTurn` onto the **same `Example` shape `examples.ts` produces**:

| Inspector stage | Sourced from |
|---|---|
| `question` | the user turn that produced the assistant turn |
| **tokens** (annotation tree) | ACTION head (`intentName` / `plan.skill` / `plan.capability`), then `grounding.terms` as ENTITY concepts and `grounding.topics` as CONTEXT concepts (plan step labels stand in when grounding is empty) |
| **variants** | ONE candidate plan built from `plan.steps` (`executor = capability:stepId`, weight from step status). No synthetic ties invented — a single real plan yields a single variant |
| **scoring** | `requestedCore` / `declaredCanonicalPath` derived from the plan's concept order; `ambient` empty — fed **verbatim** to `scoreVariants` |
| **execution** | `judgment.verdict` → `resolved` (`grounded`) / `gap` (`speculative`, `contradiction`, error); `content` is the response |

`liveChainsFromTurns()` pairs each finalized (non-streaming) assistant turn with its preceding question. The adapter is pure and resolver-injected — no store/network coupling — so it is unit-testable in isolation. No `any` across the boundary.

## Label resolution (live) + fallback

`src/features/reasoning-chain/conceptResolver.ts` sources concept **LABELS** from the live learned surfaces:
- the **living ontology** (`stores/ontology.ts`) — the schema-on-the-fly loop that *induces* concept classes / relation predicates / topics from the corpus (the learned label source), plus
- the governed **KE type registry** (`features/knowledge-studio/fixture.ts` entity/relation types).

KINDs are **not** resolved here — they stay bound to `regis-entity-graph#22` via `kindVocabulary.ts`. On a resolution **miss**, `resolveConceptLabel()` falls back to the **KIND itself** (a provisional marker, surfaced with a `prov` chip) — it never crashes and never fabricates a governed label. `TokenConcept` gains an optional `provisional` flag (fixtures never set it).

## UI

Live/Demo source toggle. Defaults to **live** when a chain exists, else **demo**. With no live turn the route still renders (empty state + demo fallback). The selected turn drives the four stages and the cockpit surface context. The `scoreVariants` tie→margin collapse behavior is unchanged (only shows when a real tie exists — live single-plan turns don't fabricate one).

## Tests

- `reasoningChainLiveAdapter.test.ts` — the ChatTurn→Example transform, execution-status mapping, plan→variant, the produced variant feeding the unchanged scorer, `liveChainsFromTurns` pairing, and **live-label resolution with a mocked resolver** (resolved wins; miss falls back to KIND).
- `reasoningChainConceptResolver.test.ts` — the registry resolver over the induced ontology + governed KE registry, and `useConceptResolver` bound to the live ontology store.

Local: `typecheck` clean, **603 tests pass** (111 files), `build` succeeds.

## Follow-up

Filed for @mdheller: the KE-workbench durable authorship contract is still the seal point for authored concepts (unsigned in-memory ledger today); wiring the inspector's live-label resolution to that contract when it lands.