### PR TITLE
feat(noetica): rewire Reasoning Chain Inspector KE authoring onto the durable KE-workbench contract

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/keWorkbench.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/keWorkbench.test.ts
@@ -1,0 +1,81 @@
+// The durable KE-workbench contract: authored assets are versioned + receipted,
+// receipts are honestly sealed (never fabricated crypto), human overrides
+// supersede while the ledger retains the prior, and the current registries reuse
+// the Knowledge Studio KE-contract shapes (consume-not-fork).
+
+import { describe, expect, it } from 'vitest';
+import { createKeWorkbench, createPromotionGate } from '../features/knowledge-studio/keWorkbench';
+import {
+  promoteConceptToDictionaryTerm, overrideConcept, defineRelationType,
+} from '../features/reasoning-chain/keAuthorship';
+
+const author = { author: 'charles.peterson@socioprophet.ai', ts: '2026-08-03T00:00:00.000Z' };
+
+describe('KE-workbench durable contract', () => {
+  it('the promotion gate seals an HONEST receipt — unsigned, no fabricated crypto', () => {
+    const gate = createPromotionGate();
+    const receipt = gate.seal({ term: ':OrgUnit', version: 'v1-draft', provenanceClass: 'human_authored' });
+    expect(receipt).toContain('unsigned');
+    // Never fabricate a signed cryptographic receipt.
+    expect(receipt).not.toContain('sha256:');
+    expect(receipt).not.toMatch(/\(signed\)/);
+  });
+
+  it('appends authored assets into the KE registries as newest-first ledger entries', () => {
+    const ke = createKeWorkbench();
+    promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORGANIZATION', author, ke);
+    defineRelationType(':RollsUpTo', 'RELATION', 'OrgUnit', 'Organization', author, ke);
+
+    expect(ke.ledger.value).toHaveLength(2);
+    expect(ke.ledger.value[0].term).toBe(':RollsUpTo'); // newest-first
+    // Reuses the KE-contract shapes, not a forked model.
+    expect(ke.dictionaries.value).toHaveLength(1);
+    expect(ke.dictionaries.value[0].mappedType).toBe('ORGANIZATION');
+    expect(ke.dictionaries.value[0].authored).toBe(true);
+    expect(ke.relationTypes.value[0].subject).toBe('OrgUnit');
+  });
+
+  it('every appended asset is learned + versioned, never a match rule', () => {
+    const ke = createKeWorkbench();
+    promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORGANIZATION', author, ke);
+    const rec = ke.ledger.value[0];
+    expect(rec.learned).toBe(true);
+    expect(rec.matchRule).toBe(false);
+    expect(rec.governed).toBe(true);
+    expect(rec.version).toBeTruthy();
+    expect(rec.receipt).toContain('unsigned');
+    expect(rec.origin).toBe('reasoning-chain-inspector');
+  });
+
+  it('a superseding authorship shows the latest in the registry while the ledger retains every version', () => {
+    const ke = createKeWorkbench();
+    // author a term, then re-author the same term with a corrected mapping.
+    promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORGANIZATION', author, ke);
+    promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORG_UNIT', author, ke);
+
+    // registry surfaces only the latest (superseding) asset for the term.
+    expect(ke.dictionaries.value).toHaveLength(1);
+    expect(ke.dictionaries.value[0].mappedType).toBe('ORG_UNIT');
+    // the ledger keeps BOTH versions — nothing is discarded.
+    expect(ke.ledger.value.filter((r) => r.term === ':OrgUnit')).toHaveLength(2);
+  });
+
+  it('a human override is human-authored and retains the prior learned value as a version', () => {
+    const ke = createKeWorkbench();
+    const ev = overrideConcept(':OrgUnit', 'ENTITY_TYPE', ':Own', author, ke);
+    expect(ev.action).toBe('overwrite');
+    expect(ev.provenanceClass).toBe('human_authored');
+    expect(ev.priorVersion).toEqual({ value: ':Own', provenanceClass: 'learned', version: 'learned-v0' });
+    // the override is recorded durably in the shared ledger.
+    expect(ke.ledger.value[0].id).toBe(ev.id);
+  });
+
+  it('clear() empties the durable ledger', () => {
+    const ke = createKeWorkbench();
+    promoteConceptToDictionaryTerm(':A', 'ENTITY_TYPE', 'ORG', author, ke);
+    expect(ke.ledger.value).toHaveLength(1);
+    ke.clear();
+    expect(ke.ledger.value).toHaveLength(0);
+    expect(ke.dictionaries.value).toHaveLength(0);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/reasoningChainAuthorship.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/reasoningChainAuthorship.test.ts
@@ -9,6 +9,7 @@ import {
   defineRelationType,
   useAuthorshipLedger,
 } from '../features/reasoning-chain/keAuthorship';
+import { createKeWorkbench } from '../features/knowledge-studio/keWorkbench';
 
 const author = { author: 'charles.peterson@socioprophet.ai', ts: '2026-08-03T00:00:00.000Z' };
 
@@ -47,5 +48,17 @@ describe('KE authorship', () => {
     ledger.record(b);
     expect(ledger.events.value[0].term).toBe(':B');
     expect(ledger.events.value.length).toBe(2);
+  });
+
+  it('handing the workbench in appends durably into the KE loop (consume-not-fork)', () => {
+    const ke = createKeWorkbench();
+    const { event } = promoteConceptToDictionaryTerm(':OrgUnit', 'ENTITY_TYPE', 'ORGANIZATION', author, ke);
+    // the same record is now a durable, versioned entry AND a KE-contract dictionary asset.
+    expect(ke.ledger.value[0].id).toBe(event.id);
+    expect(ke.dictionaries.value[0].authored).toBe(true);
+    expect(ke.dictionaries.value[0].mappedType).toBe('ORGANIZATION');
+    // receipt is sealed by the promotion gate — honest, unsigned, no fabricated crypto.
+    expect(event.receipt).toContain('unsigned');
+    expect(event.receipt).not.toContain('sha256:');
   });
 });

--- a/socioprophet-web/client-vue/src/features/knowledge-studio/KE_WORKBENCH_CONTRACT.md
+++ b/socioprophet-web/client-vue/src/features/knowledge-studio/KE_WORKBENCH_CONTRACT.md
@@ -1,0 +1,115 @@
+# KE-workbench durable authorship contract — handoff
+
+**Status:** consumer-side interface pinned by the Reasoning Chain Inspector
+(`feat/reasoning-chain-inspector`, PR #516 + the rewire on `claude/infallible-haibt-6a4338`).
+The durable store is **owned by the KE-workbench agent** and not yet landed. This
+doc is the seam both sides converge on so the durable store swaps in behind the
+same interface **with no caller change**.
+
+Source of truth for the types: [`keWorkbench.ts`](./keWorkbench.ts). This file is
+the prose spec + the decisions the two sides still need to agree on.
+
+---
+
+## Who consumes it
+
+- **Writer** — `features/reasoning-chain/keAuthorship.ts` (the five hooks:
+  `buildAuthorshipEvent`, `promoteConceptToDictionaryTerm`, `defineEntityType`,
+  `defineRelationType`, `overrideConcept`). Each builds a contract record and
+  calls `ke.append(record)`.
+- **Reader** — `pages/KnowledgeStudio.vue` reads `ke.dictionaries`,
+  `ke.entityTypes`, `ke.relationTypes`, `ke.ledger` and merges authored assets
+  ahead of the seeded registries as develop-stage inputs.
+- **Bind point** — both call `useKeWorkbench()`, a session-scoped reactive
+  singleton. **This is the exact function the durable store replaces.**
+
+## The interface (do not fork)
+
+```ts
+// Reuses the Knowledge Studio KE-contract shapes — NOT a parallel data model.
+type AuthoredShape = Dictionary | EntityType | RelationType; // from ./fixture
+
+interface AuthoredAsset {
+  id: string;
+  action: 'add' | 'overwrite' | 'annotate' | 'define';
+  target: 'entity_type' | 'relation_type' | 'dictionary_term' | 'rule';
+  term: string;                 // e.g. ':OrgUnit'
+  kind: string;                 // governed KIND (regis-entity-graph#22)
+  mappedType?: string;          // KE type it maps to, e.g. 'ORGANIZATION'
+  author: string;
+  ts: string;                   // ISO-8601
+  version: string;
+  priorVersion?: { value: string; provenanceClass: ProvenanceClass; version: string };
+  provenanceClass: 'learned' | 'human_authored';
+  governed: true; learned: true; matchRule: false;   // learn, don't match
+  origin: string;               // 'reasoning-chain-inspector'
+  receipt: string;              // sealed by the promotion gate; honest + unsigned
+  note?: string;
+  asset?: AuthoredShape;        // the KE-contract shape this authored
+}
+
+interface PromotionGate {
+  seal(input: { term: string; version: string; provenanceClass: ProvenanceClass }): string;
+}
+
+interface KeWorkbench {
+  ledger: Ref<AuthoredAsset[]>;            // full version history, newest-first
+  dictionaries: ComputedRef<Dictionary[]>; // latest per term (supersede applied)
+  entityTypes: ComputedRef<EntityType[]>;
+  relationTypes: ComputedRef<RelationType[]>;
+  gate: PromotionGate;
+  append(record: AuthoredAsset): AuthoredAsset;
+  clear(): void;
+}
+```
+
+## Invariants the durable store MUST preserve
+
+1. **Learn, don't match.** Every appended asset is `learned: true`,
+   `matchRule: false`, and carries a `version`. Nothing authored here is a static
+   match rule.
+2. **Human overrides supersede; the prior is retained.** `append` never mutates
+   or deletes a prior record. The current registries (`dictionaries`/
+   `entityTypes`/`relationTypes`) surface the **latest asset-bearing record per
+   `term`**; `ledger` retains **every** version. `priorVersion` on an override
+   carries the superseded learned value.
+3. **Honest receipts.** `gate.seal()` returns a governance seal that is
+   **explicitly unsigned** (the reference impl returns a string containing
+   `unsigned (no crypto provenance)`). It **must never** fabricate a
+   `sha256:…(signed)`-style receipt. Only a real signer (the
+   model-governance-ledger) may mint a signed receipt, and only later.
+4. **Provenance class travels with the record** and is rendered on the tag and in
+   the ledger (`learned` ◐ vs `human_authored` ✎).
+
+## Decisions the two sides need to agree on
+
+The reference impl (`createKeWorkbench`) is a session-scoped reactive singleton.
+The durable store should match the interface above; these are the open points:
+
+1. **Scope / keying.** Per-project? Per-estate? The singleton is currently
+   global-per-session. If the durable store is project-scoped, `useKeWorkbench()`
+   should take/derive the project id (the active-project store already exists).
+2. **`id` scheme.** Reference uses `${target}-${seq}` (session-local monotonic).
+   The durable store should mint stable, collision-free ids (uuid / content hash).
+   Consumers treat `id` as opaque.
+3. **Supersede → durable rows.** Reference derives "latest per term" by scanning a
+   newest-first array. A durable store may prefer an explicit version chain
+   (`supersedes: id`). Either is fine **as long as** the `dictionaries` /
+   `entityTypes` / `relationTypes` views still return latest-per-term and `ledger`
+   still exposes the full history newest-first.
+4. **Receipt sealing authority.** Confirm the gate stays honestly-unsigned at
+   author time and that signing is a **separate, later** promotion step owned by
+   the governance ledger — not the gate.
+5. **Reactivity contract.** Consumers rely on Vue `Ref`/`ComputedRef`
+   reactivity. A remote-backed store must expose reactive refs (e.g. hydrate into
+   refs on load + on push) so `KnowledgeStudio.vue` updates live.
+
+## Swap-in checklist (no caller change)
+
+- [ ] Implement `KeWorkbench` (or make `createKeWorkbench` delegate to the store).
+- [ ] Keep `useKeWorkbench()` as the single bind point; return the durable-backed
+      instance.
+- [ ] Preserve the four invariants above (covered by
+      `src/__tests__/keWorkbench.test.ts` — keep it green).
+- [ ] Confirm `AuthoredAsset` / `PromotionGate` field names unchanged, or land the
+      rename in the same PR that updates `keAuthorship.ts`.

--- a/socioprophet-web/client-vue/src/features/knowledge-studio/fixture.ts
+++ b/socioprophet-web/client-vue/src/features/knowledge-studio/fixture.ts
@@ -111,6 +111,10 @@ export type EntityType = {
   /** Whether values of this type are observed or modelled — WKS cannot express this. */
   valueKind: 'observed' | 'derived';
   roles: string;
+  /** Authored into the KE loop (e.g. from the Reasoning Chain Inspector), not seeded. */
+  authored?: boolean;
+  /** Honest receipt from the promotion gate — unsigned until a real signer seals it. */
+  receipt?: string;
 };
 
 export const entityTypes: EntityType[] = [
@@ -130,6 +134,10 @@ export type RelationType = {
   object: string;
   instances: number;
   f1: number | null;
+  /** Authored into the KE loop (e.g. from the Reasoning Chain Inspector), not seeded. */
+  authored?: boolean;
+  /** Honest receipt from the promotion gate — unsigned until a real signer seals it. */
+  receipt?: string;
 };
 
 export const relationTypes: RelationType[] = [
@@ -147,6 +155,10 @@ export type Dictionary = {
   source: string;
   /** Licence provenance on the term list — a lawful-learning requirement. */
   licence: string;
+  /** Authored into the KE loop (e.g. from the Reasoning Chain Inspector), not seeded. */
+  authored?: boolean;
+  /** Honest receipt from the promotion gate — unsigned until a real signer seals it. */
+  receipt?: string;
 };
 
 export const dictionaries: Dictionary[] = [

--- a/socioprophet-web/client-vue/src/features/knowledge-studio/keWorkbench.ts
+++ b/socioprophet-web/client-vue/src/features/knowledge-studio/keWorkbench.ts
@@ -11,6 +11,10 @@
 // store swaps in behind this same interface. The reactive singleton below is the
 // session-durable stand-in until that store lands (tracked follow-up @mdheller).
 //
+// INTERFACE HANDOFF: the seam, invariants, and the decisions the durable store
+// must converge on are pinned in ./KE_WORKBENCH_CONTRACT.md. Change the shapes
+// here and there together — this file is the source of truth for the types.
+//
 // Estate rules honored (see also features/reasoning-chain/keAuthorship.ts):
 //   - "learn, don't match dictionaries": every appended asset is LEARNED +
 //     VERSIONED, never a static match rule (`matchRule: false`, `learned: true`).

--- a/socioprophet-web/client-vue/src/features/knowledge-studio/keWorkbench.ts
+++ b/socioprophet-web/client-vue/src/features/knowledge-studio/keWorkbench.ts
@@ -1,0 +1,156 @@
+// Durable KE-workbench authorship contract.
+//
+// This is the seam the Reasoning Chain Inspector writes THROUGH and the Knowledge
+// Studio loop reads FROM. It replaces the inspector's private in-memory unsigned
+// ledger with a single, session-durable, versioned + receipted append surface.
+//
+// CONSUME-NOT-FORK: an authored asset IS a Knowledge Studio KE-contract shape
+// (EntityType | RelationType | Dictionary from ./fixture) — there is no parallel
+// authorship data model. This module owns the *append surface*, the *version
+// chain*, and the *promotion gate*; the concurrent KE-workbench agent's durable
+// store swaps in behind this same interface. The reactive singleton below is the
+// session-durable stand-in until that store lands (tracked follow-up @mdheller).
+//
+// Estate rules honored (see also features/reasoning-chain/keAuthorship.ts):
+//   - "learn, don't match dictionaries": every appended asset is LEARNED +
+//     VERSIONED, never a static match rule (`matchRule: false`, `learned: true`).
+//   - Human overrides SUPERSEDE the learned value; the prior is retained as a
+//     version — the current registries surface the latest, the ledger keeps all.
+//   - No fabricated cryptographic provenance: the promotion gate seals an HONEST
+//     receipt (a governance seal that states, in the clear, that it is unsigned).
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+import type { Dictionary, EntityType, RelationType } from './fixture';
+
+/** A learned label vs a human-authored override. Human overrides supersede. */
+export type ProvenanceClass = 'learned' | 'human_authored';
+
+export type AuthorshipAction = 'add' | 'overwrite' | 'annotate' | 'define';
+export type AuthorshipTarget = 'entity_type' | 'relation_type' | 'dictionary_term' | 'rule';
+
+/** The value a human override supersedes — retained, never discarded. */
+export interface AuthorshipVersionRef {
+  value: string;
+  provenanceClass: ProvenanceClass;
+  version: string;
+}
+
+/** The KE-contract shape an authored asset carries (never a forked shape). */
+export type AuthoredShape = Dictionary | EntityType | RelationType;
+
+/**
+ * A durable, versioned, receipted authorship record. The `asset` is a KE-contract
+ * shape; the record is the governance envelope the KE contract wraps around it.
+ */
+export interface AuthoredAsset {
+  id: string;
+  action: AuthorshipAction;
+  target: AuthorshipTarget;
+  /** The concept/term being authored, e.g. ':OrgUnit'. */
+  term: string;
+  /** Governed KIND the term is typed as (regis-entity-graph#22 vocabulary). */
+  kind: string;
+  /** For dictionary terms / relations: the KE type it maps to (e.g. 'ORGANIZATION'). */
+  mappedType?: string;
+  author: string;
+  ts: string;
+  version: string;
+  /** Human authorship supersedes learned; the prior is retained here. */
+  priorVersion?: AuthorshipVersionRef;
+  provenanceClass: ProvenanceClass;
+  /** Governance flags — a term is LEARNED + versioned, never a match rule. */
+  governed: true;
+  learned: true;
+  matchRule: false;
+  /** Where the authorship originated (e.g. 'reasoning-chain-inspector'). */
+  origin: string;
+  /** Honest receipt sealed by the promotion gate — unsigned, no crypto fabricated. */
+  receipt: string;
+  /** Free-text rationale captured from the author. */
+  note?: string;
+  /** The KE-contract shape this authored, when the action produced one. */
+  asset?: AuthoredShape;
+}
+
+/**
+ * The promotion gate that seals an authored draft. It is HONEST: it records a
+ * governance seal and NEVER fabricates cryptographic provenance (no fake
+ * `sha256:…(signed)`). Sealed receipts state, in the clear, that they are unsigned
+ * — a real signer (the model-governance ledger) is the only thing that may sign.
+ */
+export interface PromotionGate {
+  seal(input: { term: string; version: string; provenanceClass: ProvenanceClass }): string;
+}
+
+/** Build an honest promotion gate with a monotonic seal counter. */
+export function createPromotionGate(): PromotionGate {
+  let seq = 0;
+  return {
+    seal({ version }) {
+      seq += 1;
+      // Honest by construction: sealed by the gate, but explicitly unsigned. A
+      // signed receipt can only be minted by a real signer, never fabricated here.
+      return `promotion-gate seal ke-wb#${seq} · ${version} · unsigned (no crypto provenance)`;
+    },
+  };
+}
+
+/** The append surface + read views both surfaces share. */
+export interface KeWorkbench {
+  /** Full versioned authorship ledger, newest-first. Durable within the session. */
+  ledger: Ref<AuthoredAsset[]>;
+  /** Current authored dictionaries — latest per term (supersede applied). */
+  dictionaries: ComputedRef<Dictionary[]>;
+  /** Current authored entity types — latest per term. */
+  entityTypes: ComputedRef<EntityType[]>;
+  /** Current authored relation types — latest per term. */
+  relationTypes: ComputedRef<RelationType[]>;
+  gate: PromotionGate;
+  /** Append a record (optionally with its KE-contract asset) durably. */
+  append(record: AuthoredAsset): AuthoredAsset;
+  clear(): void;
+}
+
+/** Latest asset per term for a target — newest-first ledger means first wins. */
+function latest<T extends AuthoredShape>(ledger: AuthoredAsset[], target: AuthorshipTarget): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const r of ledger) {
+    if (r.target !== target || !r.asset) continue;
+    if (seen.has(r.term)) continue; // an earlier (older) version is superseded
+    seen.add(r.term);
+    out.push(r.asset as T);
+  }
+  return out;
+}
+
+/**
+ * Create a fresh KE-workbench instance. Use `useKeWorkbench()` for the shared
+ * singleton that binds the inspector and the Knowledge Studio loop together.
+ */
+export function createKeWorkbench(): KeWorkbench {
+  const ledger = ref<AuthoredAsset[]>([]);
+  return {
+    ledger,
+    dictionaries: computed(() => latest<Dictionary>(ledger.value, 'dictionary_term')),
+    entityTypes: computed(() => latest<EntityType>(ledger.value, 'entity_type')),
+    relationTypes: computed(() => latest<RelationType>(ledger.value, 'relation_type')),
+    gate: createPromotionGate(),
+    append(record) {
+      ledger.value = [record, ...ledger.value];
+      return record;
+    },
+    clear() {
+      ledger.value = [];
+    },
+  };
+}
+
+// Shared, session-durable singleton — the bind point between the Reasoning Chain
+// Inspector (writes) and the Knowledge Studio loop (reads). A real durable store
+// replaces this behind the KeWorkbench interface with no caller change.
+let singleton: KeWorkbench | null = null;
+export function useKeWorkbench(): KeWorkbench {
+  if (!singleton) singleton = createKeWorkbench();
+  return singleton;
+}

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/keAuthorship.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/keAuthorship.ts
@@ -2,65 +2,50 @@
 //
 // The inspector is not read-only: from the annotation view a user can add /
 // overwrite / annotate / define entity types, relation types, dictionary terms
-// and rules. Each action emits a GOVERNED authorship event — versioned,
-// author-attributed, and receipted — into the KE/dictionary workbench contract.
+// and rules. Each action emits a GOVERNED authorship record — versioned,
+// author-attributed, and receipted — into the durable KE-workbench contract.
 //
 // Estate rules honored:
 //   - "learn, don't match dictionaries": a promoted term becomes a VERSIONED,
 //     provenance-carrying dictionary entry (learned + governed), never a static
-//     match rule. Every event carries `matchRule: false` + `learned: true`.
+//     match rule. Every record carries `matchRule: false` + `learned: true`.
 //   - Human overrides SUPERSEDE the learned value; the prior is retained as a
 //     version (`priorVersion`), never discarded.
 //   - No fabricated cryptographic provenance (AGENTS.md): new human authorship is
-//     honestly UNSIGNED — the promotion gate / KE workbench seals it later.
+//     honestly UNSIGNED — the promotion gate seals an honest receipt; only a real
+//     signer may ever sign.
 //
-// CONSUME-NOT-FORK: the event shapes mirror the live Knowledge Studio KE contract
-// (features/knowledge-studio/fixture.ts: EntityType, RelationType, Dictionary,
-// Version). The concurrent KE-workbench agent owns the durable authorship
-// contract; this module is the local emit surface + the exact hooks to rewire to
-// that contract when it lands (tracked follow-up @mdheller). No live/shared write
-// happens here — events are held in an in-memory ledger and surfaced in the UI.
+// CONSUME-NOT-FORK: this module holds NO authorship data model of its own. The
+// record shape, the version chain, the promotion gate and the durable append
+// surface are all owned by the KE-workbench contract
+// (features/knowledge-studio/keWorkbench.ts), which in turn reuses the Knowledge
+// Studio KE-contract shapes (EntityType, RelationType, Dictionary). This file is
+// the emit surface: the five hooks below build a contract record and, when handed
+// the workbench, append it durably so it becomes an input to the Knowledge Studio
+// loop. The concurrent KE-workbench agent's durable store swaps in behind the
+// same interface with no change here.
 
-import { ref, type Ref } from 'vue';
 import type { Dictionary, EntityType, RelationType } from '../knowledge-studio/fixture';
-import type { AnnotationKind, ProvenanceClass } from './kindVocabulary';
+import {
+  createKeWorkbench, createPromotionGate, type AuthoredAsset, type AuthorshipAction,
+  type AuthorshipTarget, type AuthorshipVersionRef, type KeWorkbench, type PromotionGate,
+} from '../knowledge-studio/keWorkbench';
+import type { AnnotationKind } from './kindVocabulary';
 
-export type AuthorshipAction = 'add' | 'overwrite' | 'annotate' | 'define';
-export type AuthorshipTarget = 'entity_type' | 'relation_type' | 'dictionary_term' | 'rule';
+// Re-export the contract's authorship types so existing consumers keep importing
+// them from here (the reasoning-chain emit surface) without knowing where the
+// durable contract lives.
+export type {
+  AuthoredAsset, AuthorshipAction, AuthorshipTarget, AuthorshipVersionRef, ProvenanceClass,
+} from '../knowledge-studio/keWorkbench';
 
-export interface AuthorshipVersionRef {
-  value: string;
-  provenanceClass: ProvenanceClass;
-  version: string;
-}
+/** An authorship record is a KE-workbench contract record — not a forked shape. */
+export type AuthorshipEvent = AuthoredAsset;
 
-export interface AuthorshipEvent {
-  id: string;
-  action: AuthorshipAction;
-  target: AuthorshipTarget;
-  /** The concept/term being authored, e.g. ':OrgUnit'. */
-  term: string;
-  /** Governed KIND the term is typed as. */
-  kind: AnnotationKind;
-  /** For dictionary terms / relations: the KE type it maps to (e.g. 'ORGANIZATION'). */
-  mappedType?: string;
-  author: string;
-  ts: string;
-  version: string;
-  /** Human authorship supersedes learned; the prior is retained here. */
-  priorVersion?: AuthorshipVersionRef;
-  provenanceClass: ProvenanceClass;
-  /** Governance flags — a term is LEARNED + versioned, never a match rule. */
-  governed: true;
-  learned: true;
-  matchRule: false;
-  /** Honest receipt: unsigned until the KE workbench / promotion gate seals it. */
-  receipt: string;
-  /** Free-text rationale captured from the author (annotate action). */
-  note?: string;
-}
-
-const UNSIGNED = 'unsigned — pending KE workbench seal';
+// A fallback gate for PURE builds (no workbench handed in). It seals an honest,
+// unsigned receipt exactly like the durable one — it simply isn't wired to a
+// durable ledger. Durable callers pass `ke.gate` instead (see the hooks below).
+const fallbackGate: PromotionGate = createPromotionGate();
 
 let seq = 0;
 function nextId(prefix: string): string {
@@ -77,7 +62,10 @@ export interface AuthorInput {
   prior?: AuthorshipVersionRef;
 }
 
-/** Build a governed authorship event (pure — testable; no side effects). */
+/**
+ * Build a governed authorship record (pure — testable; no side effects). The
+ * receipt is sealed by the promotion gate; honest and unsigned by construction.
+ */
 export function buildAuthorshipEvent(
   action: AuthorshipAction,
   target: AuthorshipTarget,
@@ -85,7 +73,9 @@ export function buildAuthorshipEvent(
   kind: AnnotationKind,
   input: AuthorInput,
   mappedType?: string,
+  gate: PromotionGate = fallbackGate,
 ): AuthorshipEvent {
+  const version = 'v1-draft';
   return {
     id: nextId(target),
     action,
@@ -95,7 +85,7 @@ export function buildAuthorshipEvent(
     mappedType,
     author: input.author,
     ts: input.ts ?? new Date().toISOString(),
-    version: 'v1-draft',
+    version,
     priorVersion: input.prior,
     // Any authorship action taken by a person is human-authored provenance; a
     // prior learned value (if superseded) is retained in `priorVersion`.
@@ -103,74 +93,113 @@ export function buildAuthorshipEvent(
     governed: true,
     learned: true,
     matchRule: false,
-    receipt: UNSIGNED,
+    origin: 'reasoning-chain-inspector',
+    receipt: gate.seal({ term, version, provenanceClass: 'human_authored' }),
     note: input.note,
   };
 }
 
+/** Append a built record to the workbench if one is provided, then return it. */
+function emit(event: AuthorshipEvent, ke?: KeWorkbench): AuthorshipEvent {
+  ke?.append(event);
+  return event;
+}
+
 /**
- * Promote a learned annotation concept into a versioned dictionary term. Emits a
- * Dictionary-shaped draft (mirroring the KE contract) plus the authorship event.
- * The dictionary is a governed + learned + versioned term set, NOT a match rule.
+ * Promote a learned annotation concept into a versioned dictionary term. Builds a
+ * Dictionary-shaped asset (the KE contract) plus its authorship record, and — when
+ * a workbench is handed in — appends it durably so it enters the Knowledge Studio
+ * loop. The dictionary is a governed + learned + versioned term set, NOT a match rule.
  */
 export function promoteConceptToDictionaryTerm(
   concept: string,
   kind: AnnotationKind,
   mappedType: string,
   input: AuthorInput,
+  ke?: KeWorkbench,
 ): { event: AuthorshipEvent; draft: Dictionary } {
-  const event = buildAuthorshipEvent('add', 'dictionary_term', concept, kind, input, mappedType);
+  const event = buildAuthorshipEvent('add', 'dictionary_term', concept, kind, input, mappedType, ke?.gate);
   const draft: Dictionary = {
     name: `${concept} (authored)`,
     terms: 1,
     mappedType,
     source: `reasoning-chain-inspector · ${input.author}`,
     licence: 'owned',
+    authored: true,
+    receipt: event.receipt,
   };
-  return { event, draft };
+  event.asset = draft;
+  return { event: emit(event, ke), draft };
 }
 
 /** Define a new entity type from an annotation (KE Assets → Entity Types). */
-export function defineEntityType(concept: string, kind: AnnotationKind, input: AuthorInput): { event: AuthorshipEvent; draft: EntityType } {
-  const event = buildAuthorshipEvent('define', 'entity_type', concept, kind, input);
-  const draft: EntityType = { name: concept, color: 'var(--accent)', mentions: 0, f1: null, valueKind: 'derived', roles: '' };
-  return { event, draft };
+export function defineEntityType(
+  concept: string,
+  kind: AnnotationKind,
+  input: AuthorInput,
+  ke?: KeWorkbench,
+): { event: AuthorshipEvent; draft: EntityType } {
+  const event = buildAuthorshipEvent('define', 'entity_type', concept, kind, input, undefined, ke?.gate);
+  const draft: EntityType = {
+    name: concept, color: 'var(--accent)', mentions: 0, f1: null, valueKind: 'derived', roles: '',
+    authored: true, receipt: event.receipt,
+  };
+  event.asset = draft;
+  return { event: emit(event, ke), draft };
 }
 
 /** Define a new relation type from an annotation (KE Assets → Relation Types). */
-export function defineRelationType(concept: string, kind: AnnotationKind, subject: string, object: string, input: AuthorInput): { event: AuthorshipEvent; draft: RelationType } {
-  const event = buildAuthorshipEvent('define', 'relation_type', concept, kind, input);
-  const draft: RelationType = { name: concept, subject, object, instances: 0, f1: null };
-  return { event, draft };
+export function defineRelationType(
+  concept: string,
+  kind: AnnotationKind,
+  subject: string,
+  object: string,
+  input: AuthorInput,
+  ke?: KeWorkbench,
+): { event: AuthorshipEvent; draft: RelationType } {
+  const event = buildAuthorshipEvent('define', 'relation_type', concept, kind, input, undefined, ke?.gate);
+  const draft: RelationType = {
+    name: concept, subject, object, instances: 0, f1: null, authored: true, receipt: event.receipt,
+  };
+  event.asset = draft;
+  return { event: emit(event, ke), draft };
 }
 
 /**
  * Overwrite a learned concept label with a human-authored value. The learned
- * value is retained as a prior version and the new event supersedes it.
+ * value is retained as a prior version and the new record supersedes it — in the
+ * workbench, the current registry surfaces the latest while the ledger keeps both.
  */
 export function overrideConcept(
   concept: string,
   kind: AnnotationKind,
   learnedPrior: string,
   input: Omit<AuthorInput, 'prior'>,
+  ke?: KeWorkbench,
 ): AuthorshipEvent {
-  return buildAuthorshipEvent('overwrite', 'dictionary_term', concept, kind, {
+  const event = buildAuthorshipEvent('overwrite', 'dictionary_term', concept, kind, {
     ...input,
     prior: { value: learnedPrior, provenanceClass: 'learned', version: 'learned-v0' },
-  });
+  }, undefined, ke?.gate);
+  return emit(event, ke);
 }
 
-/** In-memory authorship ledger for the inspector (surfaced in the UI). */
+/**
+ * Back-compat thin ledger. Now backed by a fresh KE-workbench instance so it
+ * shares the durable contract's shape and semantics. Prefer `useKeWorkbench()`
+ * (the shared singleton) when authored assets should reach the Knowledge Studio
+ * loop; this per-caller instance is isolated.
+ */
 export interface AuthorshipLedger {
-  events: Ref<AuthorshipEvent[]>;
+  events: KeWorkbench['ledger'];
   record: (e: AuthorshipEvent) => void;
   clear: () => void;
 }
 export function useAuthorshipLedger(): AuthorshipLedger {
-  const events = ref<AuthorshipEvent[]>([]);
+  const ke = createKeWorkbench();
   return {
-    events,
-    record: (e) => { events.value = [e, ...events.value]; },
-    clear: () => { events.value = []; },
+    events: ke.ledger,
+    record: (e) => { ke.append(e); },
+    clear: ke.clear,
   };
 }

--- a/socioprophet-web/client-vue/src/features/reasoning-chain/kindVocabulary.ts
+++ b/socioprophet-web/client-vue/src/features/reasoning-chain/kindVocabulary.ts
@@ -112,8 +112,11 @@ export function paletteForConcept(cat: SourceCat, label: string): KindPalette {
 
 // Provenance class shown on every concept tag: a learned label vs a
 // human-authored override. Human overrides supersede the learned value; the
-// prior is retained as a version (see keAuthorship.ts).
-export type ProvenanceClass = 'learned' | 'human_authored';
+// prior is retained as a version (see keAuthorship.ts). The type is owned by the
+// KE-workbench contract (single source of truth) and re-exported here for the
+// annotation layer — CONSUME-NOT-FORK.
+export type { ProvenanceClass } from '../knowledge-studio/keWorkbench';
+import type { ProvenanceClass } from '../knowledge-studio/keWorkbench';
 export const PROVENANCE_META: Record<ProvenanceClass, { glyph: string; label: string }> = {
   learned: { glyph: '◐', label: 'learned' },
   human_authored: { glyph: '✎', label: 'human-authored' },

--- a/socioprophet-web/client-vue/src/pages/KnowledgeStudio.vue
+++ b/socioprophet-web/client-vue/src/pages/KnowledgeStudio.vue
@@ -13,6 +13,7 @@ import {
   dictionaries, regexes, rules, annotationTasks, performance, perfGateThreshold,
   versions, beyondParity,
 } from '../features/knowledge-studio/fixture';
+import { useKeWorkbench } from '../features/knowledge-studio/keWorkbench';
 
 const active = ref('documents');
 const docTab = ref<'sets' | 'annotation' | 'all'>('sets');
@@ -30,6 +31,16 @@ const failing = computed(() => performance.filter((p) => p.gate === 'fail'));
 const macroF1 = computed(
   () => performance.reduce((s, p) => s + p.f1, 0) / performance.length,
 );
+
+// ---- authored inputs from the Reasoning Chain Inspector (durable KE-workbench) ----
+// Assets authored in the inspector write through the shared workbench contract and
+// enter the loop here as develop-stage inputs — authored ahead of the seeded
+// registries so they read first. Learned + versioned, never match rules.
+const ke = useKeWorkbench();
+const authoredCount = computed(() => ke.ledger.value.length);
+const allEntityTypes = computed(() => [...ke.entityTypes.value, ...entityTypes]);
+const allRelationTypes = computed(() => [...ke.relationTypes.value, ...relationTypes]);
+const allDictionaries = computed(() => [...ke.dictionaries.value, ...dictionaries]);
 </script>
 
 <template>
@@ -68,6 +79,17 @@ const macroF1 = computed(
           <span class="ks-stage-owner">{{ s.owner }}</span>
         </li>
       </ol>
+    </section>
+
+    <!-- AUTHORED INPUTS (from the Reasoning Chain Inspector, via the durable KE-workbench) -->
+    <section v-if="authoredCount" class="ks-authored" aria-label="Authored inputs from the Reasoning Chain Inspector">
+      <span class="ks-authored-dot" aria-hidden="true" />
+      <p class="ks-authored-text">
+        <b>{{ authoredCount }}</b> annotation{{ authoredCount === 1 ? '' : 's' }} authored from the
+        <b>Reasoning Chain Inspector</b> {{ authoredCount === 1 ? 'is' : 'are' }} queued as <b>develop-stage</b> inputs
+        via the durable KE-workbench contract — learned + versioned (never match rules); human overrides supersede the
+        learned value with the prior retained; receipts sealed by the promotion gate, honestly <b>unsigned</b>.
+      </p>
     </section>
 
     <!-- WORKSPACE -->
@@ -147,8 +169,11 @@ const macroF1 = computed(
             <table class="ks-table">
               <thead><tr><th>Type</th><th>Roles</th><th class="n">Mentions</th><th class="n">F1</th><th>Value kind</th></tr></thead>
               <tbody>
-                <tr v-for="e in entityTypes" :key="e.name">
-                  <td><span class="ks-swatch" :style="{ background: e.color }" aria-hidden="true" /><b class="ks-strong">{{ e.name }}</b></td>
+                <tr v-for="e in allEntityTypes" :key="e.name" :class="{ 'is-authored': e.authored }">
+                  <td>
+                    <span class="ks-swatch" :style="{ background: e.color }" aria-hidden="true" /><b class="ks-strong">{{ e.name }}</b>
+                    <span v-if="e.authored" class="ks-pill authored" :title="e.receipt">authored</span>
+                  </td>
                   <td class="ks-dim">{{ e.roles }}</td>
                   <td class="n">{{ e.mentions.toLocaleString() }}</td>
                   <td class="n" :class="e.f1 !== null && e.f1 < perfGateThreshold ? 'is-lowv' : ''">{{ e.f1 ?? '—' }}</td>
@@ -166,8 +191,11 @@ const macroF1 = computed(
             <table class="ks-table">
               <thead><tr><th>Relation</th><th>Subject</th><th>Object</th><th class="n">Instances</th><th class="n">F1</th></tr></thead>
               <tbody>
-                <tr v-for="r in relationTypes" :key="r.name">
-                  <td class="ks-strong">{{ r.name }}</td>
+                <tr v-for="r in allRelationTypes" :key="r.name" :class="{ 'is-authored': r.authored }">
+                  <td class="ks-strong">
+                    {{ r.name }}
+                    <span v-if="r.authored" class="ks-pill authored" :title="r.receipt">authored</span>
+                  </td>
                   <td class="ks-mono">{{ r.subject }}</td>
                   <td class="ks-mono">{{ r.object }}</td>
                   <td class="n">{{ r.instances.toLocaleString() }}</td>
@@ -188,8 +216,11 @@ const macroF1 = computed(
             <table class="ks-table">
               <thead><tr><th>Dictionary</th><th class="n">Terms</th><th>Maps to</th><th>Source</th><th>Licence</th></tr></thead>
               <tbody>
-                <tr v-for="d in dictionaries" :key="d.name" :class="{ 'is-bad': d.licence.startsWith('UNKNOWN') }">
-                  <td class="ks-strong">{{ d.name }}</td>
+                <tr v-for="d in allDictionaries" :key="d.name" :class="{ 'is-bad': d.licence.startsWith('UNKNOWN'), 'is-authored': d.authored }">
+                  <td class="ks-strong">
+                    {{ d.name }}
+                    <span v-if="d.authored" class="ks-pill authored" :title="d.receipt">authored</span>
+                  </td>
                   <td class="n">{{ d.terms.toLocaleString() }}</td>
                   <td class="ks-mono">{{ d.mappedType }}</td>
                   <td class="ks-dim">{{ d.source }}</td>
@@ -245,14 +276,14 @@ const macroF1 = computed(
               </div>
 
               <ul v-else class="ks-list">
-                <li v-for="d in dictionaries" :key="d.name">{{ d.name }} — <span class="ks-mono">{{ d.mappedType }}</span></li>
+                <li v-for="d in allDictionaries" :key="d.name">{{ d.name }} — <span class="ks-mono">{{ d.mappedType }}</span></li>
               </ul>
             </div>
 
             <aside class="ks-rules-class" aria-label="Class">
               <h3>Class</h3>
               <p class="ks-dim">Check a class to display its occurrences in the document.</p>
-              <label v-for="e in entityTypes" :key="e.name" class="ks-check">
+              <label v-for="e in allEntityTypes" :key="e.name" class="ks-check">
                 <input type="checkbox" checked disabled />
                 <span class="ks-swatch" :style="{ background: e.color }" aria-hidden="true" />
                 <span class="ks-mono">{{ e.name }}</span>
@@ -420,6 +451,16 @@ const macroF1 = computed(
 .ks-stage.st-active { border-top-color: var(--accent); } .ks-stage.st-active .ks-stage-dot { background: var(--accent); } .ks-stage.st-active .ks-stage-label { color: var(--accent); }
 .ks-stage.st-blocked { border-top-color: var(--down); } .ks-stage.st-blocked .ks-stage-dot { background: var(--down); } .ks-stage.st-blocked .ks-stage-label { color: var(--down); }
 
+/* authored inputs strip */
+.ks-authored {
+  display: flex; align-items: flex-start; gap: 0.55rem;
+  border: 1px solid var(--accent-soft); border-left: 2px solid var(--teal);
+  border-radius: var(--radius-sm); background: rgba(45, 212, 191, 0.06); padding: 0.6rem 0.85rem;
+}
+.ks-authored-dot { flex: none; width: 0.45rem; height: 0.45rem; margin-top: 0.35rem; border-radius: 999px; background: var(--teal); }
+.ks-authored-text { margin: 0; font-size: 0.62rem; color: var(--text-2); line-height: 1.5; }
+.ks-authored-text b { color: var(--text); }
+
 /* workspace */
 .ks-workspace { display: grid; grid-template-columns: 190px 1fr; gap: 0.9rem; align-items: start; }
 @media (max-width: 820px) { .ks-workspace { grid-template-columns: 1fr; } }
@@ -479,6 +520,8 @@ tr.is-off td { opacity: 0.55; }
 .ks-pill.warn { color: var(--amber); background: var(--amber-soft); }
 .ks-pill.bad { color: var(--down); background: rgba(240, 101, 106, 0.14); }
 .ks-pill.off { color: var(--neutral); background: rgba(139, 148, 158, 0.14); }
+.ks-pill.authored { color: var(--teal); background: rgba(45, 212, 191, 0.14); margin-left: 0.4rem; cursor: help; }
+tr.is-authored td { background: rgba(45, 212, 191, 0.06); }
 
 .ks-swatch { display: inline-block; width: 0.5rem; height: 0.5rem; border-radius: 2px; margin-right: 0.35rem; vertical-align: middle; }
 .ks-bar { display: block; height: 0.2rem; margin-top: 0.2rem; border-radius: 999px; background: var(--line-2); overflow: hidden; }

--- a/socioprophet-web/client-vue/src/pages/KnowledgeStudio.vue
+++ b/socioprophet-web/client-vue/src/pages/KnowledgeStudio.vue
@@ -169,7 +169,7 @@ const allDictionaries = computed(() => [...ke.dictionaries.value, ...dictionarie
             <table class="ks-table">
               <thead><tr><th>Type</th><th>Roles</th><th class="n">Mentions</th><th class="n">F1</th><th>Value kind</th></tr></thead>
               <tbody>
-                <tr v-for="e in allEntityTypes" :key="e.name" :class="{ 'is-authored': e.authored }">
+                <tr v-for="e in allEntityTypes" :key="(e.authored ? 'a:' : 's:') + e.name" :class="{ 'is-authored': e.authored }">
                   <td>
                     <span class="ks-swatch" :style="{ background: e.color }" aria-hidden="true" /><b class="ks-strong">{{ e.name }}</b>
                     <span v-if="e.authored" class="ks-pill authored" :title="e.receipt">authored</span>
@@ -191,7 +191,7 @@ const allDictionaries = computed(() => [...ke.dictionaries.value, ...dictionarie
             <table class="ks-table">
               <thead><tr><th>Relation</th><th>Subject</th><th>Object</th><th class="n">Instances</th><th class="n">F1</th></tr></thead>
               <tbody>
-                <tr v-for="r in allRelationTypes" :key="r.name" :class="{ 'is-authored': r.authored }">
+                <tr v-for="r in allRelationTypes" :key="(r.authored ? 'a:' : 's:') + r.name" :class="{ 'is-authored': r.authored }">
                   <td class="ks-strong">
                     {{ r.name }}
                     <span v-if="r.authored" class="ks-pill authored" :title="r.receipt">authored</span>
@@ -216,7 +216,7 @@ const allDictionaries = computed(() => [...ke.dictionaries.value, ...dictionarie
             <table class="ks-table">
               <thead><tr><th>Dictionary</th><th class="n">Terms</th><th>Maps to</th><th>Source</th><th>Licence</th></tr></thead>
               <tbody>
-                <tr v-for="d in allDictionaries" :key="d.name" :class="{ 'is-bad': d.licence.startsWith('UNKNOWN'), 'is-authored': d.authored }">
+                <tr v-for="d in allDictionaries" :key="(d.authored ? 'a:' : 's:') + d.name" :class="{ 'is-bad': d.licence.startsWith('UNKNOWN'), 'is-authored': d.authored }">
                   <td class="ks-strong">
                     {{ d.name }}
                     <span v-if="d.authored" class="ks-pill authored" :title="d.receipt">authored</span>
@@ -276,14 +276,14 @@ const allDictionaries = computed(() => [...ke.dictionaries.value, ...dictionarie
               </div>
 
               <ul v-else class="ks-list">
-                <li v-for="d in allDictionaries" :key="d.name">{{ d.name }} — <span class="ks-mono">{{ d.mappedType }}</span></li>
+                <li v-for="d in allDictionaries" :key="(d.authored ? 'a:' : 's:') + d.name">{{ d.name }} — <span class="ks-mono">{{ d.mappedType }}</span></li>
               </ul>
             </div>
 
             <aside class="ks-rules-class" aria-label="Class">
               <h3>Class</h3>
               <p class="ks-dim">Check a class to display its occurrences in the document.</p>
-              <label v-for="e in allEntityTypes" :key="e.name" class="ks-check">
+              <label v-for="e in allEntityTypes" :key="(e.authored ? 'a:' : 's:') + e.name" class="ks-check">
                 <input type="checkbox" checked disabled />
                 <span class="ks-swatch" :style="{ background: e.color }" aria-hidden="true" />
                 <span class="ks-mono">{{ e.name }}</span>

--- a/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
+++ b/socioprophet-web/client-vue/src/pages/ReasoningChainInspector.vue
@@ -26,12 +26,13 @@ import {
 } from '../features/reasoning-chain/kindVocabulary';
 import { scoreVariants, type ScoredVariant } from '../features/reasoning-chain/scoreVariants';
 import {
-  useAuthorshipLedger, promoteConceptToDictionaryTerm, defineEntityType,
-  defineRelationType, overrideConcept, type AuthorshipEvent,
+  promoteConceptToDictionaryTerm, defineEntityType,
+  defineRelationType, overrideConcept,
 } from '../features/reasoning-chain/keAuthorship';
 import { useNoeticaChat } from '../composables/useNoeticaChat';
 import { useConceptResolver } from '../features/reasoning-chain/conceptResolver';
 import { chatTurnToExample, liveChainsFromTurns, type LiveChain } from '../features/reasoning-chain/chatTurnAdapter';
+import { useKeWorkbench } from '../features/knowledge-studio/keWorkbench';
 
 const cockpit = useCockpit();
 const auth = useAuth();
@@ -73,8 +74,10 @@ watch(activeExamples, (list) => {
   if (!list.some((e) => e.id === exampleId.value)) exampleId.value = list[0]?.id ?? 'A';
 }, { immediate: true });
 
-// ---- authorship (human overrides supersede learned; prior retained) ----
-const ledger = useAuthorshipLedger();
+// ---- authorship → durable KE-workbench contract (shared with Knowledge Studio) ----
+// Writing through the shared workbench means authored assets become inputs to the
+// Knowledge Studio loop; the in-memory unsigned ledger is gone.
+const ke = useKeWorkbench();
 // Human overrides recorded this session, keyed by concept label.
 const overrides = ref<Record<string, string>>({});
 const selectedConcept = ref<{ label: string; kind: AnnotationKind } | null>(null);
@@ -89,25 +92,20 @@ function kindOf(concept: TokenConcept): AnnotationKind {
 function selectConcept(concept: TokenConcept) {
   selectedConcept.value = { label: concept.l, kind: kindOf(concept) };
 }
-function record(e: AuthorshipEvent) {
-  ledger.record(e);
-  if (e.action === 'overwrite') overrides.value = { ...overrides.value, [e.term]: e.version };
-}
 function onPromote() {
   const s = selectedConcept.value; if (!s) return;
-  record(promoteConceptToDictionaryTerm(s.label, s.kind, KIND_META[s.kind].label, { author: author.value }).event);
+  promoteConceptToDictionaryTerm(s.label, s.kind, KIND_META[s.kind].label, { author: author.value }, ke);
 }
 function onDefineType() {
   const s = selectedConcept.value; if (!s) return;
   const rel = s.kind === 'RELATION' || s.kind === 'POSSESSION';
-  const built = rel
-    ? defineRelationType(s.label, s.kind, 'SUBJECT', 'OBJECT', { author: author.value })
-    : defineEntityType(s.label, s.kind, { author: author.value });
-  record(built.event);
+  if (rel) defineRelationType(s.label, s.kind, 'SUBJECT', 'OBJECT', { author: author.value }, ke);
+  else defineEntityType(s.label, s.kind, { author: author.value }, ke);
 }
 function onOverride() {
   const s = selectedConcept.value; if (!s) return;
-  record(overrideConcept(s.label, s.kind, s.label, { author: author.value, note: 'human override of learned label' }));
+  const ev = overrideConcept(s.label, s.kind, s.label, { author: author.value, note: 'human override of learned label' }, ke);
+  overrides.value = { ...overrides.value, [ev.term]: ev.version };
 }
 
 // ---- governed scoring ----
@@ -198,14 +196,14 @@ watch([example, mode, source], setCockpitContext);
       v-if="source === 'live'"
       label="live · active conversation chain"
       tone="muted"
-      message="Bound to the live Noetica conversation chain (useNoeticaChat): the selected turn's plan / retrieval / grounding populate the four stages. Concept LABELS resolve against the live learned resolver / KE registries; KINDs stay bound to regis-entity-graph#22. Where a label has no live resolution the KIND is shown (provisional). The governed variant scorer is unchanged; authorship events are held in an in-memory ledger (unsigned) until the KE workbench seals them."
+      message="Bound to the live Noetica conversation chain (useNoeticaChat): the selected turn's plan / retrieval / grounding populate the four stages. Concept LABELS resolve against the live learned resolver / KE registries; KINDs stay bound to regis-entity-graph#22. Where a label has no live resolution the KIND is shown (provisional). The governed variant scorer is unchanged; authorship writes through the durable KE-workbench contract (versioned, receipted) and surfaces as an input to the Knowledge Studio loop — receipts honestly unsigned, sealed by the promotion gate, never fabricated."
       aria-label="Reasoning Chain Inspector boundary"
     />
     <BoundaryNotice
       v-else
       label="demo · seed conversation chains"
       tone="muted"
-      message="Demo/offline mode over three seed conversation chains — shown when no live turn is selected. KINDs are bound to regis-entity-graph#22; authorship events are held in an in-memory ledger (unsigned) — the durable KE-workbench contract seals them."
+      message="Demo/offline mode over three seed conversation chains — shown when no live turn is selected. KINDs are bound to regis-entity-graph#22; authorship writes through the durable KE-workbench contract (versioned, receipted) and surfaces as an input to the Knowledge Studio loop. Receipts are honestly unsigned — sealed by the promotion gate, never fabricated."
       aria-label="Reasoning Chain Inspector boundary"
     />
 
@@ -290,9 +288,9 @@ watch([example, mode, source], setCockpitContext);
         <aside class="rci-author" aria-label="Knowledge-engineering authoring">
           <div class="rci-author-h">Author into the KE loop</div>
           <p class="rci-author-hint">
-            Select a concept tag, then author it. Terms are learned + <b>versioned</b> (never a match rule); a human
-            override supersedes the learned value and keeps the prior as a version. Events are receipted (unsigned
-            until the KE workbench seals them).
+            Select a concept tag, then author it into the durable KE-workbench. Terms are learned + <b>versioned</b>
+            (never a match rule); a human override supersedes the learned value and keeps the prior as a version.
+            Receipts are sealed by the promotion gate — honestly <b>unsigned</b>, never fabricated.
           </p>
           <div v-if="selectedConcept" class="rci-author-sel">
             selected <b class="mono">{{ selectedConcept.label }}</b>
@@ -305,10 +303,10 @@ watch([example, mode, source], setCockpitContext);
             <button type="button" :disabled="!selectedConcept" @click="onOverride">✎ Overwrite (human)</button>
           </div>
 
-          <div v-if="ledger.events.value.length" class="rci-ledger">
-            <div class="rci-ledger-h">Authorship ledger · governed &amp; versioned</div>
+          <div v-if="ke.ledger.value.length" class="rci-ledger">
+            <div class="rci-ledger-h">Authorship ledger · governed &amp; versioned · durable KE-workbench</div>
             <ul>
-              <li v-for="ev in ledger.events.value" :key="ev.id">
+              <li v-for="ev in ke.ledger.value" :key="ev.id">
                 <span class="rci-led-act">{{ ev.action }}</span>
                 <span class="mono">{{ ev.term }}</span>
                 <span class="rci-tag-kind">{{ ev.kind }}</span>


### PR DESCRIPTION
Follow-up to #516 (now merged). The inspector's KE authoring emitted governed, versioned, receipted events into an **in-memory unsigned ledger**; this rewires the five hooks to write **through a durable KE-workbench contract** and surfaces the authored assets as inputs to the Knowledge Studio loop. Rebased onto current master (keeps the live-chain sourcing #516 landed).

## What changed
- **New contract** `features/knowledge-studio/keWorkbench.ts` — the seam the KE-workbench agent's durable store swaps in behind. **Consume-not-fork:** authored assets reuse the Knowledge Studio KE-contract shapes (`EntityType`/`RelationType`/`Dictionary`), no parallel data model. Owns the append surface, version chain, and an honest **promotion gate**; `useKeWorkbench()` is the single bind point.
- **Rewired hooks** `keAuthorship.ts` — `buildAuthorshipEvent`, `promoteConceptToDictionaryTerm`, `defineEntityType`, `defineRelationType`, `overrideConcept` build a contract record and append it durably when handed the workbench.
- **Exposed into the loop** — `ReasoningChainInspector.vue` writes through the shared workbench; `KnowledgeStudio.vue` merges authored dictionaries/entity/relation types ahead of the seeded registries with an `authored` pill + a develop-stage inputs strip. `fixture.ts` types gained optional `authored?`/`receipt?`.
- **Handoff** `KE_WORKBENCH_CONTRACT.md` — interface, invariants, five open decisions, and a no-caller-change swap-in checklist for the durable-store author.

## Invariants preserved (locked by `keWorkbench.test.ts`)
- learn-don't-match (`matchRule:false` + versioned)
- human overrides supersede learned; prior retained as a version
- honest receipts sealed by the promotion gate — explicitly **unsigned**, no fabricated crypto
- provenance class on tags + ledger entries

## Verify
`vue-tsc` clean · **628 tests pass** (new `keWorkbench.test.ts` + extended authorship test) · `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)