### PR TITLE
feat(server): sovereign delivery producer + cutover reconciliation

### DIFF
--- a/socioprophet-web/server/package.json
+++ b/socioprophet-web/server/package.json
@@ -43,7 +43,8 @@
   "scripts": {
     "start": "node src/server.ts",
     "dev": "nodemon src/server.ts",
-    "test:contracts": "node test/contracts.test.mjs"
+    "test:contracts": "node test/contracts.test.mjs",
+    "test:delivery": "node test/delivery.reconcile.test.mjs"
   },
   "author": "Will Jones",
   "dependencies": {

--- a/socioprophet-web/server/src/routes/api/delivery-route.ts
+++ b/socioprophet-web/server/src/routes/api/delivery-route.ts
@@ -1,0 +1,40 @@
+export {};
+// /api/delivery + /api/cowork — the sovereign delivery producer.
+//   GET  /delivery/tasks       sovereign tasks in the github-issue mirror shape
+//   GET  /cowork/threads       sovereign cowork threads
+//   POST /delivery/reconcile   { target, mirror: MirrorRecord[] } → reconcile report
+//
+// The sovereign store is canonical; reconcile only ever converges the MIRROR toward
+// sovereign (see services/mirrorReconcile.ts, validated in
+// test/delivery.reconcile.test.mjs). Public read producer — the client adapters
+// (deliveryExcellenceLive / coworkLive) fail closed when this is unreachable.
+const express = require("express");
+const router = express.Router();
+
+// ESM services loaded via dynamic import (they are pure/validated modules).
+const store = () => import("../../services/deliveryStore.ts");
+const recon = () => import("../../services/mirrorReconcile.ts");
+
+router.get("/delivery/tasks", async (_req: any, res: any) => {
+  const { tasksAsIssues } = await store();
+  return res.json({ issues: tasksAsIssues() });
+});
+
+router.get("/cowork/threads", async (_req: any, res: any) => {
+  const { threadsWire } = await store();
+  return res.json({ threads: threadsWire() });
+});
+
+router.post("/delivery/reconcile", async (req: any, res: any) => {
+  const target = String(req.body?.target || "github");
+  if (!["github", "taskwarrior", "cowork"].includes(target)) {
+    return res.status(400).json({ error: "invalid target (github|taskwarrior|cowork)" });
+  }
+  const mirror = Array.isArray(req.body?.mirror) ? req.body.mirror : [];
+  const { sovereignTasks } = await store();
+  const { reconcile } = await recon();
+  // Sovereign is the source of truth; the report's ops converge the mirror only.
+  return res.json(reconcile(target, sovereignTasks, mirror));
+});
+
+module.exports = router;

--- a/socioprophet-web/server/src/server.ts
+++ b/socioprophet-web/server/src/server.ts
@@ -15,6 +15,7 @@ const buildsRouter = require("./routes/api/builds-route");
 const fleetRouter = require("./routes/api/fleet-route");
 const bootRouter = require("./routes/boot-route");
 const proCyberneticaRouter = require("./routes/api/procybernetica-dashboard-route");
+const deliveryRouter = require("./routes/api/delivery-route");
 const { requireAuth } = require("./middleware/auth");
 
 const app = express();
@@ -43,6 +44,9 @@ app.use("/api/feed", rssRouter);
 app.use("/api/builds", apiLimiter, requireAuth, buildsRouter);
 app.use("/api/fleet", apiLimiter, requireAuth, fleetRouter);
 app.use("/api/procybernetica", apiLimiter, proCyberneticaRouter);
+// Sovereign delivery producer (public read): /api/delivery/* + /api/cowork/*.
+// Sovereign store is canonical; the client adapters fail closed when unreachable.
+app.use("/api", apiLimiter, deliveryRouter);
 // Device provisioning is UNAUTHENTICATED (claim-code authorized) — nlboot devices
 // have no Socbase token; rate-limited at the HTTP layer.
 app.use("/boot", bootLimiter, bootRouter);

--- a/socioprophet-web/server/src/services/deliveryStore.ts
+++ b/socioprophet-web/server/src/services/deliveryStore.ts
@@ -1,0 +1,61 @@
+// Sovereign delivery store — the server-side CANONICAL source for the WBS/cowork
+// graph. This is the thing GitHub issues / Taskwarrior mirror; the client's
+// fail-closed adapters (deliveryExcellenceLive / coworkLive) read its wire
+// projections. Seed matches the client fixture's XSEDE task ids so the loop closes.
+//
+// Local-first posture: this seed stands in for the durable sovereign store (the
+// server already has a db/ + Supabase). Kept pure so it validates under type-strip.
+
+import type { SovereignTask } from './mirrorReconcile.ts';
+
+export const sovereignTasks: SovereignTask[] = [
+  { id: 't-cee-train', title: 'Ship the training certification program (Moodle LMS + Open Badges)', status: 'in_progress' },
+  { id: 't-cee-spoc', title: 'Convert MOOCs → quarterly SPOCs with mentoring + credit', status: 'todo' },
+  { id: 't-ecss-esrt', title: 'Staff ESRT engagements against XSEDE-prioritized use cases', status: 'in_progress' },
+  { id: 't-xci-xcsr', title: 'Publish the XSEDE Community Software Repository catalog', status: 'blocked' },
+  { id: 't-ops-cyber', title: 'Operate the XSEDE cybersecurity plan', status: 'done' },
+  { id: 't-ras-xrac', title: 'Support XRAC quarterly review of ~200 large-scale requests', status: 'done' },
+  { id: 't-po-pep', title: 'Maintain the Project Execution Plan (living SOP)', status: 'in_progress' },
+];
+
+// ---- wire projections (canonical → mirror shapes the client reads) ----
+
+const GH_STATE: Record<string, 'open' | 'closed'> = { done: 'closed' };
+const GH_LABEL: Record<string, string> = { in_progress: 'in progress', blocked: 'blocked', review: 'review' };
+
+/** Project sovereign tasks into the GitHub-issue wire shape (`{ issues }`). */
+export function tasksAsIssues() {
+  return sovereignTasks.map((t, i) => ({
+    number: 1000 + i,
+    title: t.title,
+    state: GH_STATE[t.status] ?? 'open',
+    html_url: `https://github.com/SocioProphet/delivery-excellence/issues/${1000 + i}`,
+    labels: GH_LABEL[t.status] ? [{ name: GH_LABEL[t.status] }] : [],
+    // Sovereign provenance carried alongside the mirror shape — the canonical id.
+    sovereign_id: t.id,
+  }));
+}
+
+export interface WireThread {
+  id: string;
+  title: string;
+  subject_ref: string;
+  subject_kind: 'task' | 'element';
+  status: 'open' | 'proposed' | 'decided' | 'blocked';
+  participants: string[];
+  messages: Array<{ id: string; author: string; at: string; kind: string; body: string; evidence?: string }>;
+  decision?: string;
+}
+
+export function threadsWire(): WireThread[] {
+  return [
+    {
+      id: 'cw-spoc', title: 'SPOC conversion plan — mentoring + credit gating', subject_ref: 't-cee-spoc', subject_kind: 'task', status: 'decided',
+      participants: ['ada.newhope.social', 'linus.dev'],
+      messages: [
+        { id: 'm1', author: 'ada.newhope.social', at: '2026-07-30T11:00:00Z', kind: 'decision', body: 'Pilot 2 mentor-gated SPOCs with a preregistered completion metric.', evidence: 'aud_01JCEE7RAIN' },
+      ],
+      decision: 'Pilot 2 mentor-gated SPOCs with a preregistered completion metric.',
+    },
+  ];
+}

--- a/socioprophet-web/server/src/services/mirrorReconcile.ts
+++ b/socioprophet-web/server/src/services/mirrorReconcile.ts
@@ -1,0 +1,93 @@
+// Sovereign-cutover reconciliation — the mechanism that makes GitHub/Taskwarrior
+// mirrors REMOVABLE. The sovereign store is the single source of truth; mirrors are
+// DERIVED projections. Reconciliation only ever converges the MIRROR toward the
+// sovereign store — never the reverse — so dropping a mirror at cutover loses
+// nothing. Orphan mirror records (no sovereign source) are FLAGGED, never
+// auto-deleted (a mirror can't authorize destruction of sovereign truth).
+//
+// Pure + dependency-free so it validates under `node` type-stripping
+// (test/delivery.reconcile.test.mjs) without the server's TS/express runtime.
+
+export type SyncState = 'sovereign_only' | 'mirrored' | 'drifted';
+export type MirrorTarget = 'github' | 'taskwarrior' | 'cowork';
+
+export interface SovereignTask {
+  id: string;
+  title: string;
+  status: string;
+}
+
+/** A record observed in an external mirror, claiming to reflect a sovereign task. */
+export interface MirrorRecord {
+  sovereignId: string;
+  title: string;
+  status: string;
+  ref: string; // issue url / task uuid / thread id
+}
+
+export type MirrorOp =
+  | { op: 'create'; target: MirrorTarget; sovereignId: string; title: string; status: string }
+  | { op: 'update'; target: MirrorTarget; ref: string; sovereignId: string; fields: Partial<{ title: string; status: string }> }
+  | { op: 'orphan'; target: MirrorTarget; ref: string };
+
+export interface ReconcileResult {
+  target: MirrorTarget;
+  /** sovereignId → sync state. */
+  states: Record<string, SyncState>;
+  /** Convergence ops applied to the MIRROR to match sovereign (one-directional). */
+  ops: MirrorOp[];
+  drifted: string[];
+  sovereignOnly: string[];
+  /** Mirror refs with no sovereign source — flagged, never auto-deleted. */
+  orphans: string[];
+}
+
+export function reconcile(
+  target: MirrorTarget,
+  sovereign: SovereignTask[],
+  mirror: MirrorRecord[],
+): ReconcileResult {
+  const mirrorById = new Map<string, MirrorRecord>();
+  for (const m of mirror) mirrorById.set(m.sovereignId, m);
+  const sovereignIds = new Set(sovereign.map((s) => s.id));
+
+  const states: Record<string, SyncState> = {};
+  const ops: MirrorOp[] = [];
+  const drifted: string[] = [];
+  const sovereignOnly: string[] = [];
+
+  for (const s of sovereign) {
+    const m = mirrorById.get(s.id);
+    if (!m) {
+      states[s.id] = 'sovereign_only';
+      sovereignOnly.push(s.id);
+      ops.push({ op: 'create', target, sovereignId: s.id, title: s.title, status: s.status });
+      continue;
+    }
+    const fields: Partial<{ title: string; status: string }> = {};
+    if (m.title !== s.title) fields.title = s.title;
+    if (m.status !== s.status) fields.status = s.status;
+    if (Object.keys(fields).length > 0) {
+      states[s.id] = 'drifted';
+      drifted.push(s.id);
+      ops.push({ op: 'update', target, ref: m.ref, sovereignId: s.id, fields });
+    } else {
+      states[s.id] = 'mirrored';
+    }
+  }
+
+  const orphans: string[] = [];
+  for (const m of mirror) {
+    if (!sovereignIds.has(m.sovereignId)) {
+      orphans.push(m.ref);
+      ops.push({ op: 'orphan', target, ref: m.ref });
+    }
+  }
+
+  return { target, states, ops, drifted, sovereignOnly, orphans };
+}
+
+/** True iff the mirror is a faithful projection of sovereign (nothing to converge). */
+export function isFullyMirrored(r: ReconcileResult): boolean {
+  return r.drifted.length === 0 && r.sovereignOnly.length === 0 && r.orphans.length === 0;
+}

--- a/socioprophet-web/server/test/delivery.reconcile.test.mjs
+++ b/socioprophet-web/server/test/delivery.reconcile.test.mjs
@@ -1,0 +1,60 @@
+// Sovereign-cutover reconciliation test. Runs under plain node via type-stripping
+// (no TS loader needed): `node test/delivery.reconcile.test.mjs`.
+import { reconcile, isFullyMirrored } from '../src/services/mirrorReconcile.ts';
+import { sovereignTasks, tasksAsIssues, threadsWire } from '../src/services/deliveryStore.ts';
+
+let fail = 0;
+const ck = (n, ok) => { console.log((ok ? 'ok   ' : 'FAIL ') + n); if (!ok) fail++; };
+
+const sov = [
+  { id: 'a', title: 'Alpha', status: 'todo' },
+  { id: 'b', title: 'Beta', status: 'done' },
+];
+
+// 1. A faithful mirror → fully mirrored, no ops.
+const faithful = reconcile('github', sov, [
+  { sovereignId: 'a', title: 'Alpha', status: 'todo', ref: 'gh:1' },
+  { sovereignId: 'b', title: 'Beta', status: 'done', ref: 'gh:2' },
+]);
+ck('faithful mirror → isFullyMirrored', isFullyMirrored(faithful));
+ck('faithful mirror → all states mirrored', Object.values(faithful.states).every((s) => s === 'mirrored'));
+ck('faithful mirror → zero ops', faithful.ops.length === 0);
+
+// 2. A drifted mirror → drift detected, one UPDATE op on the MIRROR.
+const drift = reconcile('github', sov, [
+  { sovereignId: 'a', title: 'Alpha (stale)', status: 'todo', ref: 'gh:1' },
+  { sovereignId: 'b', title: 'Beta', status: 'done', ref: 'gh:2' },
+]);
+ck('drift detected', drift.drifted.includes('a') && drift.states.a === 'drifted');
+ck('drift → update op targets the mirror ref', drift.ops.some((o) => o.op === 'update' && o.ref === 'gh:1' && o.fields.title === 'Alpha'));
+
+// 3. A missing mirror → sovereign_only, CREATE op.
+const missing = reconcile('taskwarrior', sov, [{ sovereignId: 'a', title: 'Alpha', status: 'todo', ref: 'tw:1' }]);
+ck('missing → sovereign_only', missing.sovereignOnly.includes('b') && missing.states.b === 'sovereign_only');
+ck('missing → create op', missing.ops.some((o) => o.op === 'create' && o.sovereignId === 'b'));
+
+// 4. An orphan mirror (no sovereign source) → FLAGGED, never deleted.
+const orphan = reconcile('github', sov, [
+  { sovereignId: 'a', title: 'Alpha', status: 'todo', ref: 'gh:1' },
+  { sovereignId: 'ghost', title: 'Ghost', status: 'todo', ref: 'gh:99' },
+]);
+ck('orphan flagged', orphan.orphans.includes('gh:99'));
+ck('orphan op is "orphan" (flag), never delete', orphan.ops.some((o) => o.op === 'orphan' && o.ref === 'gh:99'));
+
+// 5. CUTOVER INVARIANT: reconciliation is one-directional — no op ever mutates
+//    sovereign. Every op targets a mirror (create/update/orphan), never sovereign.
+const allOps = [...faithful.ops, ...drift.ops, ...missing.ops, ...orphan.ops];
+ck('one-directional: every op targets the mirror, never sovereign', allOps.every((o) => o.op === 'create' || o.op === 'update' || o.op === 'orphan'));
+
+// 6. Store wire projections match the client adapter contracts.
+const issues = tasksAsIssues();
+ck('tasksAsIssues → github-issue shape', issues.every((i) => typeof i.number === 'number' && i.title && (i.state === 'open' || i.state === 'closed') && i.html_url.startsWith('https://')));
+ck('tasksAsIssues carries sovereign provenance', issues.every((i) => typeof i.sovereign_id === 'string'));
+ck('a done task projects to a closed issue', issues.find((i) => i.sovereign_id === 't-ops-cyber').state === 'closed');
+
+const threads = threadsWire();
+const taskIds = new Set(sovereignTasks.map((t) => t.id));
+ck('threadsWire subjects reference real sovereign tasks', threads.every((t) => taskIds.has(t.subject_ref)));
+
+console.log(fail ? `\n${fail} FAILED` : '\nall reconciliation + projection checks passed');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
The real backend for the sovereign cutover — the server-side **canonical store** the GitHub/Taskwarrior/cowork mirrors derive from, and the **reconciliation that makes those mirrors removable**. Closes the loop with the client `/delivery/wbs` + `/delivery/cowork` fail-closed adapters (#525, #526).

## The cutover mechanism (validated)
- **`services/mirrorReconcile.ts`** — pure reconciliation. Sovereign store is the source of truth; reconcile only ever converges the **mirror → sovereign** (create/update on the mirror), **never the reverse**. Orphan mirror records (no sovereign source) are **flagged, never auto-deleted** — a mirror can't authorize destroying sovereign truth. Per-task drift detection.
- **`services/deliveryStore.ts`** — the canonical sovereign store (seed matches the client XSEDE task ids) + wire projections to the exact shapes the client adapters read (`tasksAsIssues → {issues}`, `threadsWire → {threads}`).
- **`routes/api/delivery-route.ts`** — `GET /api/delivery/tasks`, `GET /api/cowork/threads`, `POST /api/delivery/reconcile`; mounted in `server.ts` as a public read producer.

## Validation
`test/delivery.reconcile.test.mjs` runs on **plain node via type-stripping** (no TS loader) — **14 checks green**, including the one-directional cutover invariant (*every op targets the mirror, never sovereign*), drift detection, orphan-flagging, and the wire-projection contracts. Added `npm run test:delivery`.

## Honest scope
The Express route mirrors the existing route convention (fleet/builds); **full server integration is testable once the server's TS runtime/env is restored** (the pre-existing `test:contracts` needs its `typescript` dep). The load-bearing logic is validated standalone. **GCP/Cloud Run deploy is the follow-up** — needs the project id + secrets; nothing here egresses or touches real GitHub tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)