### PR TITLE
fix(ci): delivery-snapshot installs with npm install, not npm ci

### DIFF
--- a/.github/workflows/delivery-snapshot.yml
+++ b/.github/workflows/delivery-snapshot.yml
@@ -62,7 +62,12 @@ jobs:
 
       - name: Typecheck and test the surface
         run: |
-          npm ci --no-audit --no-fund
+          # client-vue commits a pnpm-lock.yaml, not a package-lock.json, so
+          # `npm ci` (which requires package-lock/npm-shrinkwrap) fails EUSAGE and
+          # the whole snapshot job dies before it can commit the refreshed data.
+          # Match the working convention of client-vue-product-build.yml, which
+          # installs with `npm install`.
+          npm install --no-audit --no-fund
           npx vue-tsc --noEmit
           npx vitest run src/__tests__/deliveryDashboard.test.ts src/__tests__/deliveryEconomics.test.ts
 


### PR DESCRIPTION
## Problem
The `delivery-snapshot` workflow (added in #524) has been **failing on every push to master** (run [30849623000](https://github.com/SocioProphet/socioprophet/actions/runs/30849623000)) at the *Typecheck and test the surface* step:

```
npm error The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json
```

`socioprophet-web/client-vue` commits a **pnpm-lock.yaml**, not a package-lock.json, so `npm ci` fails EUSAGE. The job dies there — after the integrity gate passes but *before* the commit step — so the auto-refreshed snapshot is **never committed**. The dashboard's whole reason for existing (cannot drift from what shipped) was silently broken.

## Fix
Install with `npm install --no-audit --no-fund`, matching the already-green `client-vue-product-build.yml`. One line; no behaviour change to the gates.

## Verification
Verified by dispatching the actual `delivery-snapshot` workflow on this branch (see checks) — regenerate → integrity gate → typecheck/test now completes.

Fixes the red-main introduced by #524.