### PR TITLE
fix(server): make sp-server runnable (node 24 + tsx) — validated dev deploy

### DIFF
--- a/socioprophet-web/server/Dockerfile
+++ b/socioprophet-web/server/Dockerfile
@@ -1,20 +1,21 @@
-# Server Dockerfile
-
-# pull official base image
-FROM node:18-alpine
+# sp-server — the sovereign API / delivery producer.
+#
+# Node 24: the server runs TypeScript directly (`node src/server.ts`) and the
+# delivery route dynamically imports `.ts` services, both of which require Node's
+# native type-stripping (stable + on-by-default from Node 23.6). Node 18 could not
+# run this at all. Matches the delivery-mirror-sync workflow (setup-node 24).
+FROM node:24-alpine
 
 # set working directory
 WORKDIR /usr/src/app/sp-server
 
-# copy package.json from host to current location in alpine image
+# install dependencies first (cached layer) …
 COPY package.json .
-
-# install dependencies inside image filesystem
 RUN yarn
 
-# run command in the container
-CMD [ "yarn", "start" ]
-
-# copy over rest of source code from host to image filesystem
+# … then copy the rest of the source.
 COPY . .
 
+# serve on 8080 (matches the k8s Deployment PORT env + probes)
+EXPOSE 8080
+CMD [ "yarn", "start" ]


### PR DESCRIPTION
Makes the sp-server sovereign delivery producer **actually runnable** and validates it end-to-end on the dev cluster. Two pre-existing blockers meant the server never booted via its Dockerfile:

1. **`node:18-alpine`** — the server runs TypeScript directly; type-stripping needs Node 22+. → `node:24-alpine`.
2. **`node src/server.ts`** — the server uses extensionless `require("./routes/...")` of `.ts` files, which plain node can't resolve (even with type-stripping). → added **`tsx`** as a runtime dep; `start`/`dev` run under tsx (handles the hybrid CJS requires + the delivery route's dynamic `.ts` imports).

## Validated live on dev (not just built)
Built via Cloud Build (`cloudbuild-runner` SA) → `gcr.io/socioprophet-platform/sp-server`, deployed to the **`socioprophet-dev`** namespace on `prophet-platform` (ClusterIP, isolated, no ingress/DNS → zero prod impact), and confirmed serving:
- `GET /api/delivery/tasks` → sovereign tasks in issue shape ✓
- `GET /api/cowork/threads` → cowork threads ✓
- `POST /api/delivery/reconcile` → the sovereign→mirror **cutover reconciliation** running live (drift → update, orphan flagged, missing → create) ✓

Boot also needs `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` (the auth middleware constructs a client eagerly); dev used placeholders since the delivery endpoints are public and never touch Supabase — a proper dev/prod deploy should source these from a secret.

**Prod cutover remains deferred** per `deploy/sovereign/README.md` (ingress/cert/DNS + Firebase-v0 validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)