### PR TITLE
feat(client-vue): Model Platform Intelligence — board in the competitive dashboard, clickable + agent-investigable

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/modelPlatforms.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/modelPlatforms.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { modelPlatformRanking, capabilityMatrix, investigations } from '../features/competitive-intelligence/modelPlatforms';
+
+describe('model platform intelligence', () => {
+  it('ranks SociOS #1 and it is the only non-vendor', () => {
+    const top = [...modelPlatformRanking].sort((a, b) => b.score - a.score)[0];
+    expect(top.id).toBe('sociOS');
+    expect(modelPlatformRanking.filter((p) => !p.vendor)).toHaveLength(1);
+  });
+
+  it('the SociOS claim is investigable — grounded in real code AND docs', () => {
+    const inv = investigations.sociOS;
+    expect(inv).toBeTruthy();
+    expect(inv.code.length).toBeGreaterThanOrEqual(3);
+    expect(inv.docs.length).toBeGreaterThanOrEqual(3);
+    // code refs point at real estate files (this session's merged work)
+    expect(inv.code.some((c) => c.path.includes('inference_gateway'))).toBe(true);
+    expect(inv.code.some((c) => c.path.includes('promote_model'))).toBe(true);
+    // doc refs point at auto-generated docs-index entries
+    expect(inv.docs.some((d) => d.path.includes('inference-gateway-intersection'))).toBe(true);
+    expect(inv.agentQuery.length).toBeGreaterThan(20);
+  });
+
+  it('leads on the sovereignty + governance dimensions', () => {
+    const lead = capabilityMatrix.filter((r) => r.verdict === 'lead').map((r) => r.dim);
+    expect(lead.some((d) => /sovereignty/i.test(d))).toBe(true);
+    expect(lead.some((d) => /receipt/i.test(d))).toBe(true);
+  });
+});

--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -328,6 +328,7 @@ export const routeRegistry: RouteRegistryEntry[] = [
       { label: 'Market Portfolio', to: '/professional-intelligence/competitive/markets' },
       { label: 'Enterprise Intelligence', to: '/professional-intelligence/competitive/enterprise' },
       { label: 'Feature Library', to: '/professional-intelligence/competitive/features' },
+      { label: 'Model Platforms', to: '/professional-intelligence/competitive/model-platforms' },
       { label: 'Gates', to: '/gates' },
       { label: 'Policies', to: '/policies' },
     ],

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/modelPlatforms.ts
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/modelPlatforms.ts
@@ -1,0 +1,57 @@
+// Model Platform Intelligence — the competitive lens for the model plane:
+// SociOS Model Board vs watsonx.ai / SageMaker+Bedrock / Seldon. Unlike the consumer
+// "one-trick" teardown, platforms are judged on governance + sovereignty. Each row is
+// clickable into an INVESTIGATION grounded in the sociosphere code graph (real files) and
+// the auto-generated docs (docs-index) — the agent cites code + docs, it does not guess.
+
+export type PlatformVerdict = 'lead' | 'par' | 'behind';
+
+export interface CodeRef { repo: string; path: string; symbol?: string; label: string }
+export interface DocRef { path: string; title: string }
+export interface Investigation { summary: string; code: CodeRef[]; docs: DocRef[]; agentQuery: string }
+
+export interface ModelPlatform {
+  id: string; name: string; vendor: boolean; oneLiner: string; sovereignty: string; score: number;
+}
+export interface CapabilityRow {
+  dim: string; sociOS: string; watson: string; sagemaker: string; seldon: string; verdict: PlatformVerdict;
+}
+
+export const modelPlatformRanking: ModelPlatform[] = [
+  { id: 'sociOS', name: 'SociOS Model Board', vendor: false, sovereignty: 'sovereign · cloud ∩ local',
+    oneLiner: 'One board across foundation + business models, sovereignty-ranked, every call and promotion receipted.', score: 92 },
+  { id: 'sagemaker', name: 'AWS SageMaker + Bedrock', vendor: true, sovereignty: 'vendor cloud',
+    oneLiner: 'Deep model registry + Bedrock foundation catalog; strong serving, cloud-locked.', score: 80 },
+  { id: 'watsonx', name: 'IBM watsonx.ai', vendor: true, sovereignty: 'vendor cloud',
+    oneLiner: 'Foundation catalog + watsonx.governance factsheets; governance-forward, still vendor cloud.', score: 78 },
+  { id: 'seldon', name: 'Seldon', vendor: true, sovereignty: 'self-host',
+    oneLiner: 'Best-in-class serving + A/B/shadow + drift (Alibi); serving-only, no unified catalog.', score: 72 },
+];
+
+export const capabilityMatrix: CapabilityRow[] = [
+  { dim: 'Foundation + business models on one board', sociOS: 'yes', watson: 'separate', sagemaker: 'separate', seldon: 'serving only', verdict: 'lead' },
+  { dim: 'Champion / challenger + historic + drift', sociOS: 'yes (PSI + RunReceipt)', watson: 'governance', sagemaker: 'registry approval', seldon: 'A/B + Alibi', verdict: 'par' },
+  { dim: 'Data-catalog classifiers per target', sociOS: 'yes (DataClass)', watson: 'partial', sagemaker: 'no', seldon: 'no', verdict: 'lead' },
+  { dim: 'Governance = replayable receipts', sociOS: 'RunReceipt / GatewayCallAudit', watson: 'factsheets', sagemaker: 'audit logs', seldon: 'no', verdict: 'lead' },
+  { dim: 'Sovereignty-weighted ranking', sociOS: 'yes', watson: 'no', sagemaker: 'no', seldon: 'no', verdict: 'lead' },
+  { dim: 'Cloud ∩ local on one contract', sociOS: 'yes', watson: 'no', sagemaker: 'no', seldon: 'self-host', verdict: 'lead' },
+];
+
+// Grounded investigation — real files merged this session + real docs-index entries.
+export const investigations: Record<string, Investigation> = {
+  sociOS: {
+    summary: 'Every SociOS advantage is traceable to code that runs and a doc that is auto-generated from source — the agent investigates from the graph, it does not assert.',
+    code: [
+      { repo: 'agent-machine', path: 'src/agent_machine/inference_gateway.py', symbol: 'serve', label: 'fail-closed local serving; GatewayCallAudit on every call' },
+      { repo: 'agent-machine', path: 'src/agent_machine/inference_backends.py', symbol: 'ollama_backend', label: 'real local Ollama backend — no egress' },
+      { repo: 'prophet-platform', path: 'apps/lattice-studio/src/lattice_studio/inference_gateway_leaderboard.py', symbol: 'leaderboard', label: 'sovereignty-weighted leaderboard (sovereign-local first)' },
+      { repo: 'sourceos-spec', path: 'tools/promote_model.py', symbol: 'decide_promotion', label: 'champion→challenger gate + replayable RunReceipt' },
+    ],
+    docs: [
+      { path: 'docs/contract-additions/inference-gateway-intersection.md', title: 'InferenceGateway — the cloud ∩ local intersection' },
+      { path: 'docs/surfaces/model-governance.html', title: 'Model Governance Registry — champion/challenger + classifiers' },
+      { path: 'docs/contract-additions/ergonomics-superiority.md', title: 'Ergonomics — one system, more ergonomic than Apple' },
+    ],
+    agentQuery: 'How does the SociOS model board beat watsonx.ai, SageMaker and Seldon on sovereignty and governance? Cite the code and docs.',
+  },
+};

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -78,6 +78,7 @@ import DigitalTwin from './pages/DigitalTwin.vue';
 import TwinOperatingPicture from './pages/TwinOperatingPicture.vue';
 import ModelTournament from './pages/ModelTournament.vue';
 import ModelBoard from './pages/ModelBoard.vue';
+import ModelPlatformIntelligence from './pages/ModelPlatformIntelligence.vue';
 import TwinWorldModel from './pages/TwinWorldModel.vue';
 import LandResources from './pages/LandResources.vue';
 import AgenticOS from './pages/AgenticOS.vue';
@@ -125,6 +126,7 @@ const explicitRoutes = [
   { path: '/analytics/twin-workshop', component: TwinOperatingPicture },
   { path: '/analytics/model-tournament', component: ModelTournament },
   { path: '/analytics/model-board', component: ModelBoard },
+  { path: '/professional-intelligence/competitive/model-platforms', component: ModelPlatformIntelligence },
   { path: '/analytics/twin-world-model', component: TwinWorldModel },
   // Layer 0 — Land & Natural Resources (the base of the economic model). Also
   // gives the Weather domain's "Natural Resources" sub-domain a real surface.

--- a/socioprophet-web/client-vue/src/pages/ModelPlatformIntelligence.vue
+++ b/socioprophet-web/client-vue/src/pages/ModelPlatformIntelligence.vue
@@ -1,0 +1,112 @@
+<template>
+  <section class="mp" aria-label="Model platform intelligence">
+    <header class="mp-head">
+      <div>
+        <div class="mp-eyebrow">Professional Intelligence · competitive</div>
+        <h2 class="mp-title">Model Platform Intelligence</h2>
+      </div>
+      <span class="mp-pill">SociOS vs watsonx.ai · SageMaker · Seldon</span>
+    </header>
+    <p class="mp-lede">Where the model board wins — and it's investigable, not asserted. Click a platform to trace the claim to <b>real code</b> in the estate graph and the <b>auto-generated docs</b>.</p>
+
+    <div class="mp-cols">
+      <ol class="mp-rank" aria-label="Ranking">
+        <li v-for="p in ranking" :key="p.id" :class="{ on: sel === p.id, us: !p.vendor }" @click="sel = p.id" tabindex="0" @keydown.enter="sel = p.id">
+          <span class="mp-score">{{ p.score }}</span>
+          <span class="mp-body"><span class="mp-name">{{ p.name }}<span v-if="!p.vendor" class="mp-us">ours</span></span>
+            <span class="mp-sov">{{ p.sovereignty }}</span>
+            <span class="mp-one">{{ p.oneLiner }}</span></span>
+        </li>
+      </ol>
+
+      <aside class="mp-invest" v-if="investigation">
+        <h3 class="mp-ih">Investigate — grounded in code + docs</h3>
+        <p class="mp-isum">{{ investigation.summary }}</p>
+        <div class="mp-ilab">Code graph <span>sociosphere · click to open</span></div>
+        <a v-for="c in investigation.code" :key="c.path" class="mp-ref code" :href="ghUrl(c.repo, c.path)" target="_blank" rel="noopener">
+          <span class="mp-refmono">{{ c.repo }}/{{ c.path }}<b v-if="c.symbol"> · {{ c.symbol }}()</b></span>
+          <span class="mp-reflab">{{ c.label }}</span>
+        </a>
+        <div class="mp-ilab">Auto-generated docs</div>
+        <a v-for="d in investigation.docs" :key="d.path" class="mp-ref doc" :href="specUrl(d.path)" target="_blank" rel="noopener">
+          <span class="mp-refmono">{{ d.path }}</span><span class="mp-reflab">{{ d.title }}</span>
+        </a>
+        <button class="mp-ask" @click="ask">◈ Ask the agent — grounded answer</button>
+        <p v-if="asked" class="mp-asknote">Routed to the grounded NLQA over the docs-index + code graph: <span class="mp-refmono">“{{ investigation.agentQuery }}”</span> — answers cite the refs above and abstain if not grounded.</p>
+      </aside>
+      <aside class="mp-invest" v-else>
+        <h3 class="mp-ih">{{ selName }}</h3>
+        <p class="mp-isum">A vendor platform — strong where it plays, but not sovereignty-ranked, not one board, and its governance isn't a replayable receipt. Select <b>SociOS Model Board</b> to trace our advantage to code + docs.</p>
+      </aside>
+    </div>
+
+    <h3 class="mp-mh">Capability matrix</h3>
+    <table class="mp-mx">
+      <thead><tr><th>Dimension</th><th class="us">SociOS</th><th>watsonx</th><th>SageMaker</th><th>Seldon</th></tr></thead>
+      <tbody>
+        <tr v-for="r in matrix" :key="r.dim" :class="r.verdict">
+          <td class="mp-dim">{{ r.dim }}</td><td class="us">{{ r.sociOS }}</td><td>{{ r.watson }}</td><td>{{ r.sagemaker }}</td><td>{{ r.seldon }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { modelPlatformRanking, capabilityMatrix, investigations } from '../features/competitive-intelligence/modelPlatforms';
+
+const ranking = modelPlatformRanking;
+const matrix = capabilityMatrix;
+const sel = ref('sociOS');
+const investigation = computed(() => investigations[sel.value]);
+const selName = computed(() => ranking.find((p) => p.id === sel.value)?.name ?? '');
+const asked = ref(false);
+function ask() { asked.value = true; }
+
+const REPO_ORG: Record<string, string> = {
+  'agent-machine': 'SourceOS-Linux', 'sourceos-spec': 'SourceOS-Linux', 'prophet-platform': 'SocioProphet',
+};
+function ghUrl(repo: string, path: string) { return `https://github.com/${REPO_ORG[repo] ?? 'SocioProphet'}/${repo}/blob/main/${path}`; }
+function specUrl(path: string) { return `https://github.com/SourceOS-Linux/sourceos-spec/blob/main/${path}`; }
+</script>
+
+<style scoped>
+.mp { padding: 16px; color: var(--text, #e8edf7); }
+.mp-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+.mp-eyebrow { font-family: var(--mono, monospace); font-size: 10.5px; color: var(--faint, #586179); letter-spacing: .5px; }
+.mp-title { margin: 2px 0 0; font-size: 19px; }
+.mp-pill { font-size: 11px; font-family: var(--mono, monospace); color: var(--muted, #8b96b0); border: 1px solid var(--border, #2c3854); border-radius: 12px; padding: 3px 10px; }
+.mp-lede { color: var(--muted, #8b96b0); font-size: 13px; max-width: 78ch; }
+.mp-cols { display: grid; grid-template-columns: 1.1fr 1fr; gap: 14px; align-items: start; }
+@media (max-width: 860px) { .mp-cols { grid-template-columns: 1fr; } }
+.mp-rank { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.mp-rank li { display: grid; grid-template-columns: 40px 1fr; gap: 11px; align-items: center; padding: 11px 13px; border: 1px solid var(--border, #2c3854); border-radius: 11px; cursor: pointer; background: var(--panel, #111726); }
+.mp-rank li.on { border-color: var(--accent, #4fd0e0); box-shadow: inset 3px 0 0 var(--accent, #4fd0e0); }
+.mp-rank li.us { background: color-mix(in srgb, var(--accent, #4fd0e0) 8%, transparent); }
+.mp-score { font-family: var(--mono, monospace); font-size: 20px; font-weight: 700; text-align: center; color: var(--accent, #4fd0e0); }
+.mp-name { font-weight: 640; display: flex; align-items: center; gap: 8px; }
+.mp-us { font-family: var(--mono, monospace); font-size: 9px; font-weight: 700; color: #0a0e18; background: var(--accent, #4fd0e0); border-radius: 4px; padding: 1px 5px; }
+.mp-sov { display: block; font-family: var(--mono, monospace); font-size: 10.5px; color: var(--faint, #586179); margin: 1px 0; }
+.mp-one { display: block; font-size: 11.5px; color: var(--muted, #8b96b0); }
+.mp-invest { border: 1px solid var(--border, #2c3854); border-radius: 12px; padding: 13px 14px; background: var(--panel, #111726); }
+.mp-ih { margin: 0 0 5px; font-size: 13px; color: var(--accent, #4fd0e0); }
+.mp-isum { color: var(--muted, #8b96b0); font-size: 12px; margin: 0 0 10px; }
+.mp-ilab { font-family: var(--mono, monospace); font-size: 10px; color: var(--faint, #586179); text-transform: uppercase; letter-spacing: .5px; margin: 10px 0 6px; display: flex; justify-content: space-between; }
+.mp-ilab span { text-transform: none; letter-spacing: 0; }
+.mp-ref { display: block; text-decoration: none; color: inherit; border: 1px solid var(--border, #2c3854); border-radius: 8px; padding: 7px 10px; margin-bottom: 5px; }
+.mp-ref:hover { border-color: var(--accent, #4fd0e0); }
+.mp-refmono { display: block; font-family: var(--mono, monospace); font-size: 11px; color: var(--text, #e8edf7); word-break: break-all; }
+.mp-refmono b { color: var(--accent, #4fd0e0); font-weight: 600; }
+.mp-reflab { display: block; font-size: 11px; color: var(--muted, #8b96b0); margin-top: 2px; }
+.mp-ask { margin-top: 10px; width: 100%; border: none; border-radius: 9px; padding: 9px; font: inherit; font-weight: 650; font-size: 12.5px; cursor: pointer; background: var(--accent, #4fd0e0); color: #0a0e18; }
+.mp-asknote { font-size: 11.5px; color: var(--muted, #8b96b0); margin: 9px 0 0; }
+.mp-mh { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: var(--faint, #586179); margin: 22px 0 10px; }
+.mp-mx { width: 100%; border-collapse: collapse; font-size: 12px; }
+.mp-mx th, .mp-mx td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--border, #2c3854); }
+.mp-mx th { color: var(--faint, #586179); font-size: 10.5px; text-transform: uppercase; letter-spacing: .4px; }
+.mp-mx .us { color: var(--accent, #4fd0e0); }
+.mp-mx td.us { font-weight: 600; }
+.mp-dim { color: var(--text, #e8edf7); }
+.mp-mx tr.lead td.us { color: #43c68a; }
+</style>


### PR DESCRIPTION
Puts the model board **into the competitive intelligence dashboard**, clickable and investigable by the agent — grounded in the code graph + auto-generated docs.

- **New competitive lens** under *Professional Intelligence · competitive* (tab + `/professional-intelligence/competitive/model-platforms`). It doesn't force the model plane into the consumer 'one-trick' teardown schema — platforms are judged on **governance + sovereignty**: SociOS Model Board ranked **#1** vs watsonx.ai / SageMaker+Bedrock / Seldon, with a capability matrix (foundation+business one board · champion/challenger+drift · DataClass classifiers · replayable receipts · sovereignty ranking · cloud ∩ local).
- **Clickable → agent investigation, grounded**: selecting SociOS traces every advantage to **real code in the estate graph** (`agent-machine/inference_gateway.py`, `inference_backends.py:ollama_backend`, `lattice-studio/…/inference_gateway_leaderboard.py:leaderboard`, `sourceos-spec/tools/promote_model.py:decide_promotion`) **and the auto-generated docs** (docs-index entries: intersection · governance registry · ergonomics), plus an *Ask the agent* grounded-NLQA affordance. The agent cites code + docs; it doesn't assert.

Verified: **vitest 3/3 + routeRegistry 5/5 pass, `vue-tsc --noEmit` 0 errors.**