### PR TITLE
fix(client-vue): post-merge review follow-ups for competitive-superiority-boards (#545)

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/competitiveBoardsApi.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/competitiveBoardsApi.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchCompetitiveBoardsWithFallback } from '../api/competitiveBoardsApi';
+import { COMPETITIVE_BOARDS_FIXTURE } from '../features/competitive-intelligence/boards/fixture';
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('competitiveBoardsApi', () => {
+  it('returns the live dataset and mode when the producer responds ok', async () => {
+    const payload = { ...COMPETITIVE_BOARDS_FIXTURE, service: 'competitive-boards (live)' };
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, statusText: 'OK', json: async () => payload })));
+    const result = await fetchCompetitiveBoardsWithFallback();
+    expect(result.mode).toBe('live');
+    expect(result.data.service).toBe('competitive-boards (live)');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('fails closed to the bundled fixture when the producer 404s', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 404, statusText: 'Not Found', json: async () => ({}) })));
+    const result = await fetchCompetitiveBoardsWithFallback();
+    expect(result.mode).toBe('fixture');
+    expect(result.data).toBe(COMPETITIVE_BOARDS_FIXTURE);
+    expect(result.error).toContain('404');
+  });
+
+  it('fails closed to the bundled fixture when fetch rejects (network error)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+    const result = await fetchCompetitiveBoardsWithFallback();
+    expect(result.mode).toBe('fixture');
+    expect(result.data).toBe(COMPETITIVE_BOARDS_FIXTURE);
+    expect(result.error).toBe('network down');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { COMPETITIVE_BOARDS_FIXTURE } from '../features/competitive-intelligence/boards/fixture';
+import { RANK_ORDER, cellFor, estateCells, tallyBoard, tallyDataset, tallyTotal } from '../features/competitive-intelligence/boards/tally';
+
+describe('competitive-intelligence boards fixture', () => {
+  it('has unique category ids', () => {
+    const ids = COMPETITIVE_BOARDS_FIXTURE.categories.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('gives every category exactly one estate column matching estate_column_id', () => {
+    for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
+      const estateCols = board.columns.filter((c) => c.is_estate);
+      expect(estateCols.length, board.id).toBe(1);
+      expect(estateCols[0]?.id, board.id).toBe(board.estate_column_id);
+    }
+  });
+
+  it('never references a column or feature id that is not declared on the board', () => {
+    for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
+      const colIds = new Set(board.columns.map((c) => c.id));
+      const featIds = new Set(board.features.map((f) => f.id));
+      for (const cell of board.cells) {
+        expect(colIds.has(cell.column_id), `${board.id}: ${cell.column_id}`).toBe(true);
+        expect(featIds.has(cell.feature_id), `${board.id}: ${cell.feature_id}`).toBe(true);
+      }
+    }
+  });
+
+  it('has no duplicate (feature × column) cells', () => {
+    for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
+      const keys = board.cells.map((c) => `${c.feature_id}::${c.column_id}`);
+      expect(new Set(keys).size, board.id).toBe(keys.length);
+    }
+  });
+
+  it('gives every litmus feature an estate cell so the row never renders empty for the estate', () => {
+    for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
+      for (const feat of board.features) {
+        const cell = cellFor(board, feat.id, board.estate_column_id);
+        expect(cell, `${board.id}: ${feat.id}`).toBeDefined();
+      }
+    }
+  });
+});
+
+describe('board tally helpers', () => {
+  const board = COMPETITIVE_BOARDS_FIXTURE.categories[0];
+
+  it('estateCells returns exactly one cell per feature, in feature order', () => {
+    const cells = estateCells(board);
+    expect(cells.map((c) => c.feature_id)).toEqual(board.features.map((f) => f.id));
+  });
+
+  it('tallyBoard counts only the estate column and reconciles with the feature count', () => {
+    const tally = tallyBoard(board);
+    expect(tallyTotal(tally)).toBe(board.features.length);
+  });
+
+  it('tallyDataset sums every category tally', () => {
+    const overall = tallyDataset(COMPETITIVE_BOARDS_FIXTURE);
+    const summed = COMPETITIVE_BOARDS_FIXTURE.categories.reduce((sum, b) => {
+      const t = tallyBoard(b);
+      for (const r of RANK_ORDER) sum[r] += t[r];
+      return sum;
+    }, { BEAT: 0, MEET: 0, PARTIAL: 0, GAP: 0 });
+    expect(overall).toEqual(summed);
+    expect(tallyTotal(overall)).toBe(
+      COMPETITIVE_BOARDS_FIXTURE.categories.reduce((n, b) => n + b.features.length, 0),
+    );
+  });
+
+  it('cellFor returns undefined for a non-existent (feature × column) pair', () => {
+    expect(cellFor(board, 'does-not-exist', board.estate_column_id)).toBeUndefined();
+  });
+});

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
@@ -35,61 +35,61 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="feat in board.features" :key="feat.id">
+          <tr v-for="row in rows" :key="row.feat.id">
             <th scope="row" class="bt-featcell">
               <button
                 type="button"
                 class="bt-feat-toggle"
-                :aria-expanded="expanded.has(feat.id)"
-                :title="feat.definition"
-                @click="toggle(feat.id)"
+                :aria-expanded="expanded.has(row.feat.id)"
+                :title="row.feat.definition"
+                @click="toggle(row.feat.id)"
               >
-                <span class="bt-feat-name">{{ feat.name }}</span>
-                <span class="bt-feat-i" aria-hidden="true">{{ expanded.has(feat.id) ? '−' : 'i' }}</span>
+                <span class="bt-feat-name">{{ row.feat.name }}</span>
+                <span class="bt-feat-i" aria-hidden="true">{{ expanded.has(row.feat.id) ? '−' : 'i' }}</span>
               </button>
-              <p v-if="expanded.has(feat.id)" class="bt-feat-def">{{ feat.definition }}</p>
+              <p v-if="expanded.has(row.feat.id)" class="bt-feat-def">{{ row.feat.definition }}</p>
             </th>
             <td
-              v-for="col in board.columns"
-              :key="col.id"
+              v-for="rc in row.cells"
+              :key="rc.col.id"
               class="bt-cell"
-              :class="{ 'bt-cell--estate': col.is_estate }"
+              :class="{ 'bt-cell--estate': rc.col.is_estate }"
             >
-              <template v-if="cell(feat.id, col.id)">
+              <template v-if="rc.cell">
                 <span
                   class="rank-chip"
-                  :class="`rank-${cell(feat.id, col.id)!.rank.toLowerCase()}`"
-                  :aria-label="`${feat.name} · ${col.name}: ${cell(feat.id, col.id)!.rank}`"
+                  :class="`rank-${rc.cell.rank.toLowerCase()}`"
+                  :aria-label="`${row.feat.name} · ${rc.col.name}: ${rc.cell.rank}`"
                 >
-                  <span class="rank-glyph" aria-hidden="true">{{ glyph(cell(feat.id, col.id)!.rank) }}</span>
-                  {{ cell(feat.id, col.id)!.rank }}
+                  <span class="rank-glyph" aria-hidden="true">{{ glyph(rc.cell.rank) }}</span>
+                  {{ rc.cell.rank }}
                 </span>
-                <template v-if="col.is_estate">
+                <template v-if="rc.col.is_estate">
                   <span class="bt-badges">
                     <span
-                      v-if="cell(feat.id, col.id)!.maturity"
+                      v-if="rc.cell.maturity"
                       class="bt-badge"
-                      :class="`bt-badge--${cell(feat.id, col.id)!.maturity}`"
-                      :title="cell(feat.id, col.id)!.maturity === 'live' ? 'Live — shipped capability' : 'Spec — declared / planned'"
-                    >{{ cell(feat.id, col.id)!.maturity }}</span>
+                      :class="`bt-badge--${rc.cell.maturity}`"
+                      :title="rc.cell.maturity === 'live' ? 'Live — shipped capability' : 'Spec — declared / planned'"
+                    >{{ rc.cell.maturity }}</span>
                     <span
-                      v-if="cell(feat.id, col.id)!.basis"
+                      v-if="rc.cell.basis"
                       class="bt-badge bt-badge--basis"
-                      :title="cell(feat.id, col.id)!.basis === 'externally-certified' ? 'Rank verified by an external party' : 'Rank asserted by the estate'"
-                    >{{ cell(feat.id, col.id)!.basis === 'externally-certified' ? 'certified' : 'self' }}</span>
+                      :title="rc.cell.basis === 'externally-certified' ? 'Rank verified by an external party' : 'Rank asserted by the estate'"
+                    >{{ rc.cell.basis === 'externally-certified' ? 'certified' : 'self' }}</span>
                   </span>
                   <a
-                    v-if="cell(feat.id, col.id)!.evidence"
+                    v-if="rc.cell.evidence"
                     class="bt-evidence"
-                    :href="cell(feat.id, col.id)!.evidence!.href"
+                    :href="rc.cell.evidence.href"
                     target="_blank"
                     rel="noopener noreferrer"
-                  >{{ cell(feat.id, col.id)!.evidence!.label }} ↗</a>
+                  >{{ rc.cell.evidence.label }} ↗</a>
                 </template>
                 <span
-                  v-if="cell(feat.id, col.id)!.note && expanded.has(feat.id)"
+                  v-if="rc.cell.note && expanded.has(row.feat.id)"
                   class="bt-cellnote"
-                >{{ cell(feat.id, col.id)!.note }}</span>
+                >{{ rc.cell.note }}</span>
               </template>
               <span v-else class="bt-cell-empty" aria-label="no data">—</span>
             </td>
@@ -113,7 +113,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import PCard from '../../../components/workbench/PCard.vue';
-import type { BoardRank, CategoryBoard } from '../../../api/competitiveBoardsApi';
+import type { BoardCell, BoardColumn, BoardRank, CategoryBoard, LitmusFeature } from '../../../api/competitiveBoardsApi';
 import { RANK_ORDER, cellFor, tallyBoard } from './tally';
 
 const props = defineProps<{ board: CategoryBoard }>();
@@ -128,9 +128,26 @@ function toggle(id: string) {
   expanded.value = next;
 }
 
-function cell(featureId: string, columnId: string) {
-  return cellFor(props.board, featureId, columnId);
+interface ResolvedCell {
+  col: BoardColumn;
+  cell: BoardCell | undefined;
 }
+interface FeatureRow {
+  feat: LitmusFeature;
+  cells: ResolvedCell[];
+}
+
+// Resolve every (feature × column) cell once per render instead of re-scanning
+// board.cells for the same lookup at every template usage site.
+const rows = computed<FeatureRow[]>(() =>
+  props.board.features.map((feat) => ({
+    feat,
+    cells: props.board.columns.map((col) => ({
+      col,
+      cell: cellFor(props.board, feat.id, col.id),
+    })),
+  })),
+);
 
 function glyph(rank: BoardRank): string {
   return { BEAT: '▲', MEET: '●', PARTIAL: '◐', GAP: '▽' }[rank];


### PR DESCRIPTION
## Context
#545 (competitive-intelligence superiority boards) was merged to `master` while an independent second-pass review of the diff was in progress. No PR review comments existed on #545 to remediate (checked `pulls/545/comments`, `pulls/545/reviews`, and issue comments — all empty; CI was green). This PR carries the fixes from that independent review, on top of current `master`.

## What changed
- `socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue`: the template was calling `cellFor()` (a linear scan over `board.cells`) up to six times per table cell — once each for the rank chip, maturity badge, basis badge, evidence link, and note — and non-null-asserting (`!`) the result at each call site independently. Replaced with a `rows` computed that resolves every `(feature × column)` cell exactly once per render; the template now consumes the resolved cell directly with a single `v-if` guard, no repeated lookups or assertions.
- Added test coverage for the two new pure/data modules the PR introduced (previously untested, unlike sibling competitive-intelligence features which all have coverage):
  - `src/__tests__/competitiveBoardsApi.test.ts` — live-fetch parsing and fail-closed fallback to the bundled fixture (ok, non-ok, and network-rejection cases), mirroring `modelBoardApi.test.ts`.
  - `src/__tests__/competitiveIntelligenceBoards.test.ts` — fixture referential integrity (unique ids, no dangling cell references, no duplicate cells, every litmus feature has an estate cell) and `tally.ts` arithmetic, mirroring `competitiveIntelligenceMarkets.test.ts`.

Also manually verified (outside the diff, no fix needed) that the hand-authored 332-line fixture in `boards/fixture.ts` has no referential-integrity bugs, and that the `routeRegistry.ts` addition uses valid enum values consistent with existing entries.

## Test plan
- [x] `npx vue-tsc --noEmit -p tsconfig.json` passes clean
- [x] `npx vitest run` — 125 test files / 739 tests pass