### PR TITLE
chore(app-vue): vendor url-safe.ts from estate-safety-kit

### DIFF
--- a/socioprophet-web/app-vue/src/services/PROVENANCE.txt
+++ b/socioprophet-web/app-vue/src/services/PROVENANCE.txt
@@ -1,15 +1,12 @@
 source-repo: SourceOS-Linux/sourceos-spec
 source-path: estate-safety-kit/js/urlSafe.ts
-source-commit: 78f5cf69d231ef5d2c9bd6df45bdf500e7a97ced
+source-commit: 297c4e38befc4a04935cd8cd80bd66874888deb0
 vendored-path: socioprophet-web/app-vue/src/services/url-safe.ts
-vendored-at: 2026-08-03
+vendored-at: 2026-08-04
 
-# PROVISIONAL PIN: source-commit above is the head of sourceos-spec PR
-# https://github.com/SourceOS-Linux/sourceos-spec/pull/276 (feat/estate-safety-kit),
-# not yet merged to main. GitHub serves raw content for any pushed commit, so
-# tools/check_vendored_safety_kit.py resolves this pin correctly today, but the
-# branch could be deleted after merge — re-pin source-commit to the actual merge
-# commit on sourceos-spec's main once #276 lands, then re-run the checker.
+# Re-pinned to the actual squash-merge commit on sourceos-spec's main (PR #276 merged).
+# Verified byte-identical against this commit's copy before re-pinning:
+# sha256 9493df8ba2d957798233181f262c30a2fefc718c184200222e119709168703a1 both sides.
 #
 # Run: python3 check_vendored_safety_kit.py url-safe.ts
 # (fetch tools/check_vendored_safety_kit.py from sourceos-spec at source-commit above,

--- a/socioprophet-web/app-vue/src/services/PROVENANCE.txt
+++ b/socioprophet-web/app-vue/src/services/PROVENANCE.txt
@@ -1,0 +1,16 @@
+source-repo: SourceOS-Linux/sourceos-spec
+source-path: estate-safety-kit/js/urlSafe.ts
+source-commit: 78f5cf69d231ef5d2c9bd6df45bdf500e7a97ced
+vendored-path: socioprophet-web/app-vue/src/services/url-safe.ts
+vendored-at: 2026-08-03
+
+# PROVISIONAL PIN: source-commit above is the head of sourceos-spec PR
+# https://github.com/SourceOS-Linux/sourceos-spec/pull/276 (feat/estate-safety-kit),
+# not yet merged to main. GitHub serves raw content for any pushed commit, so
+# tools/check_vendored_safety_kit.py resolves this pin correctly today, but the
+# branch could be deleted after merge — re-pin source-commit to the actual merge
+# commit on sourceos-spec's main once #276 lands, then re-run the checker.
+#
+# Run: python3 check_vendored_safety_kit.py url-safe.ts
+# (fetch tools/check_vendored_safety_kit.py from sourceos-spec at source-commit above,
+# or point --source-root at a local sourceos-spec checkout)

--- a/socioprophet-web/app-vue/src/services/url-safe.ts
+++ b/socioprophet-web/app-vue/src/services/url-safe.ts
@@ -1,17 +1,31 @@
 /**
- * Scheme allow-list for URLs whose source is not this app.
+ * Scheme allow-list for URLs whose source is not the app rendering them.
  *
- * Search results, ontology hits, mail links, ledger provenance — anything that lands in
- * a `:href` from an upstream we do not control (SearXNG federates to arbitrary engines;
- * mail arrives from anywhere; an evidence receipt may cite any URI) must NOT render as a
- * live `<a>` unless the scheme is one a click cannot execute in-origin. Vue does not
- * sanitise `:href`, and `rel="noopener"` blocks only the tab reference — the JS in a
- * `javascript:` link runs before a tab exists.
+ * ESTATE SAFETY KIT — canonical source (SourceOS-Linux/sourceos-spec's estate-safety-kit/).
+ * See estate-safety-kit/PROVENANCE.md in that repo for what this closes,
+ * which repos hit the defect independently, and the vendoring contract every consumer
+ * must follow (verbatim copy + PROVENANCE.txt + `tools/check_vendored_safety_kit.py`).
+ * Do not edit a vendored copy directly — edit this file, re-vendor, done.
+ *
+ * Search results, ontology hits, mail links, ledger provenance, evidence-board links —
+ * anything that lands in a `:href` from an upstream the app does not control (SearXNG
+ * federates to arbitrary engines; mail arrives from anywhere; an evidence receipt may
+ * cite any URI; a BFF's JSON is still an upstream even when it is estate-internal) must
+ * NOT render as a live `<a>` unless the scheme is one a click cannot execute in-origin.
+ * Vue does not sanitise `:href`, and `rel="noopener"` blocks only the tab reference —
+ * the JS in a `javascript:` link runs before a tab exists.
  *
  * Fail closed to plain text for everything else (data:, vbscript:, javascript:, file:,
- * ftp:, custom schemes). If a caller genuinely wants mailto: or tel:, opt in via the
- * second argument. That second argument is INTERSECTED with a fixed safe-extras set —
- * a caller CANNOT re-enable `javascript:` / `data:` / `vbscript:` by passing them in.
+ * ftp:, blob:, about:, custom schemes, protocol-relative `//`). If a caller genuinely
+ * wants mailto: or tel:, opt in via the second argument. That argument is INTERSECTED
+ * with a fixed safe-extras set — a caller CANNOT re-enable `javascript:` / `data:` /
+ * `vbscript:` by passing them in.
+ *
+ * Independently written twice before this file existed: `socioprophet-web/app-vue/src/
+ * services/url-safe.ts` (SocioProphet/socioprophet#477, the Search.vue click-XSS) and
+ * `socioprophet-web/client-vue/src/utils/urlSafe.ts` (SocioProphet/socioprophet#550, the
+ * BoardTable evidence-link hardening) — copy-pasted rather than shared because the two
+ * Vue packages do not share a workspace. Same logic both times; this is that logic, once.
  */
 
 // The extras a caller may opt into. Everything not in this set is silently ignored
@@ -30,10 +44,10 @@ export function isSafeHttp(url: unknown, extra: readonly string[] = []): boolean
   if (!m) return false;
   const s = m[1].toLowerCase();
   if (s === 'http' || s === 'https') return true;
-  // Copilot round-2: normalise the extras callers pass — lowercase + trim — so a
-  // callsite passing `['Mailto']` or `['MAILTO ']` is not mysteriously refused. The
-  // SAFE_EXTRAS filter is what keeps this from becoming an XSS vector: only schemes
-  // in the fixed safe-extras set can be enabled, regardless of what the caller passed.
+  // Normalise the extras callers pass — lowercase + trim — so a callsite passing
+  // `['Mailto']` or `['MAILTO ']` is not mysteriously refused. The SAFE_EXTRAS filter
+  // is what keeps this from becoming an XSS vector: only schemes in the fixed
+  // safe-extras set can be enabled, regardless of what the caller passed in.
   for (const raw of extra) {
     if (typeof raw !== 'string') continue;
     const norm = raw.trim().toLowerCase();


### PR DESCRIPTION
## What this is

`isSafeHttp` (the URL scheme allowlist that closes click-XSS on an unsanitised
`:href`) was written once here, in `app-vue/src/services/url-safe.ts`
([#477](https://github.com/SocioProphet/socioprophet/pull/477)), then
copy-pasted — not imported — into `client-vue/src/utils/urlSafe.ts`
([#550](https://github.com/SocioProphet/socioprophet/pull/550)), because
the two Vue packages don't share a workspace. Real duplication of a
security-relevant helper, found while fixing #550.

[SourceOS-Linux/sourceos-spec#276](https://github.com/SourceOS-Linux/sourceos-spec/pull/276)
adds `estate-safety-kit/js/urlSafe.ts` as the canonical, single source for
both copies (they'd already converged to identical logic — this doesn't
change behavior). This PR re-points `app-vue`'s copy to be a byte-identical
vendored copy of that canonical file, with `PROVENANCE.txt` recording the
source commit, following the vendoring contract in `estate-safety-kit/PROVENANCE.md`
(same shape as `prophet-platform`'s hellgraph-engine vendoring:
verbatim copy + pinned commit + a checker that proves byte-identity).

`client-vue`'s copy is being converted the same way, directly on #550's
branch (`fix/boardtable-scheme-allowlist`), since that file didn't exist on
`master` yet for this PR to touch.

## Dependency ordering

`sourceos-spec#276` is open, not merged. `PROVENANCE.txt`'s `source-commit`
pin here is provisional — it points at that PR's branch head (which GitHub
still serves raw content for), with a note to re-pin to the actual merge
commit once #276 lands. Not blocking this PR's merge on that ordering;
making the dependency explicit instead, per #276's own vendoring contract.

## Verification

No behavior change: the vendored file is logic-identical to what was here
before (only the comments differ — the canonical version documents both
consumers and the vendoring contract instead of just this one call site).
Confirmed with the existing test suite, unchanged: **65/65 app-vue tests
pass** (`npx vitest run`), including all 52 in `url-safe.test.ts` covering
the discriminating allow/deny scheme boundary — same pass/fail outcomes as
before this change.

## Status

**New shared-infrastructure pattern — held for human review of the
vendoring convention, not just the code.** `isSafeHttp`'s behavior here is
unchanged; what's new is that the estate now has one canonical copy instead
of two hand-maintained ones. Not requesting admin-merge.