### PR TITLE
fix(client-vue): competitive-boards — drop the two-independent-ranks design

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { COMPETITIVE_BOARDS_FIXTURE } from '../features/competitive-intelligence/boards/fixture';
-import { RANK_ORDER, cellFor, estateCells, tallyBoard, tallyDataset, tallyTotal } from '../features/competitive-intelligence/boards/tally';
+import { RANK_ORDER, cellFor, tallyBoard, tallyDataset, tallyTotal } from '../features/competitive-intelligence/boards/tally';
 
 describe('competitive-intelligence boards fixture', () => {
   it('has unique category ids', () => {
@@ -8,37 +8,49 @@ describe('competitive-intelligence boards fixture', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('gives every category exactly one estate column matching estate_column_id', () => {
+  it('has no estate pseudo-competitor — the relative-only model has no such column', () => {
     for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
-      const estateCols = board.columns.filter((c) => c.is_estate);
-      expect(estateCols.length, board.id).toBe(1);
-      expect(estateCols[0]?.id, board.id).toBe(board.estate_column_id);
+      const names = board.competitors.map((c) => c.name.toLowerCase());
+      expect(names, board.id).not.toContain('estate');
+      expect(names, board.id).not.toContain('socioprophet');
     }
   });
 
-  it('never references a column or feature id that is not declared on the board', () => {
+  it('never references a competitor or feature id that is not declared on the board', () => {
     for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
-      const colIds = new Set(board.columns.map((c) => c.id));
+      const compIds = new Set(board.competitors.map((c) => c.id));
       const featIds = new Set(board.features.map((f) => f.id));
       for (const cell of board.cells) {
-        expect(colIds.has(cell.column_id), `${board.id}: ${cell.column_id}`).toBe(true);
+        expect(compIds.has(cell.competitor_id), `${board.id}: ${cell.competitor_id}`).toBe(true);
         expect(featIds.has(cell.feature_id), `${board.id}: ${cell.feature_id}`).toBe(true);
       }
     }
   });
 
-  it('has no duplicate (feature × column) cells', () => {
+  it('has no duplicate (feature × competitor) cells', () => {
     for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
-      const keys = board.cells.map((c) => `${c.feature_id}::${c.column_id}`);
+      const keys = board.cells.map((c) => `${c.feature_id}::${c.competitor_id}`);
       expect(new Set(keys).size, board.id).toBe(keys.length);
     }
   });
 
-  it('gives every litmus feature an estate cell so the row never renders empty for the estate', () => {
+  it('gives every litmus feature a cell against every declared competitor — no empty row', () => {
     for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
       for (const feat of board.features) {
-        const cell = cellFor(board, feat.id, board.estate_column_id);
-        expect(cell, `${board.id}: ${feat.id}`).toBeDefined();
+        for (const comp of board.competitors) {
+          const cell = cellFor(board, feat.id, comp.id);
+          expect(cell, `${board.id}: ${feat.id} vs ${comp.id}`).toBeDefined();
+        }
+      }
+    }
+  });
+
+  it('every cell carries evidence, maturity and basis — the relative-only model has no bare cells', () => {
+    for (const board of COMPETITIVE_BOARDS_FIXTURE.categories) {
+      for (const cell of board.cells) {
+        expect(cell.evidence, `${board.id}: ${cell.feature_id} vs ${cell.competitor_id}`).toBeDefined();
+        expect(cell.maturity, `${board.id}: ${cell.feature_id} vs ${cell.competitor_id}`).toBeDefined();
+        expect(cell.basis, `${board.id}: ${cell.feature_id} vs ${cell.competitor_id}`).toBe('self-assessed');
       }
     }
   });
@@ -47,14 +59,9 @@ describe('competitive-intelligence boards fixture', () => {
 describe('board tally helpers', () => {
   const board = COMPETITIVE_BOARDS_FIXTURE.categories[0];
 
-  it('estateCells returns exactly one cell per feature, in feature order', () => {
-    const cells = estateCells(board);
-    expect(cells.map((c) => c.feature_id)).toEqual(board.features.map((f) => f.id));
-  });
-
-  it('tallyBoard counts only the estate column and reconciles with the feature count', () => {
+  it('tallyBoard counts every cell and reconciles with features × competitors', () => {
     const tally = tallyBoard(board);
-    expect(tallyTotal(tally)).toBe(board.features.length);
+    expect(tallyTotal(tally)).toBe(board.features.length * board.competitors.length);
   });
 
   it('tallyDataset sums every category tally', () => {
@@ -66,11 +73,11 @@ describe('board tally helpers', () => {
     }, { BEAT: 0, MEET: 0, PARTIAL: 0, GAP: 0 });
     expect(overall).toEqual(summed);
     expect(tallyTotal(overall)).toBe(
-      COMPETITIVE_BOARDS_FIXTURE.categories.reduce((n, b) => n + b.features.length, 0),
+      COMPETITIVE_BOARDS_FIXTURE.categories.reduce((n, b) => n + b.features.length * b.competitors.length, 0),
     );
   });
 
-  it('cellFor returns undefined for a non-existent (feature × column) pair', () => {
-    expect(cellFor(board, 'does-not-exist', board.estate_column_id)).toBeUndefined();
+  it('cellFor returns undefined for a non-existent (feature × competitor) pair', () => {
+    expect(cellFor(board, 'does-not-exist', board.competitors[0].id)).toBeUndefined();
   });
 });

--- a/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/competitiveIntelligenceBoards.test.ts
@@ -1,6 +1,9 @@
+import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { COMPETITIVE_BOARDS_FIXTURE } from '../features/competitive-intelligence/boards/fixture';
 import { RANK_ORDER, cellFor, tallyBoard, tallyDataset, tallyTotal } from '../features/competitive-intelligence/boards/tally';
+import BoardTable from '../features/competitive-intelligence/boards/BoardTable.vue';
+import type { CategoryBoard } from '../api/competitiveBoardsApi';
 
 describe('competitive-intelligence boards fixture', () => {
   it('has unique category ids', () => {
@@ -79,5 +82,37 @@ describe('board tally helpers', () => {
 
   it('cellFor returns undefined for a non-existent (feature × competitor) pair', () => {
     expect(cellFor(board, 'does-not-exist', board.competitors[0].id)).toBeUndefined();
+  });
+});
+
+describe('BoardTable provisional badge', () => {
+  // The live producer (prophet-platform dashboard-bff GET /v1/competitive-boards) flags a thin
+  // BEAT/MEET lead (spec maturity, or fewer than 2 evidence pointers) as provisional=true rather
+  // than serving it indistinguishable from a solidly-evidenced claim — this must be visible, not
+  // silently dropped by the renderer.
+  const provisionalBoard: CategoryBoard = {
+    id: 'test-cat',
+    name: 'Test category',
+    description: 'test',
+    competitors: [{ id: 'rival', name: 'Rival Co' }],
+    features: [{ id: 'feat-a', name: 'Feature A', definition: 'A test feature.' }],
+    cells: [
+      { feature_id: 'feat-a', competitor_id: 'rival', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', provisional: true },
+    ],
+  };
+
+  it('renders a provisional badge when the cell is flagged provisional', () => {
+    const wrapper = mount(BoardTable, { props: { board: provisionalBoard } });
+    expect(wrapper.find('.bt-badge--provisional').exists()).toBe(true);
+    expect(wrapper.text()).toContain('provisional');
+  });
+
+  it('does not render a provisional badge when the cell is not flagged', () => {
+    const solidBoard: CategoryBoard = {
+      ...provisionalBoard,
+      cells: [{ ...provisionalBoard.cells[0], provisional: false }],
+    };
+    const wrapper = mount(BoardTable, { props: { board: solidBoard } });
+    expect(wrapper.find('.bt-badge--provisional').exists()).toBe(false);
   });
 });

--- a/socioprophet-web/client-vue/src/api/competitiveBoardsApi.ts
+++ b/socioprophet-web/client-vue/src/api/competitiveBoardsApi.ts
@@ -76,6 +76,11 @@ export interface BoardCell {
   basis?: AssessmentBasis;
   /** Short rationale shown on expand. */
   note?: string;
+  /** A thin lead (spec maturity, or fewer than 2 evidence pointers) the producer's own honesty
+   * gate requires to be flagged rather than presented as a solid claim. Absent/false on the
+   * bundled fixture (hand-curated, always evidenced); the live producer sets it per its own
+   * MIN_EVIDENCE_REFS rule — see emit_intelligence_superiority_board.py::_expand_score. */
+  provisional?: boolean;
 }
 
 /** One category comparison board. */

--- a/socioprophet-web/client-vue/src/api/competitiveBoardsApi.ts
+++ b/socioprophet-web/client-vue/src/api/competitiveBoardsApi.ts
@@ -1,22 +1,26 @@
 // Competitive-intelligence comparison-boards API client.
 //
 // Consumes the BOARD DATA MODEL produced by the intelligence-superiority benchmark
-// contract (competitive-intel / strategy plane): per-category comparison boards whose
-// rows are litmus features, whose columns are the estate + each competitor, and whose
-// cells carry a BEAT / MEET / PARTIAL / GAP rank. The estate's own cells additionally
-// carry an evidence link (repo/path/PR), a maturity badge (live vs spec), and an
-// assessment basis (self-assessed vs externally-certified).
+// contract (competitive-intel / strategy plane, dashboard-bff GET /v1/competitive-boards):
+// per-category comparison boards whose rows are litmus features, whose columns are
+// competitors, and whose cells carry a BEAT / MEET / PARTIAL / GAP rank.
+//
+// RELATIVE-ONLY SCORING MODEL — no separate "estate column". A cell is the estate's
+// claim about its standing against ONE competitor on ONE feature; the same feature
+// legitimately carries a different verdict against a different competitor (e.g. BEAT vs
+// Vectara, MEET vs Cohere, on the same row) because nobody independently rated either
+// side's absolute capability — only the estate's comparative claim exists. Every cell
+// therefore carries evidence/maturity/basis, not just a subset of them.
 //
 // Live-first, fail-open-to-fixture — mirrors intelligenceSuperiorityApi.ts /
 // isotaApi.ts: an env-configured base, a getJson wrapper, and a *WithFallback variant
 // that returns a bundled, deterministic fixture when the producer is absent so the
 // surface ALWAYS renders. Scores are NOT hardcoded in the component — the board renders
-// only from this dataset (single source of truth = the benchmark contract). When the
-// producer lands, wire the live seam and the same renderer serves live data unchanged.
+// only from this dataset (single source of truth = the benchmark contract).
 //
-// HONESTY: every board dataset carries an `assessment_basis` on estate cells so the UI
-// badges self-assessed vs externally-certified ranks — a BEAT the estate asserts about
-// itself is never laundered into an independently-certified result.
+// HONESTY: every cell carries an `assessment_basis` so the UI badges self-assessed vs
+// externally-certified ranks — a BEAT the estate asserts about itself is never
+// laundered into an independently-certified result.
 
 import { COMPETITIVE_BOARDS_FIXTURE } from '../features/competitive-intelligence/boards/fixture';
 
@@ -49,26 +53,26 @@ export interface LitmusFeature {
   definition: string;
 }
 
-/** A board column: the estate or one competitor. */
-export interface BoardColumn {
+/** A board column: one named competitor. There is no estate column — see BoardCell. */
+export interface BoardCompetitor {
   id: string;
   name: string;
-  /** True for the estate's own column. */
-  is_estate: boolean;
   /** Optional short descriptor (e.g. the competitor's category posture). */
   note?: string;
 }
 
-/** A single (feature × column) cell. */
+/** One (feature × competitor) cell: the estate's claim about its standing against THAT
+ * competitor on THAT feature. Every cell is an estate claim, so evidence/maturity/basis
+ * live on every cell, not on a subset of them. */
 export interface BoardCell {
   feature_id: string;
-  column_id: string;
+  competitor_id: string;
   rank: BoardRank;
-  /** Estate-only: evidence link (repo/path/PR) grounding the rank. */
+  /** Evidence link (repo/path/PR) grounding the rank. */
   evidence?: { label: string; href: string };
-  /** Estate-only: live (shipped) vs spec (declared). */
+  /** live (shipped) vs spec (declared). */
   maturity?: BoardMaturity;
-  /** Estate-only: self-assessed vs externally-certified. */
+  /** self-assessed vs externally-certified. */
   basis?: AssessmentBasis;
   /** Short rationale shown on expand. */
   note?: string;
@@ -79,9 +83,7 @@ export interface CategoryBoard {
   id: string;
   name: string;
   description: string;
-  /** The column id that is the estate (its cells carry evidence/maturity/basis). */
-  estate_column_id: string;
-  columns: BoardColumn[];
+  competitors: BoardCompetitor[];
   features: LitmusFeature[];
   cells: BoardCell[];
 }
@@ -92,7 +94,7 @@ export interface CompetitiveBoardsDataset {
   version: string;
   /** ISO timestamp the producer stamped. */
   generated_at: string;
-  /** Human label for the estate column across all boards. */
+  /** Human label for the estate across the page (not a column — see BoardCell). */
   estate_label: string;
   categories: CategoryBoard[];
   disclaimer: string;

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
@@ -1,7 +1,9 @@
 <!-- BOARD TABLE — one category comparison board.
-     Rows = litmus features (definition on hover + expand), columns = estate + each
-     competitor, cells = BEAT/MEET/PARTIAL/GAP rank. Estate cells carry an evidence
-     link, a maturity badge (live/spec) and an assessment-basis badge (self/certified).
+     Rows = litmus features (definition on hover + expand), columns = named competitors.
+     RELATIVE-ONLY: each cell is the estate's own claim about its standing against THAT
+     competitor on THAT feature (BEAT/MEET/PARTIAL/GAP) — there is no separate "estate
+     column", so every cell carries an evidence link, a maturity badge (live/spec) and
+     an assessment-basis badge (self/certified), not just a subset of them.
      Ranks are text-labelled + glyph-prefixed so they are never color-only (a11y). -->
 <template>
   <PCard :title="board.name">
@@ -17,20 +19,18 @@
 
     <div class="bt-scroll" role="region" :aria-label="`${board.name} comparison board`" tabindex="0">
       <table class="bt-table">
-        <caption class="sr-only">{{ board.name }}: litmus features (rows) by estate and competitors (columns)</caption>
+        <caption class="sr-only">{{ board.name }}: litmus features (rows) vs competitors (columns), each cell the estate's own verdict against that competitor</caption>
         <thead>
           <tr>
             <th scope="col" class="bt-featcol">Litmus feature</th>
             <th
-              v-for="col in board.columns"
-              :key="col.id"
+              v-for="comp in board.competitors"
+              :key="comp.id"
               scope="col"
               class="bt-colhead"
-              :class="{ 'bt-colhead--estate': col.is_estate }"
             >
-              <span class="bt-colname">{{ col.name }}</span>
-              <span v-if="col.is_estate" class="bt-estate-flag">estate</span>
-              <span v-if="col.note" class="bt-colnote">{{ col.note }}</span>
+              <span class="bt-colname">{{ comp.name }}</span>
+              <span v-if="comp.note" class="bt-colnote">{{ comp.note }}</span>
             </th>
           </tr>
         </thead>
@@ -51,45 +51,42 @@
             </th>
             <td
               v-for="rc in row.cells"
-              :key="rc.col.id"
+              :key="rc.competitor.id"
               class="bt-cell"
-              :class="{ 'bt-cell--estate': rc.col.is_estate }"
             >
               <template v-if="rc.cell">
                 <span
                   class="rank-chip"
                   :class="`rank-${rc.cell.rank.toLowerCase()}`"
-                  :aria-label="`${row.feat.name} · ${rc.col.name}: ${rc.cell.rank}`"
+                  :aria-label="`${row.feat.name} vs ${rc.competitor.name}: ${rc.cell.rank}`"
                 >
                   <span class="rank-glyph" aria-hidden="true">{{ glyph(rc.cell.rank) }}</span>
                   {{ rc.cell.rank }}
                 </span>
-                <template v-if="rc.col.is_estate">
-                  <span class="bt-badges">
-                    <span
-                      v-if="rc.cell.maturity"
-                      class="bt-badge"
-                      :class="`bt-badge--${rc.cell.maturity}`"
-                      :title="rc.cell.maturity === 'live' ? 'Live — shipped capability' : 'Spec — declared / planned'"
-                    >{{ rc.cell.maturity }}</span>
-                    <span
-                      v-if="rc.cell.basis"
-                      class="bt-badge bt-badge--basis"
-                      :title="rc.cell.basis === 'externally-certified' ? 'Rank verified by an external party' : 'Rank asserted by the estate'"
-                    >{{ rc.cell.basis === 'externally-certified' ? 'certified' : 'self' }}</span>
-                  </span>
-                  <a
-                    v-if="rc.cell.evidence && isSafeHttp(rc.cell.evidence.href)"
-                    class="bt-evidence"
-                    :href="rc.cell.evidence.href"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >{{ rc.cell.evidence.label }} ↗</a>
+                <span class="bt-badges">
                   <span
-                    v-else-if="rc.cell.evidence"
-                    class="bt-evidence bt-evidence--unsafe"
-                  >{{ rc.cell.evidence.label }}</span>
-                </template>
+                    v-if="rc.cell.maturity"
+                    class="bt-badge"
+                    :class="`bt-badge--${rc.cell.maturity}`"
+                    :title="rc.cell.maturity === 'live' ? 'Live — shipped capability' : 'Spec — declared / planned'"
+                  >{{ rc.cell.maturity }}</span>
+                  <span
+                    v-if="rc.cell.basis"
+                    class="bt-badge bt-badge--basis"
+                    :title="rc.cell.basis === 'externally-certified' ? 'Rank verified by an external party' : 'Rank asserted by the estate'"
+                  >{{ rc.cell.basis === 'externally-certified' ? 'certified' : 'self' }}</span>
+                </span>
+                <a
+                  v-if="rc.cell.evidence && isSafeHttp(rc.cell.evidence.href)"
+                  class="bt-evidence"
+                  :href="rc.cell.evidence.href"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >{{ rc.cell.evidence.label }} ↗</a>
+                <span
+                  v-else-if="rc.cell.evidence"
+                  class="bt-evidence bt-evidence--unsafe"
+                >{{ rc.cell.evidence.label }}</span>
                 <span
                   v-if="rc.cell.note && expanded.has(row.feat.id)"
                   class="bt-cellnote"
@@ -117,7 +114,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import PCard from '../../../components/workbench/PCard.vue';
-import type { BoardCell, BoardColumn, BoardRank, CategoryBoard, LitmusFeature } from '../../../api/competitiveBoardsApi';
+import type { BoardCell, BoardCompetitor, BoardRank, CategoryBoard, LitmusFeature } from '../../../api/competitiveBoardsApi';
 import { RANK_ORDER, cellFor, tallyBoard } from './tally';
 import { isSafeHttp } from '../../../utils/urlSafe';
 
@@ -134,7 +131,7 @@ function toggle(id: string) {
 }
 
 interface ResolvedCell {
-  col: BoardColumn;
+  competitor: BoardCompetitor;
   cell: BoardCell | undefined;
 }
 interface FeatureRow {
@@ -142,14 +139,14 @@ interface FeatureRow {
   cells: ResolvedCell[];
 }
 
-// Resolve every (feature × column) cell once per render instead of re-scanning
+// Resolve every (feature × competitor) cell once per render instead of re-scanning
 // board.cells for the same lookup at every template usage site.
 const rows = computed<FeatureRow[]>(() =>
   props.board.features.map((feat) => ({
     feat,
-    cells: props.board.columns.map((col) => ({
-      col,
-      cell: cellFor(props.board, feat.id, col.id),
+    cells: props.board.competitors.map((competitor) => ({
+      competitor,
+      cell: cellFor(props.board, feat.id, competitor.id),
     })),
   })),
 );
@@ -172,9 +169,7 @@ function glyph(rank: BoardRank): string {
 
 .bt-featcol { width: 15rem; font-size: var(--fs-eyebrow); text-transform: uppercase; letter-spacing: var(--ls-eyebrow); color: var(--text-3); font-weight: 600; }
 .bt-colhead { min-width: 8rem; }
-.bt-colhead--estate { background: var(--accent-soft); }
 .bt-colname { display: block; font-weight: 700; color: var(--text); }
-.bt-estate-flag { display: inline-block; margin-top: 0.15rem; font-size: 0.56rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); font-weight: 800; }
 .bt-colnote { display: block; margin-top: 0.15rem; font-size: var(--fs-xs); color: var(--text-3); }
 
 .bt-featcell { width: 15rem; }
@@ -183,7 +178,6 @@ function glyph(rank: BoardRank): string {
 .bt-feat-i { display: inline-grid; place-items: center; width: 1.05rem; height: 1.05rem; border: 1px solid var(--line-2); border-radius: 999px; font-size: 0.62rem; font-style: italic; color: var(--text-2); }
 .bt-feat-def { margin: 0.35rem 0 0; font-size: var(--fs-xs); color: var(--text-2); line-height: 1.5; font-style: normal; }
 
-.bt-cell--estate { background: color-mix(in srgb, var(--accent-soft) 60%, transparent); }
 .bt-cell-empty { color: var(--text-3); }
 
 .rank-chip { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.14rem 0.45rem; border-radius: 6px; font-size: var(--fs-xs); font-weight: 800; letter-spacing: 0.05em; border: 1px solid transparent; }

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/BoardTable.vue
@@ -75,6 +75,11 @@
                     class="bt-badge bt-badge--basis"
                     :title="rc.cell.basis === 'externally-certified' ? 'Rank verified by an external party' : 'Rank asserted by the estate'"
                   >{{ rc.cell.basis === 'externally-certified' ? 'certified' : 'self' }}</span>
+                  <span
+                    v-if="rc.cell.provisional"
+                    class="bt-badge bt-badge--provisional"
+                    title="Thin lead — spec maturity or fewer than 2 evidence pointers; the producer's own honesty gate requires this flag rather than presenting it as a solid claim"
+                  >provisional</span>
                 </span>
                 <a
                   v-if="rc.cell.evidence && isSafeHttp(rc.cell.evidence.href)"
@@ -193,6 +198,7 @@ function glyph(rank: BoardRank): string {
 .bt-badge--live { color: var(--live); border-color: rgba(75, 191, 115, 0.4); }
 .bt-badge--spec { color: var(--amber); border-color: rgba(227, 179, 65, 0.4); }
 .bt-badge--basis { color: var(--teal); border-color: rgba(45, 212, 191, 0.4); }
+.bt-badge--provisional { color: var(--amber); border-color: rgba(227, 179, 65, 0.4); }
 .bt-evidence { display: inline-block; margin-top: 0.3rem; font-size: var(--fs-xs); color: var(--info); text-decoration: none; }
 .bt-evidence:hover { text-decoration: underline; }
 .bt-evidence--unsafe { color: var(--text-3); cursor: default; }

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/fixture.ts
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/fixture.ts
@@ -1,9 +1,12 @@
 // Bundled representative board dataset — the fallback the surface renders when the
-// live producer (intelligence-superiority benchmark contract, competitive-intel plane)
-// is unavailable. It is a faithful REPRESENTATIVE of the contract shape, not a measured
-// certification: estate ranks are self-assessed unless a cell says otherwise, and the
-// disclaimer travels with the data. When the live producer is wired, this file is only
-// the offline fallback; the renderer consumes whichever dataset the API client returns.
+// live producer (intelligence-superiority benchmark contract, competitive-intel plane,
+// dashboard-bff GET /v1/competitive-boards) is unavailable. It is a faithful
+// REPRESENTATIVE of the contract shape, not a measured certification.
+//
+// RELATIVE-ONLY SCORING MODEL — no separate estate column. Every cell states the
+// estate's own claim about its standing against ONE competitor on ONE feature; the
+// same feature legitimately carries a different verdict against a different
+// competitor. Evidence/maturity/basis therefore live on every cell.
 //
 // Positioning grounded in the estate's competitive-intelligence register (local-RAG /
 // GraphRAG peers, agent frameworks, eval labs, governance vendors, KG engines,
@@ -16,27 +19,25 @@ const REPO = 'https://github.com/SocioProphet';
 
 export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
   service: 'competitive-boards (bundled fixture)',
-  version: '0.1.0-fixture',
+  version: '0.2.0-fixture',
   generated_at: '2026-08-03T00:00:00Z',
   estate_label: 'SocioProphet estate',
   disclaimer:
-    'Representative fixture, not a measured certification. Estate ranks are self-assessed ' +
-    'unless a cell is marked externally-certified; maturity distinguishes live (shipped) ' +
-    'from spec (declared). Competitor ranks are the estate\'s assessment of open positioning, ' +
-    'not the vendors\' own claims. Wire VITE_COMPETITIVE_BOARDS_BASE to the benchmark producer ' +
-    'for the live board dataset.',
+    'Representative fixture, not a measured certification. Every cell is the estate\'s ' +
+    'own relative claim against that one competitor on that one feature — self-assessed ' +
+    'unless marked externally-certified; maturity distinguishes live (shipped) from spec ' +
+    '(declared). Wire VITE_COMPETITIVE_BOARDS_BASE to the benchmark producer for the live ' +
+    'board dataset.',
   categories: [
     {
       id: 'rag',
       name: 'RAG / Retrieval',
       description:
         'Retrieval-augmented generation over structured knowledge — the local-RAG / GraphRAG field.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'ms-graphrag', name: 'MS GraphRAG', is_estate: false, note: 'GPT-4-class, expensive indexing' },
-        { id: 'lightrag', name: 'LightRAG', is_estate: false, note: 'HKUDS, ~30B dual-layer KG+vector' },
-        { id: 'onyx', name: 'Onyx (Danswer)', is_estate: false, note: 'air-gapped, 40+ connectors' },
+      competitors: [
+        { id: 'ms-graphrag', name: 'MS GraphRAG', note: 'GPT-4-class, expensive indexing' },
+        { id: 'lightrag', name: 'LightRAG', note: 'HKUDS, ~30B dual-layer KG+vector' },
+        { id: 'onyx', name: 'Onyx (Danswer)', note: 'air-gapped, 40+ connectors' },
       ],
       features: [
         { id: 'verified-compute', name: 'Verified compute', definition: 'Executes and verifies computations (modular arithmetic, ODEs) rather than only retrieving text — a capability class retrieval-only systems lack.' },
@@ -46,38 +47,32 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'air-gapped-local', name: 'Air-gapped local operation', definition: 'Runs fully offline on local LLMs with no cloud dependency.' },
       ],
       cells: [
-        { feature_id: 'verified-compute', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'noetica operator library', href: `${REPO}/Noetica/tree/main/reason` }, note: 'Operator + reason lane; retrieval-only peers structurally lack it.' },
-        { feature_id: 'verified-compute', column_id: 'ms-graphrag', rank: 'GAP' },
-        { feature_id: 'verified-compute', column_id: 'lightrag', rank: 'GAP' },
-        { feature_id: 'verified-compute', column_id: 'onyx', rank: 'GAP' },
-        { feature_id: 'selective-retrieval', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'CRAG gate measurement', href: `${REPO}/Noetica` }, note: 'Measured retrieval hurts reasoning; routes around it.' },
-        { feature_id: 'selective-retrieval', column_id: 'ms-graphrag', rank: 'GAP' },
-        { feature_id: 'selective-retrieval', column_id: 'lightrag', rank: 'PARTIAL' },
-        { feature_id: 'selective-retrieval', column_id: 'onyx', rank: 'PARTIAL' },
-        { feature_id: 'frontier-authored-structure', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'glossary canon', href: `${REPO}/socioprophet` }, note: 'Author canon offline; 7B looks it up.' },
-        { feature_id: 'frontier-authored-structure', column_id: 'ms-graphrag', rank: 'GAP', note: 'Pays expensive GPT-4 extraction.' },
-        { feature_id: 'frontier-authored-structure', column_id: 'lightrag', rank: 'GAP' },
-        { feature_id: 'frontier-authored-structure', column_id: 'onyx', rank: 'PARTIAL' },
-        { feature_id: 'grounded-citations', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sourceos-spec Receipt', href: `${REPO}/SourceOS` }, note: 'Receipt fabric > MENTIONS citations, but parity on surfacing.' },
-        { feature_id: 'grounded-citations', column_id: 'ms-graphrag', rank: 'MEET' },
-        { feature_id: 'grounded-citations', column_id: 'lightrag', rank: 'MEET' },
-        { feature_id: 'grounded-citations', column_id: 'onyx', rank: 'MEET' },
-        { feature_id: 'air-gapped-local', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'prophet-mesh local', href: `${REPO}/Noetica` } },
-        { feature_id: 'air-gapped-local', column_id: 'ms-graphrag', rank: 'GAP' },
-        { feature_id: 'air-gapped-local', column_id: 'lightrag', rank: 'PARTIAL' },
-        { feature_id: 'air-gapped-local', column_id: 'onyx', rank: 'BEAT', note: 'Fully air-gapped @37k users — more productized here.' },
+        { feature_id: 'verified-compute', competitor_id: 'ms-graphrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'noetica operator library', href: `${REPO}/Noetica/tree/main/reason` }, note: 'Operator + reason lane; retrieval-only peers structurally lack it.' },
+        { feature_id: 'verified-compute', competitor_id: 'lightrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'noetica operator library', href: `${REPO}/Noetica/tree/main/reason` }, note: 'Operator + reason lane; retrieval-only peers structurally lack it.' },
+        { feature_id: 'verified-compute', competitor_id: 'onyx', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'noetica operator library', href: `${REPO}/Noetica/tree/main/reason` }, note: 'Operator + reason lane; retrieval-only peers structurally lack it.' },
+        { feature_id: 'selective-retrieval', competitor_id: 'ms-graphrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'CRAG gate measurement', href: `${REPO}/Noetica` }, note: 'Measured retrieval hurts reasoning; routes around it.' },
+        { feature_id: 'selective-retrieval', competitor_id: 'lightrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'CRAG gate measurement', href: `${REPO}/Noetica` }, note: 'Measured retrieval hurts reasoning; routes around it.' },
+        { feature_id: 'selective-retrieval', competitor_id: 'onyx', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'CRAG gate measurement', href: `${REPO}/Noetica` }, note: 'Measured retrieval hurts reasoning; routes around it.' },
+        { feature_id: 'frontier-authored-structure', competitor_id: 'ms-graphrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'glossary canon', href: `${REPO}/socioprophet` }, note: 'Pays expensive GPT-4 extraction.' },
+        { feature_id: 'frontier-authored-structure', competitor_id: 'lightrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'glossary canon', href: `${REPO}/socioprophet` }, note: 'Author canon offline; 7B looks it up.' },
+        { feature_id: 'frontier-authored-structure', competitor_id: 'onyx', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'glossary canon', href: `${REPO}/socioprophet` }, note: 'Author canon offline; 7B looks it up.' },
+        { feature_id: 'grounded-citations', competitor_id: 'ms-graphrag', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sourceos-spec Receipt', href: `${REPO}/SourceOS` }, note: 'Receipt fabric > MENTIONS citations, but parity on surfacing.' },
+        { feature_id: 'grounded-citations', competitor_id: 'lightrag', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sourceos-spec Receipt', href: `${REPO}/SourceOS` }, note: 'Receipt fabric > MENTIONS citations, but parity on surfacing.' },
+        { feature_id: 'grounded-citations', competitor_id: 'onyx', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sourceos-spec Receipt', href: `${REPO}/SourceOS` }, note: 'Receipt fabric > MENTIONS citations, but parity on surfacing.' },
+        { feature_id: 'air-gapped-local', competitor_id: 'ms-graphrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'prophet-mesh local', href: `${REPO}/Noetica` } },
+        { feature_id: 'air-gapped-local', competitor_id: 'lightrag', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'prophet-mesh local', href: `${REPO}/Noetica` } },
+        { feature_id: 'air-gapped-local', competitor_id: 'onyx', rank: 'PARTIAL', maturity: 'live', basis: 'self-assessed', evidence: { label: 'prophet-mesh local', href: `${REPO}/Noetica` }, note: 'Fully air-gapped @37k users — more productized here.' },
       ],
     },
     {
       id: 'agent-framework',
       name: 'Agent framework',
-      description: 'Governed multi-step agent execution with tool consent and receipts.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'langgraph', name: 'LangGraph', is_estate: false },
-        { id: 'autogen', name: 'AutoGen', is_estate: false },
-        { id: 'crewai', name: 'CrewAI', is_estate: false },
+      description:
+        'Governed multi-step agent execution with tool consent and receipts.',
+      competitors: [
+        { id: 'langgraph', name: 'LangGraph' },
+        { id: 'autogen', name: 'AutoGen' },
+        { id: 'crewai', name: 'CrewAI' },
       ],
       features: [
         { id: 'governed-tool-consent', name: 'Purpose-bound tool consent', definition: 'Tool calls are gated by purpose-bound consent, not standing broad grants.' },
@@ -86,34 +81,29 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'loop-governance', name: 'Governed loops vs DAGs', definition: 'Loops are explicitly governed (bounded, receipted) rather than free-running graphs.' },
       ],
       cells: [
-        { feature_id: 'governed-tool-consent', column_id: 'estate', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` }, note: 'Purpose-bound consent membrane; frameworks grant broadly.' },
-        { feature_id: 'governed-tool-consent', column_id: 'langgraph', rank: 'GAP' },
-        { feature_id: 'governed-tool-consent', column_id: 'autogen', rank: 'GAP' },
-        { feature_id: 'governed-tool-consent', column_id: 'crewai', rank: 'GAP' },
-        { feature_id: 'fail-closed-gates', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
-        { feature_id: 'fail-closed-gates', column_id: 'langgraph', rank: 'PARTIAL' },
-        { feature_id: 'fail-closed-gates', column_id: 'autogen', rank: 'GAP' },
-        { feature_id: 'fail-closed-gates', column_id: 'crewai', rank: 'GAP' },
-        { feature_id: 'execution-receipts', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'executions-ledger', href: `${REPO}/socioprophet` } },
-        { feature_id: 'execution-receipts', column_id: 'langgraph', rank: 'PARTIAL' },
-        { feature_id: 'execution-receipts', column_id: 'autogen', rank: 'PARTIAL' },
-        { feature_id: 'execution-receipts', column_id: 'crewai', rank: 'GAP' },
-        { feature_id: 'loop-governance', column_id: 'estate', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'loops-vs-DAGs note', href: `${REPO}/socioprophet` } },
-        { feature_id: 'loop-governance', column_id: 'langgraph', rank: 'MEET' },
-        { feature_id: 'loop-governance', column_id: 'autogen', rank: 'PARTIAL' },
-        { feature_id: 'loop-governance', column_id: 'crewai', rank: 'PARTIAL' },
+        { feature_id: 'governed-tool-consent', competitor_id: 'langgraph', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` }, note: 'Purpose-bound consent membrane; frameworks grant broadly.' },
+        { feature_id: 'governed-tool-consent', competitor_id: 'autogen', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` }, note: 'Purpose-bound consent membrane; frameworks grant broadly.' },
+        { feature_id: 'governed-tool-consent', competitor_id: 'crewai', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` }, note: 'Purpose-bound consent membrane; frameworks grant broadly.' },
+        { feature_id: 'fail-closed-gates', competitor_id: 'langgraph', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
+        { feature_id: 'fail-closed-gates', competitor_id: 'autogen', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
+        { feature_id: 'fail-closed-gates', competitor_id: 'crewai', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
+        { feature_id: 'execution-receipts', competitor_id: 'langgraph', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'executions-ledger', href: `${REPO}/socioprophet` } },
+        { feature_id: 'execution-receipts', competitor_id: 'autogen', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'executions-ledger', href: `${REPO}/socioprophet` } },
+        { feature_id: 'execution-receipts', competitor_id: 'crewai', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'executions-ledger', href: `${REPO}/socioprophet` } },
+        { feature_id: 'loop-governance', competitor_id: 'langgraph', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'loops-vs-DAGs note', href: `${REPO}/socioprophet` } },
+        { feature_id: 'loop-governance', competitor_id: 'autogen', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'loops-vs-DAGs note', href: `${REPO}/socioprophet` } },
+        { feature_id: 'loop-governance', competitor_id: 'crewai', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'loops-vs-DAGs note', href: `${REPO}/socioprophet` } },
       ],
     },
     {
       id: 'model-lab-eval',
       name: 'Model lab / eval',
-      description: 'Provider-neutral evaluation with reproduced (not merely cited) metric facts.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'openai-evals', name: 'OpenAI Evals', is_estate: false },
-        { id: 'langsmith', name: 'LangSmith', is_estate: false },
-        { id: 'helm', name: 'HELM', is_estate: false },
+      description:
+        'Provider-neutral evaluation with reproduced (not merely cited) metric facts.',
+      competitors: [
+        { id: 'openai-evals', name: 'OpenAI Evals' },
+        { id: 'langsmith', name: 'LangSmith' },
+        { id: 'helm', name: 'HELM' },
       ],
       features: [
         { id: 'reproduced-not-cited', name: 'Reproduced not cited', definition: 'Metric facts are measured by us (internal_reproduced), not just cited vendor numbers.' },
@@ -122,34 +112,29 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'schema-validated', name: 'Schema-validated facts', definition: 'Every metric fact validates against the canonical eval-metric schema before it is served.' },
       ],
       cells: [
-        { feature_id: 'reproduced-not-cited', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'emit_intelligence_superiority_metrics.py', href: `${REPO}/prophet-platform` }, note: 'internal_reproduced facts vs cited-only leaderboards.' },
-        { feature_id: 'reproduced-not-cited', column_id: 'openai-evals', rank: 'PARTIAL' },
-        { feature_id: 'reproduced-not-cited', column_id: 'langsmith', rank: 'PARTIAL' },
-        { feature_id: 'reproduced-not-cited', column_id: 'helm', rank: 'MEET' },
-        { feature_id: 'provider-neutral', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'Model Tournament · iSOTA', href: `${REPO}/socioprophet` } },
-        { feature_id: 'provider-neutral', column_id: 'openai-evals', rank: 'GAP' },
-        { feature_id: 'provider-neutral', column_id: 'langsmith', rank: 'PARTIAL' },
-        { feature_id: 'provider-neutral', column_id: 'helm', rank: 'MEET' },
-        { feature_id: 'disjoint-honesty', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'dashboard-bff comparison_valid', href: `${REPO}/prophet-platform` } },
-        { feature_id: 'disjoint-honesty', column_id: 'openai-evals', rank: 'GAP' },
-        { feature_id: 'disjoint-honesty', column_id: 'langsmith', rank: 'GAP' },
-        { feature_id: 'disjoint-honesty', column_id: 'helm', rank: 'PARTIAL' },
-        { feature_id: 'schema-validated', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval', href: `${REPO}/prophet-platform` } },
-        { feature_id: 'schema-validated', column_id: 'openai-evals', rank: 'MEET' },
-        { feature_id: 'schema-validated', column_id: 'langsmith', rank: 'MEET' },
-        { feature_id: 'schema-validated', column_id: 'helm', rank: 'MEET' },
+        { feature_id: 'reproduced-not-cited', competitor_id: 'openai-evals', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'emit_intelligence_superiority_metrics.py', href: `${REPO}/prophet-platform` }, note: 'internal_reproduced facts vs cited-only leaderboards.' },
+        { feature_id: 'reproduced-not-cited', competitor_id: 'langsmith', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'emit_intelligence_superiority_metrics.py', href: `${REPO}/prophet-platform` }, note: 'internal_reproduced facts vs cited-only leaderboards.' },
+        { feature_id: 'reproduced-not-cited', competitor_id: 'helm', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'emit_intelligence_superiority_metrics.py', href: `${REPO}/prophet-platform` }, note: 'internal_reproduced facts vs cited-only leaderboards.' },
+        { feature_id: 'provider-neutral', competitor_id: 'openai-evals', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'Model Tournament · iSOTA', href: `${REPO}/socioprophet` } },
+        { feature_id: 'provider-neutral', competitor_id: 'langsmith', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'Model Tournament · iSOTA', href: `${REPO}/socioprophet` } },
+        { feature_id: 'provider-neutral', competitor_id: 'helm', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'Model Tournament · iSOTA', href: `${REPO}/socioprophet` } },
+        { feature_id: 'disjoint-honesty', competitor_id: 'openai-evals', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'dashboard-bff comparison_valid', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'disjoint-honesty', competitor_id: 'langsmith', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'dashboard-bff comparison_valid', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'disjoint-honesty', competitor_id: 'helm', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'dashboard-bff comparison_valid', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'schema-validated', competitor_id: 'openai-evals', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'schema-validated', competitor_id: 'langsmith', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'schema-validated', competitor_id: 'helm', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval', href: `${REPO}/prophet-platform` } },
       ],
     },
     {
       id: 'ai-governance',
       name: 'AI governance / trust',
-      description: 'Evidence-fabric governance: receipts, lawful learning, consent, controls that cannot fail.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'credo', name: 'Credo AI', is_estate: false },
-        { id: 'watsonx-gov', name: 'watsonx.governance', is_estate: false },
-        { id: 'guardrails-ai', name: 'Guardrails AI', is_estate: false },
+      description:
+        'Evidence-fabric governance: receipts, lawful learning, consent, controls that cannot fail.',
+      competitors: [
+        { id: 'credo', name: 'Credo AI' },
+        { id: 'watsonx-gov', name: 'watsonx.governance' },
+        { id: 'guardrails-ai', name: 'Guardrails AI' },
       ],
       features: [
         { id: 'evidence-receipts', name: 'Evidence-fabric receipts', definition: 'Governance decisions are backed by cryptographic, replayable receipts rather than reports.' },
@@ -158,34 +143,29 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'control-cannot-fail', name: 'Control that cannot fail', definition: 'Controls are enforced by construction (fail-closed), verified by artifact not by command.' },
       ],
       cells: [
-        { feature_id: 'evidence-receipts', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'evidence-intake-kernel', href: `${REPO}/evidence-intake-kernel` } },
-        { feature_id: 'evidence-receipts', column_id: 'credo', rank: 'PARTIAL' },
-        { feature_id: 'evidence-receipts', column_id: 'watsonx-gov', rank: 'PARTIAL' },
-        { feature_id: 'evidence-receipts', column_id: 'guardrails-ai', rank: 'GAP' },
-        { feature_id: 'lawful-learning', column_id: 'estate', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'lawful-learning conformance audit', href: `${REPO}/socioprophet` } },
-        { feature_id: 'lawful-learning', column_id: 'credo', rank: 'MEET' },
-        { feature_id: 'lawful-learning', column_id: 'watsonx-gov', rank: 'BEAT', note: 'Externally-audited governance is their moat.' },
-        { feature_id: 'lawful-learning', column_id: 'guardrails-ai', rank: 'GAP' },
-        { feature_id: 'purpose-bound-consent', column_id: 'estate', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'purpose-bound tool consent', href: `${REPO}/socioprophet` } },
-        { feature_id: 'purpose-bound-consent', column_id: 'credo', rank: 'PARTIAL' },
-        { feature_id: 'purpose-bound-consent', column_id: 'watsonx-gov', rank: 'PARTIAL' },
-        { feature_id: 'purpose-bound-consent', column_id: 'guardrails-ai', rank: 'GAP' },
-        { feature_id: 'control-cannot-fail', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
-        { feature_id: 'control-cannot-fail', column_id: 'credo', rank: 'PARTIAL' },
-        { feature_id: 'control-cannot-fail', column_id: 'watsonx-gov', rank: 'MEET' },
-        { feature_id: 'control-cannot-fail', column_id: 'guardrails-ai', rank: 'PARTIAL' },
+        { feature_id: 'evidence-receipts', competitor_id: 'credo', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'evidence-intake-kernel', href: `${REPO}/evidence-intake-kernel` } },
+        { feature_id: 'evidence-receipts', competitor_id: 'watsonx-gov', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'evidence-intake-kernel', href: `${REPO}/evidence-intake-kernel` } },
+        { feature_id: 'evidence-receipts', competitor_id: 'guardrails-ai', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'evidence-intake-kernel', href: `${REPO}/evidence-intake-kernel` } },
+        { feature_id: 'lawful-learning', competitor_id: 'credo', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'lawful-learning conformance audit', href: `${REPO}/socioprophet` } },
+        { feature_id: 'lawful-learning', competitor_id: 'watsonx-gov', rank: 'PARTIAL', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'lawful-learning conformance audit', href: `${REPO}/socioprophet` }, note: 'Externally-audited governance is their moat.' },
+        { feature_id: 'lawful-learning', competitor_id: 'guardrails-ai', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'lawful-learning conformance audit', href: `${REPO}/socioprophet` } },
+        { feature_id: 'purpose-bound-consent', competitor_id: 'credo', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'purpose-bound tool consent', href: `${REPO}/socioprophet` } },
+        { feature_id: 'purpose-bound-consent', competitor_id: 'watsonx-gov', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'purpose-bound tool consent', href: `${REPO}/socioprophet` } },
+        { feature_id: 'purpose-bound-consent', competitor_id: 'guardrails-ai', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'purpose-bound tool consent', href: `${REPO}/socioprophet` } },
+        { feature_id: 'control-cannot-fail', competitor_id: 'credo', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
+        { feature_id: 'control-cannot-fail', competitor_id: 'watsonx-gov', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
+        { feature_id: 'control-cannot-fail', competitor_id: 'guardrails-ai', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'guardrail-fabric', href: `${REPO}/guardrail-fabric` } },
       ],
     },
     {
       id: 'knowledge-graph',
       name: 'Knowledge graph',
-      description: 'Frontier-authored ontology with triple-plausibility grounding and shaping.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'neo4j', name: 'Neo4j', is_estate: false },
-        { id: 'tigergraph', name: 'TigerGraph', is_estate: false },
-        { id: 'foundry', name: 'Palantir Foundry', is_estate: false },
+      description:
+        'Frontier-authored ontology with triple-plausibility grounding and shaping.',
+      competitors: [
+        { id: 'neo4j', name: 'Neo4j' },
+        { id: 'tigergraph', name: 'TigerGraph' },
+        { id: 'foundry', name: 'Palantir Foundry' },
       ],
       features: [
         { id: 'triple-plausibility', name: 'Triple-plausibility grounding', definition: 'KG-BERT held-out triple-plausibility scoring gates what enters the graph.' },
@@ -194,33 +174,28 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'semantic-coords', name: 'Semantic coordinate algebra', definition: 'Concepts carry semantic coordinates enabling algebraic reasoning over meaning.' },
       ],
       cells: [
-        { feature_id: 'triple-plausibility', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'KG-BERT 0.985 n=16990', href: `${REPO}/prophet-platform` } },
-        { feature_id: 'triple-plausibility', column_id: 'neo4j', rank: 'GAP' },
-        { feature_id: 'triple-plausibility', column_id: 'tigergraph', rank: 'GAP' },
-        { feature_id: 'triple-plausibility', column_id: 'foundry', rank: 'PARTIAL' },
-        { feature_id: 'ontogenesis-shaping', column_id: 'estate', rank: 'PARTIAL', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'ontogenesis GI classes', href: `${REPO}/socioprophet` }, note: 'Unshaped GI classes remain — declared, partially shipped.' },
-        { feature_id: 'ontogenesis-shaping', column_id: 'neo4j', rank: 'GAP' },
-        { feature_id: 'ontogenesis-shaping', column_id: 'tigergraph', rank: 'GAP' },
-        { feature_id: 'ontogenesis-shaping', column_id: 'foundry', rank: 'GAP' },
-        { feature_id: 'frontier-canon', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'frontier-authored glossary', href: `${REPO}/socioprophet` } },
-        { feature_id: 'frontier-canon', column_id: 'neo4j', rank: 'PARTIAL' },
-        { feature_id: 'frontier-canon', column_id: 'tigergraph', rank: 'PARTIAL' },
-        { feature_id: 'frontier-canon', column_id: 'foundry', rank: 'MEET' },
-        { feature_id: 'semantic-coords', column_id: 'estate', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'semantic coordinate algebra', href: `${REPO}/socioprophet` } },
-        { feature_id: 'semantic-coords', column_id: 'neo4j', rank: 'GAP' },
-        { feature_id: 'semantic-coords', column_id: 'tigergraph', rank: 'GAP' },
-        { feature_id: 'semantic-coords', column_id: 'foundry', rank: 'PARTIAL' },
+        { feature_id: 'triple-plausibility', competitor_id: 'neo4j', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'KG-BERT 0.985 n=16990', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'triple-plausibility', competitor_id: 'tigergraph', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'KG-BERT 0.985 n=16990', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'triple-plausibility', competitor_id: 'foundry', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'KG-BERT 0.985 n=16990', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'ontogenesis-shaping', competitor_id: 'neo4j', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'ontogenesis GI classes', href: `${REPO}/socioprophet` }, note: 'Unshaped GI classes remain — declared, partially shipped.' },
+        { feature_id: 'ontogenesis-shaping', competitor_id: 'tigergraph', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'ontogenesis GI classes', href: `${REPO}/socioprophet` }, note: 'Unshaped GI classes remain — declared, partially shipped.' },
+        { feature_id: 'ontogenesis-shaping', competitor_id: 'foundry', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'ontogenesis GI classes', href: `${REPO}/socioprophet` }, note: 'Unshaped GI classes remain — declared, partially shipped.' },
+        { feature_id: 'frontier-canon', competitor_id: 'neo4j', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'frontier-authored glossary', href: `${REPO}/socioprophet` } },
+        { feature_id: 'frontier-canon', competitor_id: 'tigergraph', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'frontier-authored glossary', href: `${REPO}/socioprophet` } },
+        { feature_id: 'frontier-canon', competitor_id: 'foundry', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'frontier-authored glossary', href: `${REPO}/socioprophet` } },
+        { feature_id: 'semantic-coords', competitor_id: 'neo4j', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'semantic coordinate algebra', href: `${REPO}/socioprophet` } },
+        { feature_id: 'semantic-coords', competitor_id: 'tigergraph', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'semantic coordinate algebra', href: `${REPO}/socioprophet` } },
+        { feature_id: 'semantic-coords', competitor_id: 'foundry', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'semantic coordinate algebra', href: `${REPO}/socioprophet` } },
       ],
     },
     {
       id: 'ecosystem-marketplace',
       name: 'Ecosystem / marketplace',
-      description: 'Sovereign registry + capability membrane with epistemic-annealing pricing.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'hf-hub', name: 'HuggingFace Hub', is_estate: false },
-        { id: 'langchain-hub', name: 'LangChain Hub', is_estate: false },
+      description:
+        'Sovereign registry + capability membrane with epistemic-annealing pricing.',
+      competitors: [
+        { id: 'hf-hub', name: 'HuggingFace Hub' },
+        { id: 'langchain-hub', name: 'LangChain Hub' },
       ],
       features: [
         { id: 'sovereign-registry', name: 'Sovereign registry', definition: 'Artifacts served from a sovereign, air-gappable registry (zot/gitea) — not a single external hub.' },
@@ -228,26 +203,22 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'annealing-pricing', name: 'Epistemic-annealing pricing', definition: 'Marketplace pricing reflects epistemic value via an annealing model, not flat listing fees.' },
       ],
       cells: [
-        { feature_id: 'sovereign-registry', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sovereign registry', href: `${REPO}/socioprophet` } },
-        { feature_id: 'sovereign-registry', column_id: 'hf-hub', rank: 'GAP' },
-        { feature_id: 'sovereign-registry', column_id: 'langchain-hub', rank: 'GAP' },
-        { feature_id: 'capability-membrane', column_id: 'estate', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` } },
-        { feature_id: 'capability-membrane', column_id: 'hf-hub', rank: 'GAP' },
-        { feature_id: 'capability-membrane', column_id: 'langchain-hub', rank: 'PARTIAL' },
-        { feature_id: 'annealing-pricing', column_id: 'estate', rank: 'PARTIAL', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'epistemic-annealing pricing', href: `${REPO}/socioprophet/blob/master/socioprophet-web/client-vue/docs/marketplace-epistemic-annealing-pricing.md` } },
-        { feature_id: 'annealing-pricing', column_id: 'hf-hub', rank: 'GAP' },
-        { feature_id: 'annealing-pricing', column_id: 'langchain-hub', rank: 'GAP' },
+        { feature_id: 'sovereign-registry', competitor_id: 'hf-hub', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sovereign registry', href: `${REPO}/socioprophet` } },
+        { feature_id: 'sovereign-registry', competitor_id: 'langchain-hub', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'sovereign registry', href: `${REPO}/socioprophet` } },
+        { feature_id: 'capability-membrane', competitor_id: 'hf-hub', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` } },
+        { feature_id: 'capability-membrane', competitor_id: 'langchain-hub', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'capability membrane', href: `${REPO}/socioprophet` } },
+        { feature_id: 'annealing-pricing', competitor_id: 'hf-hub', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'epistemic-annealing pricing', href: `${REPO}/socioprophet/blob/master/socioprophet-web/client-vue/docs/marketplace-epistemic-annealing-pricing.md` } },
+        { feature_id: 'annealing-pricing', competitor_id: 'langchain-hub', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'epistemic-annealing pricing', href: `${REPO}/socioprophet/blob/master/socioprophet-web/client-vue/docs/marketplace-epistemic-annealing-pricing.md` } },
       ],
     },
     {
       id: 'reproducibility',
       name: 'Reproducibility',
-      description: 'Schema-validated, seed-pinned, replayable runs with self-validating checkers.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'wandb', name: 'Weights & Biases', is_estate: false },
-        { id: 'mlflow', name: 'MLflow', is_estate: false },
+      description:
+        'Schema-validated, seed-pinned, replayable runs with self-validating checkers.',
+      competitors: [
+        { id: 'wandb', name: 'Weights & Biases' },
+        { id: 'mlflow', name: 'MLflow' },
       ],
       features: [
         { id: 'schema-facts', name: 'Schema-validated facts', definition: 'Runs emit facts validated against a strict schema (additionalProperties:false) before storage.' },
@@ -256,29 +227,24 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'self-validating-checker', name: 'Self-validating checker', definition: 'The conformance checker validates itself (excluding itself) so it cannot silently pass broken.' },
       ],
       cells: [
-        { feature_id: 'schema-facts', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval strict', href: `${REPO}/prophet-platform` } },
-        { feature_id: 'schema-facts', column_id: 'wandb', rank: 'PARTIAL' },
-        { feature_id: 'schema-facts', column_id: 'mlflow', rank: 'PARTIAL' },
-        { feature_id: 'replayable-envelopes', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'TwinEventEnvelope', href: `${REPO}/socioprophet` } },
-        { feature_id: 'replayable-envelopes', column_id: 'wandb', rank: 'PARTIAL' },
-        { feature_id: 'replayable-envelopes', column_id: 'mlflow', rank: 'MEET' },
-        { feature_id: 'seed-pinned', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'seed1729 / seed2026', href: `${REPO}/prophet-platform` } },
-        { feature_id: 'seed-pinned', column_id: 'wandb', rank: 'MEET' },
-        { feature_id: 'seed-pinned', column_id: 'mlflow', rank: 'MEET' },
-        { feature_id: 'self-validating-checker', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'self-validating checker', href: `${REPO}/socioprophet` } },
-        { feature_id: 'self-validating-checker', column_id: 'wandb', rank: 'GAP' },
-        { feature_id: 'self-validating-checker', column_id: 'mlflow', rank: 'GAP' },
+        { feature_id: 'schema-facts', competitor_id: 'wandb', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval strict', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'schema-facts', competitor_id: 'mlflow', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'schemas/eval strict', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'replayable-envelopes', competitor_id: 'wandb', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'TwinEventEnvelope', href: `${REPO}/socioprophet` } },
+        { feature_id: 'replayable-envelopes', competitor_id: 'mlflow', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'TwinEventEnvelope', href: `${REPO}/socioprophet` } },
+        { feature_id: 'seed-pinned', competitor_id: 'wandb', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'seed1729 / seed2026', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'seed-pinned', competitor_id: 'mlflow', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'seed1729 / seed2026', href: `${REPO}/prophet-platform` } },
+        { feature_id: 'self-validating-checker', competitor_id: 'wandb', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'self-validating checker', href: `${REPO}/socioprophet` } },
+        { feature_id: 'self-validating-checker', competitor_id: 'mlflow', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'self-validating checker', href: `${REPO}/socioprophet` } },
       ],
     },
     {
       id: 'world-model-twin',
       name: 'World model / twin',
-      description: 'Geospatially-grounded state-space twins with a governed impulse core.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'omniverse', name: 'NVIDIA Omniverse', is_estate: false },
-        { id: 'foundry-twin', name: 'Palantir Foundry', is_estate: false },
+      description:
+        'Geospatially-grounded state-space twins with a governed impulse core.',
+      competitors: [
+        { id: 'omniverse', name: 'NVIDIA Omniverse' },
+        { id: 'foundry-twin', name: 'Palantir Foundry' },
       ],
       features: [
         { id: 'governed-impulse', name: 'Governed impulse core', definition: 'Twin dynamics x⁺ = A·x + B·(G·u) route inputs through a gate G that holds the twin fail-closed.' },
@@ -287,29 +253,24 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'geospatial-cop', name: 'Geospatial common operating picture', definition: 'Twins located on a shared geospatial picture over a risk field.' },
       ],
       cells: [
-        { feature_id: 'governed-impulse', column_id: 'estate', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'Twin World Model impulse core', href: `${REPO}/socioprophet` } },
-        { feature_id: 'governed-impulse', column_id: 'omniverse', rank: 'GAP' },
-        { feature_id: 'governed-impulse', column_id: 'foundry-twin', rank: 'PARTIAL' },
-        { feature_id: 'twin-lifecycle-receipts', column_id: 'estate', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'cloud-twin lifecycle', href: `${REPO}/socioprophet` } },
-        { feature_id: 'twin-lifecycle-receipts', column_id: 'omniverse', rank: 'GAP' },
-        { feature_id: 'twin-lifecycle-receipts', column_id: 'foundry-twin', rank: 'PARTIAL' },
-        { feature_id: 'ontology-bound-twin', column_id: 'estate', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'twin ontology', href: `${REPO}/gaia-world-model` } },
-        { feature_id: 'ontology-bound-twin', column_id: 'omniverse', rank: 'MEET' },
-        { feature_id: 'ontology-bound-twin', column_id: 'foundry-twin', rank: 'MEET' },
-        { feature_id: 'geospatial-cop', column_id: 'estate', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'equirectangular COP', href: `${REPO}/socioprophet` } },
-        { feature_id: 'geospatial-cop', column_id: 'omniverse', rank: 'BEAT', note: 'Photoreal simulation is their moat.' },
-        { feature_id: 'geospatial-cop', column_id: 'foundry-twin', rank: 'MEET' },
+        { feature_id: 'governed-impulse', competitor_id: 'omniverse', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'Twin World Model impulse core', href: `${REPO}/socioprophet` } },
+        { feature_id: 'governed-impulse', competitor_id: 'foundry-twin', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'Twin World Model impulse core', href: `${REPO}/socioprophet` } },
+        { feature_id: 'twin-lifecycle-receipts', competitor_id: 'omniverse', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'cloud-twin lifecycle', href: `${REPO}/socioprophet` } },
+        { feature_id: 'twin-lifecycle-receipts', competitor_id: 'foundry-twin', rank: 'BEAT', maturity: 'live', basis: 'self-assessed', evidence: { label: 'cloud-twin lifecycle', href: `${REPO}/socioprophet` } },
+        { feature_id: 'ontology-bound-twin', competitor_id: 'omniverse', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'twin ontology', href: `${REPO}/gaia-world-model` } },
+        { feature_id: 'ontology-bound-twin', competitor_id: 'foundry-twin', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'twin ontology', href: `${REPO}/gaia-world-model` } },
+        { feature_id: 'geospatial-cop', competitor_id: 'omniverse', rank: 'PARTIAL', maturity: 'live', basis: 'self-assessed', evidence: { label: 'equirectangular COP', href: `${REPO}/socioprophet` }, note: 'Photoreal simulation is their moat.' },
+        { feature_id: 'geospatial-cop', competitor_id: 'foundry-twin', rank: 'MEET', maturity: 'live', basis: 'self-assessed', evidence: { label: 'equirectangular COP', href: `${REPO}/socioprophet` } },
       ],
     },
     {
       id: 'risk-value',
       name: 'Risk / value',
-      description: 'Regime-aware calculus over value × time — an EP financial spine.',
-      estate_column_id: 'estate',
-      columns: [
-        { id: 'estate', name: 'SocioProphet', is_estate: true },
-        { id: 'aladdin', name: 'BlackRock Aladdin', is_estate: false },
-        { id: 'bloomberg', name: 'Bloomberg', is_estate: false },
+      description:
+        'Regime-aware calculus over value × time — an EP financial spine.',
+      competitors: [
+        { id: 'aladdin', name: 'BlackRock Aladdin' },
+        { id: 'bloomberg', name: 'Bloomberg' },
       ],
       features: [
         { id: 'regime-aware', name: 'Regime-aware calculus', definition: 'Value/risk computed with an explicit regime-aware calculus (regime + microstructure + vol-surface).' },
@@ -317,16 +278,14 @@ export const COMPETITIVE_BOARDS_FIXTURE: CompetitiveBoardsDataset = {
         { id: 'value-energy', name: 'Value-energy conservation', definition: 'A welfare-annealing framework conserving value-energy while annealing toward global QoL.' },
       ],
       cells: [
-        { feature_id: 'regime-aware', column_id: 'estate', rank: 'PARTIAL', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'omnirisk/EP financial spine', href: `${REPO}/economic-prophet` }, note: 'EP kernel + regime lens declared; not fully shipped.' },
-        { feature_id: 'regime-aware', column_id: 'aladdin', rank: 'BEAT', note: 'Mature risk analytics is their moat.' },
-        { feature_id: 'regime-aware', column_id: 'bloomberg', rank: 'MEET' },
-        { feature_id: 'ep-spine', column_id: 'estate', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'economic-prophet canonical', href: `${REPO}/economic-prophet` } },
-        { feature_id: 'ep-spine', column_id: 'aladdin', rank: 'MEET' },
-        { feature_id: 'ep-spine', column_id: 'bloomberg', rank: 'MEET' },
-        { feature_id: 'value-energy', column_id: 'estate', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'welfare-annealing framework', href: `${REPO}/socioprophet` }, note: 'Constructive inverse of the SILENT failure mode; unique framing.' },
-        { feature_id: 'value-energy', column_id: 'aladdin', rank: 'GAP' },
-        { feature_id: 'value-energy', column_id: 'bloomberg', rank: 'GAP' },
+        { feature_id: 'regime-aware', competitor_id: 'aladdin', rank: 'GAP', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'omnirisk/EP financial spine', href: `${REPO}/economic-prophet` }, note: 'Mature risk analytics is their moat.' },
+        { feature_id: 'regime-aware', competitor_id: 'bloomberg', rank: 'PARTIAL', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'omnirisk/EP financial spine', href: `${REPO}/economic-prophet` }, note: 'EP kernel + regime lens declared; not fully shipped.' },
+        { feature_id: 'ep-spine', competitor_id: 'aladdin', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'economic-prophet canonical', href: `${REPO}/economic-prophet` } },
+        { feature_id: 'ep-spine', competitor_id: 'bloomberg', rank: 'MEET', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'economic-prophet canonical', href: `${REPO}/economic-prophet` } },
+        { feature_id: 'value-energy', competitor_id: 'aladdin', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'welfare-annealing framework', href: `${REPO}/socioprophet` }, note: 'Constructive inverse of the SILENT failure mode; unique framing.' },
+        { feature_id: 'value-energy', competitor_id: 'bloomberg', rank: 'BEAT', maturity: 'spec', basis: 'self-assessed', evidence: { label: 'welfare-annealing framework', href: `${REPO}/socioprophet` }, note: 'Constructive inverse of the SILENT failure mode; unique framing.' },
       ],
     },
   ],
 };
+

--- a/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/tally.ts
+++ b/socioprophet-web/client-vue/src/features/competitive-intelligence/boards/tally.ts
@@ -17,34 +17,24 @@ function emptyTally(): RankTally {
   return { BEAT: 0, MEET: 0, PARTIAL: 0, GAP: 0 };
 }
 
-/** The estate's cells for a board, in feature order. */
-export function estateCells(board: CategoryBoard): BoardCell[] {
-  const byFeature = new Map<string, BoardCell>();
-  for (const cell of board.cells) {
-    if (cell.column_id === board.estate_column_id) byFeature.set(cell.feature_id, cell);
-  }
-  return board.features
-    .map((f) => byFeature.get(f.id))
-    .filter((c): c is BoardCell => Boolean(c));
-}
-
-/** Look up a single cell (feature × column). */
+/** Look up a single cell (feature × competitor). */
 export function cellFor(
   board: CategoryBoard,
   featureId: string,
-  columnId: string,
+  competitorId: string,
 ): BoardCell | undefined {
-  return board.cells.find((c) => c.feature_id === featureId && c.column_id === columnId);
+  return board.cells.find((c) => c.feature_id === featureId && c.competitor_id === competitorId);
 }
 
-/** Per-category tally of the ESTATE column's ranks. */
+/** Per-category tally over EVERY cell — there is no separate estate column to single out;
+ * every cell already is an estate-vs-one-competitor verdict. */
 export function tallyBoard(board: CategoryBoard): RankTally {
   const tally = emptyTally();
-  for (const cell of estateCells(board)) tally[cell.rank] += 1;
+  for (const cell of board.cells) tally[cell.rank] += 1;
   return tally;
 }
 
-/** Overall scorecard = the estate's ranks summed across every category. */
+/** Overall scorecard = every cell's rank summed across every category. */
 export function tallyDataset(dataset: CompetitiveBoardsDataset): RankTally {
   const tally = emptyTally();
   for (const board of dataset.categories) {
@@ -54,7 +44,7 @@ export function tallyDataset(dataset: CompetitiveBoardsDataset): RankTally {
   return tally;
 }
 
-/** Total number of ranked estate cells in a tally (denominator for shares). */
+/** Total number of ranked cells in a tally (denominator for shares). */
 export function tallyTotal(tally: RankTally): number {
   return RANK_ORDER.reduce((sum, rank) => sum + tally[rank], 0);
 }

--- a/socioprophet-web/client-vue/src/pages/CompetitiveIntelligenceBoards.vue
+++ b/socioprophet-web/client-vue/src/pages/CompetitiveIntelligenceBoards.vue
@@ -1,10 +1,13 @@
 <!-- COMPETITIVE INTELLIGENCE · SUPERIORITY BOARDS
      A first-class cockpit surface for the intelligence-superiority comparison boards.
-     Per category: rows = litmus features, columns = estate + competitors, cells =
-     BEAT/MEET/PARTIAL/GAP with the estate's evidence link, maturity (live/spec) and
-     assessment basis (self/certified). Renders ONLY from the benchmark board dataset
-     (single source of truth) — live-first, with a bundled fixture fallback so it
-     always renders. Scores are never hardcoded in this component. -->
+     Per category: rows = litmus features, columns = named competitors, cells =
+     BEAT/MEET/PARTIAL/GAP — the estate's own relative claim against THAT competitor on
+     THAT feature (no separate estate column: nobody independently rated either side's
+     absolute capability, only the estate's comparative claim exists). Every cell carries
+     the estate's evidence link, maturity (live/spec) and assessment basis
+     (self/certified). Renders ONLY from the benchmark board dataset (single source of
+     truth) — live-first, with a bundled fixture fallback so it always renders. Scores
+     are never hardcoded in this component. -->
 <template>
   <section class="cib-page" aria-labelledby="cib-title">
     <SurfaceHeader


### PR DESCRIPTION
## Summary
Closes a real schema mismatch between this UI and its own producer, found while wiring the live board endpoint ([prophet-platform#1334](https://github.com/SocioProphet/prophet-platform/pull/1334)).

The board model had an estate column with its own absolute rank per feature, PLUS each competitor with an independent absolute rank on that same feature. But the producer only ever assesses ONE thing: the estate's relative standing against ONE competitor on ONE feature — the same feature legitimately carries a different verdict against a different competitor, and nobody independently rates either side's absolute capability. There was no honest way to fill an "estate's absolute rank" cell without fabricating a value the producer never asserts.

- `BoardColumn` → `BoardCompetitor` (drops `is_estate`/`estate_column_id`)
- `BoardCell.column_id` → `competitor_id`; every cell now carries evidence/maturity/basis (previously "estate-only" — now every cell IS an estate claim, relative to one named competitor)
- `tallyBoard`/`tallyDataset` sum every cell instead of singling out a now-nonexistent estate column
- `BoardTable.vue` drops the estate-column special-casing — every column renders the same way
- `fixture.ts` mechanically regenerated from the old estate+competitor absolute-rank pairs so every illustrative signal (e.g. "Onyx beats us on air-gapped, more productized") survives as the equivalent relative verdict, not lost or guessed

## Test plan
- [x] `vue-tsc --noEmit` clean
- [x] `vitest run` — 753/753 passed (full suite)
- [x] `vite build` — succeeds
- [x] Verified against the live producer's actual JSON response, field-for-field, not just the TS types