### PR TITLE
feat(client-vue): Data Catalogue + governed acquisition plane (catalogue, policy, reputation, fetch, console)

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/AcquisitionConsole.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/AcquisitionConsole.smoke.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Smoke tests for the Governed Acquisition console (/data/acquisition) — makes the account-tiered
+ * policy gate tangible: flipping the account class re-runs evaluateJob() per source and flips
+ * verdicts. Verifies it mounts, renders verdicts, and that commercial (enforced) blocks strictly
+ * more than sovereign (advisory).
+ */
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AcquisitionConsole from '../pages/AcquisitionConsole.vue';
+
+async function mountConsole() {
+  const w = mount(AcquisitionConsole);
+  await flushPromises();
+  return w;
+}
+
+function blockedCount(text: string): number {
+  return (text.match(/✕ block/g) || []).length;
+}
+
+describe('Governed Acquisition console', () => {
+  it('mounts, defaults to advisory, and renders verdicts', async () => {
+    const w = await mountConsole();
+    const text = w.text();
+    expect(text).toContain('Governed Acquisition');
+    expect(text).toContain('advisory');
+    // advisory allows everything except the-line auth-gated (none in our current catalogue)
+    expect(w.findAll('.ac-verdict').length).toBeGreaterThan(0);
+  });
+
+  it('flipping to Commercial (enforced) blocks strictly more sources than Sovereign (advisory)', async () => {
+    const w = await mountConsole();
+    const advisoryBlocks = blockedCount(w.text());
+
+    const buttons = w.findAll('.ac-seg button');
+    const commercial = buttons.find((b) => b.text().includes('Commercial'))!;
+    await commercial.trigger('click');
+    await flushPromises();
+    const enforcedBlocks = blockedCount(w.text());
+
+    expect(w.text()).toContain('enforced');
+    expect(enforcedBlocks).toBeGreaterThan(advisoryBlocks); // T2+/restricted sources now blocked
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/DataCatalogue.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/DataCatalogue.smoke.test.ts
@@ -35,6 +35,14 @@ describe('Data Catalogue', () => {
     expect(wrapper.findAll('.dc-grade').length).toBeGreaterThan(0);
   });
 
+  it('surfaces the acquisition tier + compliance grade per source (governed plane)', async () => {
+    const wrapper = await mountCatalogue();
+    expect(wrapper.findAll('.dc-tier').length).toBeGreaterThan(0);
+    const text = wrapper.text();
+    expect(text).toContain('Compliance');
+    expect(text).toContain('Tier');
+  });
+
   it('surfaces the honest world grade distribution (not uniformly A)', async () => {
     const wrapper = await mountCatalogue();
     const segs = wrapper.findAll('.dc-dist-seg');

--- a/socioprophet-web/client-vue/src/__tests__/DataCatalogue.smoke.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/DataCatalogue.smoke.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke tests for the Data Catalogue (/data/catalogue) — the searchable registry of every source
+ * plus per-country coverage grading. Verifies it mounts, lists live sources, and honestly renders
+ * the world grade distribution (which must NOT be uniformly "A").
+ */
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import DataCatalogue from '../pages/DataCatalogue.vue';
+
+const stub = { template: '<div />' };
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: stub },
+    { path: '/:pathMatch(.*)*', component: stub },
+  ],
+});
+
+async function mountCatalogue() {
+  const wrapper = mount(DataCatalogue, { global: { plugins: [router] } });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('Data Catalogue', () => {
+  it('mounts and renders the source registry with real upstreams', async () => {
+    const wrapper = await mountCatalogue();
+    const text = wrapper.text();
+    expect(text).toContain('Data Catalogue');
+    expect(text).toContain('Census ACS');
+    expect(text).toContain('USGS earthquakes');
+    expect(text).toContain('World Bank indicators');
+    // grade chips present
+    expect(wrapper.findAll('.dc-grade').length).toBeGreaterThan(0);
+  });
+
+  it('surfaces the honest world grade distribution (not uniformly A)', async () => {
+    const wrapper = await mountCatalogue();
+    const segs = wrapper.findAll('.dc-dist-seg');
+    expect(segs.length).toBe(5); // A B C D F
+    // there is at least one non-A grade band with countries in it
+    const text = wrapper.text();
+    expect(text).toContain('World coverage grade');
+  });
+
+  it('switches to the world tab and lists graded countries', async () => {
+    const wrapper = await mountCatalogue();
+    const worldTab = wrapper.findAll('.dc-tabs button').find((b) => b.text().includes('World coverage'));
+    expect(worldTab).toBeTruthy();
+    await worldTab!.trigger('click');
+    await flushPromises();
+    const countries = wrapper.findAll('.dc-country');
+    expect(countries.length).toBeGreaterThan(150);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/acquisitionFetcher.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/acquisitionFetcher.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { parseRobots, isAllowed, crawlDelayFor } from '../features/acquisition/robots';
+import { RateGovernor } from '../features/acquisition/rateGovernor';
+import { GovernedFetcher, type NetResponse } from '../features/acquisition/fetcher';
+import type { JobEnvelope, SourcePolicy } from '../features/acquisition/policy';
+import type { EgressIdentity } from '../features/acquisition/reputation';
+
+// ── robots.txt ──────────────────────────────────────────────────────────────
+describe('robots.txt parsing + matching', () => {
+  const txt = `
+User-agent: *
+Disallow: /private
+Allow: /private/public
+Crawl-delay: 5
+
+User-agent: sociobot
+Disallow: /
+Sitemap: https://x.example/sitemap.xml
+`;
+  const rules = parseRobots(txt);
+  it('longest-match wins: /private denied but /private/public allowed', () => {
+    expect(isAllowed(rules, 'generic', '/private/data')).toBe(false);
+    expect(isAllowed(rules, 'generic', '/private/public/x')).toBe(true);
+    expect(isAllowed(rules, 'generic', '/open')).toBe(true);
+  });
+  it('a more-specific agent group overrides the * group', () => {
+    expect(isAllowed(rules, 'sociobot/1.0', '/anything')).toBe(false); // Disallow: /
+  });
+  it('parses crawl-delay and sitemaps', () => {
+    expect(crawlDelayFor(rules, 'generic')).toBe(5);
+    expect(rules.sitemaps).toContain('https://x.example/sitemap.xml');
+  });
+  it('supports * and $ wildcards', () => {
+    const r = parseRobots('User-agent: *\nDisallow: /*.pdf$');
+    expect(isAllowed(r, 'g', '/docs/a.pdf')).toBe(false);
+    expect(isAllowed(r, 'g', '/docs/a.pdf?x=1')).toBe(true); // $ anchors end
+  });
+});
+
+// ── rate governor ───────────────────────────────────────────────────────────
+describe('rate governor', () => {
+  it('spaces requests and refills tokens over time', () => {
+    let t = 0;
+    const g = new RateGovernor({ ratePerSec: 1, burst: 2, minSpacingMs: 100, maxBackoffMs: 10000, breakAfter: 3 }, () => t);
+    expect(g.msUntilReady('h')).toBe(0); g.take('h'); // token 1
+    t = 100; expect(g.msUntilReady('h')).toBe(0); g.take('h'); // token 2 after spacing
+    // out of tokens now-ish → must wait
+    expect(g.msUntilReady('h')).toBeGreaterThan(0);
+  });
+  it('backs off then circuit-breaks on repeated throttling', () => {
+    let t = 0;
+    const g = new RateGovernor({ ratePerSec: 5, burst: 5, minSpacingMs: 0, maxBackoffMs: 10000, breakAfter: 3 }, () => t);
+    for (let i = 0; i < 3; i++) g.onResult('h', 429);
+    expect(g.isBroken('h')).toBe(true);
+    g.onResult('h', 200); // a success closes the circuit
+    expect(g.isBroken('h')).toBe(false);
+  });
+});
+
+// ── governed fetcher (orchestration) ─────────────────────────────────────────
+const publicPolicy: SourcePolicy = { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' };
+const identity = (): EgressIdentity => ({ id: 'i', egressClass: 'residential', geo: 'US', fingerprintId: 'fp', cookieJar: 'cj', reputation: 0.7, successes: 0, challenges: 0, blocks: 0, lastUsedAt: 0 });
+const job = (o: Partial<JobEnvelope> = {}): JobEnvelope => ({ accountClass: 'sovereign', sourceId: 'src', policy: publicPolicy, tier: 'T1', now: '2026-08-03T00:00:00Z', ...o });
+
+function fetcherWith(res: NetResponse | (() => Promise<NetResponse>), extra = {}) {
+  const net = typeof res === 'function' ? res : async () => res;
+  return new GovernedFetcher({ net, hash: (b) => `sha256:${b.length}`, now: () => 1_700_000_000_000, ...extra });
+}
+
+describe('GovernedFetcher', () => {
+  it('blocks at policy before any network call (the line)', async () => {
+    let called = false;
+    const f = fetcherWith(async () => { called = true; return { status: 200, headers: {}, body: 'x' }; });
+    const r = await f.fetch({ url: 'https://x.example/a', job: job({ policy: { ...publicPolicy, tos: 'auth-gated' } }), identityPool: [identity()], userAgent: 'sociobot' });
+    expect(r.status).toBe('blocked');
+    expect(called).toBe(false);
+  });
+
+  it('fetches, emits provenance, and lifts reputation on success', async () => {
+    const f = fetcherWith({ status: 200, headers: { etag: 'W/"abc"' }, body: 'hello' });
+    const r = await f.fetch({ url: 'https://x.example/a', job: job(), identityPool: [identity()], userAgent: 'sociobot' });
+    expect(r.status).toBe('ok');
+    expect(r.body).toBe('hello');
+    expect(r.provenance?.contentHash).toBe('sha256:5');
+    expect(r.provenance?.egress).toEqual({ class: 'residential', geo: 'US' });
+    expect(r.identity!.reputation).toBeGreaterThan(0.7);
+  });
+
+  it('sends conditional-GET validators on the second request and handles 304', async () => {
+    const seen: Record<string, string>[] = [];
+    const openGov = new RateGovernor({ ratePerSec: 100, burst: 100, minSpacingMs: 0, maxBackoffMs: 1000, breakAfter: 9 }, () => 1_700_000_000_000);
+    const f = fetcherWith({ status: 200, headers: {}, body: 'x' }, {
+      governor: openGov,
+      net: async (_url: string, opts: { headers: Record<string, string> }) => { seen.push(opts.headers); return seen.length === 1 ? { status: 200, headers: { etag: '"v1"' }, body: 'data' } : { status: 304, headers: {}, body: '' }; },
+    });
+    const base = { url: 'https://x.example/a', job: job(), identityPool: [identity()], userAgent: 'sociobot' };
+    const r1 = await f.fetch(base);
+    expect(r1.status).toBe('ok');
+    const r2 = await f.fetch(base);
+    expect(r2.status).toBe('not-modified');
+    expect(seen[1]['If-None-Match']).toBe('"v1"'); // validator replayed
+  });
+
+  it('defers when the rate governor is not ready', async () => {
+    let t = 0;
+    const gov = new RateGovernor({ ratePerSec: 1, burst: 1, minSpacingMs: 1000, maxBackoffMs: 10000, breakAfter: 3 }, () => t);
+    const f = fetcherWith({ status: 200, headers: {}, body: 'x' }, { governor: gov, now: () => t });
+    const base = { url: 'https://x.example/a', job: job(), identityPool: [identity()], userAgent: 'sociobot' };
+    expect((await f.fetch(base)).status).toBe('ok');       // consumes the one token
+    const second = await f.fetch(base);                     // no tokens, spacing not elapsed
+    expect(second.status).toBe('rate-limited');
+    expect(second.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('enforced mode denies a robots-disallowed path per-URL', async () => {
+    const robots = parseRobots('User-agent: *\nDisallow: /secret');
+    const f = fetcherWith({ status: 200, headers: {}, body: 'x' }, { robotsFor: () => robots });
+    const r = await f.fetch({ url: 'https://x.example/secret/a', job: job({ accountClass: 'commercial', tier: 'T1' }), identityPool: [identity()], userAgent: 'sociobot' });
+    expect(r.status).toBe('robots-denied');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/acquisitionPolicy.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/acquisitionPolicy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolvePosture, evaluateJob, complianceGrade,
+  type JobEnvelope, type SourcePolicy, type AcquisitionProfile, type Override,
+} from '../features/acquisition/policy';
+
+const publicPolicy: SourcePolicy = { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' };
+const base = (over: Partial<JobEnvelope> = {}): JobEnvelope => ({
+  accountClass: 'sovereign', sourceId: 's', policy: publicPolicy, tier: 'T1', now: '2026-08-03T00:00:00Z', ...over,
+});
+const validOverride: Override = { by: 'mdheller', reason: 'documented risk accepted', expiresAt: '2026-12-31T00:00:00Z' };
+
+describe('acquisition policy — posture resolution', () => {
+  it('commercial → enforced, everything else → advisory', () => {
+    expect(resolvePosture('commercial')).toBe('enforced');
+    expect(resolvePosture('sovereign')).toBe('advisory');
+    expect(resolvePosture('research')).toBe('advisory');
+    expect(resolvePosture('own-estate')).toBe('advisory');
+  });
+});
+
+describe('acquisition policy — advisory (default) never blocks except on the line', () => {
+  it('allows a disallowed-robots T4 job but records warnings', () => {
+    const r = evaluateJob(base({ policy: { ...publicPolicy, robots: 'disallowed' }, tier: 'T4' }));
+    expect(r.decision).toBe('allow');
+    expect(r.posture).toBe('advisory');
+    expect(r.warnings.some((w) => w.includes('robots'))).toBe(true);
+  });
+  it('warns on PII and restricted ToS but still allows', () => {
+    const r = evaluateJob(base({ policy: { robots: 'allowed', tos: 'restricted', pii: true, legalBasis: 'public-data' } }));
+    expect(r.decision).toBe('allow');
+    expect(r.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('acquisition policy — enforced (commercial) is compliant-by-default', () => {
+  const commercial = (o: Partial<JobEnvelope> = {}) => base({ accountClass: 'commercial', ...o });
+
+  it('allows a clean public T1 job', () => {
+    expect(evaluateJob(commercial()).decision).toBe('allow');
+  });
+  it('blocks disallowed robots without an override', () => {
+    const r = evaluateJob(commercial({ policy: { ...publicPolicy, robots: 'disallowed' } }));
+    expect(r.decision).toBe('block');
+    expect(r.reasons.some((x) => x.includes('robots'))).toBe(true);
+  });
+  it('blocks T2–T4 tiers without an override', () => {
+    for (const tier of ['T2', 'T3', 'T4'] as const) {
+      expect(evaluateJob(commercial({ tier })).decision).toBe('block');
+    }
+    expect(evaluateJob(commercial({ tier: 'T1' })).decision).toBe('allow');
+  });
+  it('blocks PII with only a public-data basis', () => {
+    const r = evaluateJob(commercial({ policy: { robots: 'allowed', tos: 'public', pii: true, legalBasis: 'public-data' } }));
+    expect(r.decision).toBe('block');
+  });
+  it('a valid override lifts robots + tier gates (but is logged as a warning)', () => {
+    const r = evaluateJob(commercial({ tier: 'T4', policy: { ...publicPolicy, robots: 'disallowed' }, override: validOverride }));
+    expect(r.decision).toBe('allow');
+    expect(r.overrideApplied).toBe(true);
+    expect(r.warnings.every((w) => w.startsWith('override:'))).toBe(true);
+  });
+  it('an expired override does NOT lift gates', () => {
+    const expired: Override = { ...validOverride, expiresAt: '2020-01-01T00:00:00Z' };
+    const r = evaluateJob(commercial({ tier: 'T4', override: expired }));
+    expect(r.decision).toBe('block');
+  });
+});
+
+describe('acquisition policy — the line is absolute', () => {
+  it('auth-gated is blocked in every posture, even with an override', () => {
+    for (const accountClass of ['sovereign', 'commercial'] as const) {
+      const r = evaluateJob(base({ accountClass, policy: { ...publicPolicy, tos: 'auth-gated' }, override: validOverride }));
+      expect(r.decision).toBe('block');
+      expect(r.overrideApplied).toBe(false);
+      expect(r.reasons[0]).toContain('the line');
+    }
+  });
+});
+
+describe('acquisition compliance grade', () => {
+  const prof = (p: Partial<SourcePolicy>, tier: AcquisitionProfile['tier'] = 'T1'): AcquisitionProfile => ({
+    tier, policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data', ...p }, egressDefault: 'direct', freshness: 'daily',
+  });
+  it('clean public API grades A, auth-gated grades F', () => {
+    expect(complianceGrade(prof({}))).toBe('A');
+    expect(complianceGrade(prof({ tos: 'auth-gated' }))).toBe('F');
+  });
+  it('degrades for disallowed robots / restricted ToS / hard walls', () => {
+    expect(complianceGrade(prof({ robots: 'disallowed' }))).toBe('C');
+    expect(complianceGrade(prof({ tos: 'restricted' }, 'T4'))).toBe('D');
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/acquisitionReputation.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/acquisitionReputation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  selectIdentity, scoreOutcome, reputationTier, shouldRetire, motionParams,
+  type EgressIdentity,
+} from '../features/acquisition/reputation';
+
+const id = (over: Partial<EgressIdentity>): EgressIdentity => ({
+  id: 'i', egressClass: 'residential', geo: 'US', fingerprintId: 'fp', cookieJar: 'cj',
+  reputation: 0.6, successes: 0, challenges: 0, blocks: 0, lastUsedAt: 0, ...over,
+});
+
+describe('reputation — identity selection', () => {
+  it('picks the cheapest egress class that satisfies the tier', () => {
+    const pool = [id({ id: 'mob', egressClass: 'mobile' }), id({ id: 'res', egressClass: 'residential' })];
+    // T2 needs >= residential; residential is cheaper than mobile → pick residential.
+    const r = selectIdentity(pool, { tier: 'T2' });
+    expect(r.identity?.id).toBe('res');
+  });
+  it('rejects identities below the tier reputation floor', () => {
+    const pool = [id({ id: 'low', egressClass: 'mobile', reputation: 0.5 })];
+    // T4 needs mobile + rep >= 0.75 → the 0.5-rep mobile fails.
+    expect(selectIdentity(pool, { tier: 'T4' }).identity).toBeNull();
+  });
+  it('honors sticky sessions — never rotates mid-session', () => {
+    const pool = [id({ id: 'a', reputation: 0.9 }), id({ id: 'b', reputation: 0.61 })];
+    const r = selectIdentity(pool, { tier: 'T2', session: 's1' }, { s1: 'b' });
+    expect(r.identity?.id).toBe('b'); // stuck to b even though a is more reputable
+    expect(r.reason).toContain('sticky');
+  });
+  it('prefers an egress in the requested geo', () => {
+    const pool = [id({ id: 'de', geo: 'DE' }), id({ id: 'us', geo: 'US' })];
+    expect(selectIdentity(pool, { tier: 'T2', geo: 'DE' }).identity?.id).toBe('de');
+  });
+});
+
+describe('reputation — learning from outcomes', () => {
+  it('a block pulls reputation down hard; a success lifts it gently', () => {
+    const start = id({ reputation: 0.6 });
+    const blocked = scoreOutcome(start, 'block');
+    expect(blocked.reputation).toBeLessThan(0.4);
+    expect(blocked.blocks).toBe(1);
+    const succeeded = scoreOutcome(start, 'success');
+    expect(succeeded.reputation).toBeGreaterThan(0.6);
+    expect(succeeded.reputation).toBeLessThan(0.75); // gentle
+    expect(succeeded.successes).toBe(1);
+  });
+  it('repeated challenges degrade an identity toward burned', () => {
+    let x = id({ reputation: 0.7 });
+    for (let i = 0; i < 5; i++) x = scoreOutcome(x, 'challenge');
+    expect(reputationTier(x.reputation)).toMatch(/suspect|burned/);
+  });
+  it('flags an identity for retirement once it is burned or repeatedly blocked', () => {
+    expect(shouldRetire(id({ reputation: 0.1 }))).toBe(true);
+    expect(shouldRetire(id({ reputation: 0.25, blocks: 3 }))).toBe(true);
+    expect(shouldRetire(id({ reputation: 0.6 }))).toBe(false);
+  });
+});
+
+describe('reputation — tiers + human motion', () => {
+  it('maps scores to tiers', () => {
+    expect(reputationTier(0.9)).toBe('trusted');
+    expect(reputationTier(0.5)).toBe('neutral');
+    expect(reputationTier(0.05)).toBe('burned');
+  });
+  it('motion params are deterministic per seed and within human ranges', () => {
+    const a = motionParams(42);
+    const b = motionParams(42);
+    expect(a).toEqual(b); // deterministic → session replays consistently
+    expect(a.steps).toBeGreaterThanOrEqual(12);
+    expect(a.thinkMs).toBeGreaterThanOrEqual(300);
+    expect(motionParams(43)).not.toEqual(a); // different seed → different motion
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/acquisitionTransport.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/acquisitionTransport.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { StaticProxyPool, type ProxyEndpoint } from '../features/acquisition/egress';
+import { HttpUnblocker, NullUnblocker } from '../features/acquisition/unblocker';
+import { makeTieredTransport } from '../features/acquisition/transport';
+import type { EgressIdentity } from '../features/acquisition/reputation';
+import type { AcquisitionTier } from '../features/acquisition/policy';
+
+const identity = (o: Partial<EgressIdentity> = {}): EgressIdentity => ({
+  id: 'i', egressClass: 'residential', geo: 'US', fingerprintId: 'fp', cookieJar: 'sess-1',
+  reputation: 0.7, successes: 0, challenges: 0, blocks: 0, lastUsedAt: 0, ...o,
+});
+
+// ── egress pool ───────────────────────────────────────────────────────────────
+describe('StaticProxyPool', () => {
+  const eps: ProxyEndpoint[] = [
+    { id: 'r-us-1', url: 'http://p1', class: 'residential', geo: 'US' },
+    { id: 'r-us-2', url: 'http://p2', class: 'residential', geo: 'US' },
+    { id: 'm-de-1', url: 'http://p3', class: 'mobile', geo: 'DE' },
+  ];
+  it('returns null for a direct identity (no proxy needed)', () => {
+    const pool = new StaticProxyPool(eps);
+    expect(pool.acquire({ egressClass: 'direct', geo: 'US' })).toBeNull();
+  });
+  it('matches class+geo and round-robins within the bucket', () => {
+    const pool = new StaticProxyPool(eps);
+    const a = pool.acquire({ egressClass: 'residential', geo: 'US' });
+    const b = pool.acquire({ egressClass: 'residential', geo: 'US' });
+    expect(new Set([a?.id, b?.id])).toEqual(new Set(['r-us-1', 'r-us-2']));
+  });
+  it('benches an endpoint after repeated failures', () => {
+    let t = 0;
+    const pool = new StaticProxyPool([eps[2]], () => t, 3);
+    for (let i = 0; i < 3; i++) pool.report('m-de-1', false);
+    expect(pool.benchedCount()).toBe(1);
+    expect(pool.acquire({ egressClass: 'mobile', geo: 'DE' })).toBeNull(); // benched → unavailable
+  });
+});
+
+// ── unblocker adapter ─────────────────────────────────────────────────────────
+describe('HttpUnblocker', () => {
+  it('adapts a generic vendor endpoint and enforces a cost cap', async () => {
+    const fakeFetch = (async () => ({
+      status: 200, text: async () => '<html>ok</html>', headers: new Map<string, string>() as unknown as Headers,
+    })) as unknown as typeof fetch;
+    const ub = new HttpUnblocker({
+      endpoint: 'https://vendor/api',
+      buildRequest: (r) => ({ url: 'https://vendor/api', init: { method: 'POST', body: JSON.stringify(r) } }),
+      parseResponse: (raw) => ({ html: raw.body, status: raw.status, egressGeo: 'US', cost: 0.002 }),
+      fetchImpl: fakeFetch,
+      costCapPerReq: 0.001,
+    });
+    await expect(ub.fetch({ url: 'https://x/a' })).rejects.toThrow(/cost/);
+  });
+  it('NullUnblocker makes T4 explicitly unavailable', async () => {
+    await expect(new NullUnblocker().fetch({ url: 'https://x/a' })).rejects.toThrow(/no unblocker/);
+  });
+});
+
+// ── tiered transport routing ────────────────────────────────────────────────
+describe('makeTieredTransport routing', () => {
+  const netOpts = (tier: AcquisitionTier, id = identity()) => ({ headers: {}, identity: id, tier });
+
+  it('T1 fetches direct (no proxy url)', async () => {
+    const seen: Array<{ proxyUrl?: string }> = [];
+    const t = makeTieredTransport({ directFetch: async (_u, o) => { seen.push(o); return { status: 200, headers: {}, body: 'x' }; } });
+    await t('https://x/a', netOpts('T1', identity({ egressClass: 'direct' })));
+    expect(seen[0].proxyUrl).toBeUndefined();
+  });
+
+  it('T2 routes through the proxy pool and reports health', async () => {
+    const pool = new StaticProxyPool([{ id: 'r-us-1', url: 'http://p1', class: 'residential', geo: 'US' }]);
+    const seen: Array<{ proxyUrl?: string }> = [];
+    const t = makeTieredTransport({ proxyPool: pool, directFetch: async (_u, o) => { seen.push(o); return { status: 200, headers: {}, body: 'x' }; } });
+    const res = await t('https://x/a', netOpts('T2'));
+    expect(seen[0].proxyUrl).toBe('http://p1');
+    expect(res.status).toBe(200);
+  });
+
+  it('T2 throws when no proxy is available', async () => {
+    const t = makeTieredTransport({ proxyPool: new StaticProxyPool([]), directFetch: async () => ({ status: 200, headers: {}, body: 'x' }) });
+    await expect(t('https://x/a', netOpts('T2'))).rejects.toThrow(/no residential proxy/);
+  });
+
+  it('T4 routes to the unblocker, not directFetch', async () => {
+    let direct = false;
+    const ub = { fetch: async () => ({ html: '<b>wall</b>', status: 200, egressGeo: 'US', cost: 0.01 }) };
+    const t = makeTieredTransport({ unblocker: ub, directFetch: async () => { direct = true; return { status: 0, headers: {}, body: '' }; } });
+    const res = await t('https://x/a', netOpts('T4'));
+    expect(direct).toBe(false);
+    expect(res.body).toBe('<b>wall</b>');
+  });
+
+  it('T4 without an unblocker throws', async () => {
+    const t = makeTieredTransport({ directFetch: async () => ({ status: 200, headers: {}, body: 'x' }) });
+    await expect(t('https://x/a', netOpts('T4'))).rejects.toThrow(/requires an unblocker/);
+  });
+});

--- a/socioprophet-web/client-vue/src/__tests__/catalogueCoverage.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/catalogueCoverage.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { allCoverage, coverageFor, regionSummaries, worldGradeDistribution } from '../features/catalogue/coverage';
+import { COUNTRIES } from '../data/countries';
+import { DATA_SOURCES } from '../data/dataSources';
+
+describe('data catalogue — per-country coverage grading', () => {
+  it('grades every registered country', () => {
+    const all = allCoverage();
+    expect(all.length).toBe(COUNTRIES.length);
+    expect(all.length).toBeGreaterThan(180); // "all ~195 countries of the world"
+    for (const c of all) expect(['A', 'B', 'C', 'D', 'F']).toContain(c.grade);
+  });
+
+  it('grades the US highest — it holds the US federal stack nobody else has', () => {
+    const us = coverageFor('US')!;
+    expect(us.grade).toBe('A');
+    expect(us.pct).toBe(1); // US is the ceiling the scale normalises against
+    const others = allCoverage().filter((c) => c.iso !== 'US');
+    // No other country reaches an A — honest about the ceiling.
+    expect(others.every((c) => c.grade !== 'A')).toBe(true);
+  });
+
+  it('grades a data-poor low-income state worse than a high-income one (honest, not uniform)', () => {
+    const de = coverageFor('DE')!; // Germany, high income
+    const td = coverageFor('TD')!; // Chad, low income, lightly mapped
+    expect(de.score).toBeGreaterThan(td.score);
+    // The whole point: the world is NOT painted uniformly green.
+    const dist = worldGradeDistribution();
+    const belowC = dist.filter((d) => ['D', 'F'].includes(d.grade)).reduce((n, d) => n + d.count, 0);
+    expect(belowC).toBeGreaterThan(0);
+  });
+
+  it('excludes sovereign and planned sources from country grading', () => {
+    const us = coverageFor('US')!;
+    const hitIds = new Set(us.hits.map((h) => h.id));
+    const sovereignOrPlanned = DATA_SOURCES.filter((s) => s.scope === 'sovereign' || s.status === 'planned');
+    for (const s of sovereignOrPlanned) expect(hitIds.has(s.id)).toBe(false);
+  });
+
+  it('reports a live-source count that never exceeds the total contributing count', () => {
+    for (const c of allCoverage()) {
+      expect(c.liveCount).toBeLessThanOrEqual(c.totalCount);
+      expect(c.liveCount).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('summarises all five regions', () => {
+    const rs = regionSummaries();
+    expect(rs.length).toBe(5);
+    for (const r of rs) {
+      expect(r.countries).toBeGreaterThan(0);
+      const summed = Object.values(r.dist).reduce((a, b) => a + b, 0);
+      expect(summed).toBe(r.countries);
+    }
+  });
+});

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -327,6 +327,7 @@ export const DRAWER_SECTIONS: DrawerSection[] = [
       { label: 'Knowledge Graph', to: '/knowledge/graph' },
       { label: 'Search', to: '/data/search' },
       { label: 'Data Catalogue', to: '/data/catalogue' },
+      { label: 'Governed Acquisition', to: '/data/acquisition' },
       { label: 'Living Ontology', to: '/ontology' },
       { label: 'Noetica Chat', to: '/noetica' },
     ],

--- a/socioprophet-web/client-vue/src/config/cockpitNav.ts
+++ b/socioprophet-web/client-vue/src/config/cockpitNav.ts
@@ -326,6 +326,7 @@ export const DRAWER_SECTIONS: DrawerSection[] = [
     items: [
       { label: 'Knowledge Graph', to: '/knowledge/graph' },
       { label: 'Search', to: '/data/search' },
+      { label: 'Data Catalogue', to: '/data/catalogue' },
       { label: 'Living Ontology', to: '/ontology' },
       { label: 'Noetica Chat', to: '/noetica' },
     ],

--- a/socioprophet-web/client-vue/src/data/acquisitionProfiles.ts
+++ b/socioprophet-web/client-vue/src/data/acquisitionProfiles.ts
@@ -1,0 +1,59 @@
+// Acquisition profile per catalogue source — the governed-plane companion to dataSources.ts.
+// Each source declares HOW we acquire it (tier) and under what policy (robots/ToS/PII/legal basis),
+// from which a compliance grade A–F is derived (features/acquisition/policy.ts). Our current 24 are
+// almost all clean public/open feeds acquired at T0/T1 — the "no-key CORS" moat is also a clean
+// right-to-acquire. The few licensed/restricted sources grade lower, honestly.
+import { type AcquisitionProfile, type SourcePolicy, complianceGrade } from '../features/acquisition/policy';
+import type { Grade } from './dataSources';
+
+const PUBLIC: SourcePolicy = { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' };
+
+// Default: a public T1 fetch (grade A). Only sources that differ are listed explicitly.
+const DEFAULT: AcquisitionProfile = { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'varies' };
+
+const PROFILES: Record<string, AcquisitionProfile> = {
+  // Official APIs / open data — T0, direct, clean.
+  acs: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'annual' },
+  fips: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'static' },
+  treasury: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'daily' },
+  worldbank: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'annual' },
+  fedreg: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'daily' },
+  quakes: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  'nws-alerts': { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  weather: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'hourly' },
+  aqi: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'hourly' },
+  flood: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'quarterly' },
+  markets: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'realtime' },
+  gdelt: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  'hn-news': { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  bsky: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  wikidata: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  labor: { tier: 'T0', policy: PUBLIC, egressDefault: 'direct', freshness: 'daily' },
+  // OSM family — T1 over Overpass/Nominatim, ODbL public.
+  osm: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  overpass: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  streets: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  geocode: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  transit: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  cowork: { tier: 'T1', policy: PUBLIC, egressDefault: 'direct', freshness: 'live' },
+  // Municipal open feeds — public but uneven robots; still A/B.
+  crime: { tier: 'T1', policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' }, egressDefault: 'direct', freshness: 'daily' },
+  // Free-tier keyed — public data, needs a key (minted in CI).
+  fred: { tier: 'T0', policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' }, egressDefault: 'direct', freshness: 'monthly' },
+  // Legal: CourtListener is a public free-tier API (A); PACER (auth-gated) is out — we take CourtListener only.
+  courts: { tier: 'T1', policy: { robots: 'allowed', tos: 'restricted', pii: false, legalBasis: 'public-data' }, egressDefault: 'direct', freshness: 'daily' },
+  // Licensed commercial panels — restricted ToS, licensed basis (not scraped).
+  mobility: { tier: 'T0', policy: { robots: 'allowed', tos: 'restricted', pii: true, legalBasis: 'licensed' }, egressDefault: 'direct', freshness: 'daily' },
+  logistics: { tier: 'T0', policy: { robots: 'allowed', tos: 'restricted', pii: false, legalBasis: 'licensed' }, egressDefault: 'direct', freshness: 'live' },
+  // Sovereign — our own governed substrate, direct.
+  controlplane: { tier: 'T0', policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'sovereign' }, egressDefault: 'direct', freshness: 'live' },
+  hellgraph: { tier: 'T0', policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'sovereign' }, egressDefault: 'direct', freshness: 'live' },
+  holographme: { tier: 'T0', policy: { robots: 'allowed', tos: 'public', pii: true, legalBasis: 'consent' }, egressDefault: 'direct', freshness: 'live' },
+};
+
+export interface SourceAcquisition { profile: AcquisitionProfile; grade: Grade }
+
+export function acquisitionFor(sourceId: string): SourceAcquisition {
+  const profile = PROFILES[sourceId] ?? DEFAULT;
+  return { profile, grade: complianceGrade(profile) };
+}

--- a/socioprophet-web/client-vue/src/data/countries.ts
+++ b/socioprophet-web/client-vue/src/data/countries.ts
@@ -1,0 +1,209 @@
+// The world registry — every UN member state (+ key observers/territories), used by the data
+// catalogue to grade per-country coverage. income tier (H/UM/LM/L) is a coarse proxy for how
+// much open data a country tends to expose; the catalogue combines it with each source's real
+// geographic scope to produce an HONEST per-country data-quality grade (A–F), including F.
+export type Region = 'Americas' | 'Europe' | 'Africa' | 'Asia' | 'Oceania';
+export type Income = 'H' | 'UM' | 'LM' | 'L';
+export interface Country { iso: string; name: string; region: Region; income: Income }
+
+// iso2 | name | region | income. UN members + Vatican/Palestine/Kosovo/Taiwan.
+const RAW = `
+US|United States|Americas|H
+CA|Canada|Americas|H
+MX|Mexico|Americas|UM
+BR|Brazil|Americas|UM
+AR|Argentina|Americas|UM
+CL|Chile|Americas|H
+CO|Colombia|Americas|UM
+PE|Peru|Americas|UM
+VE|Venezuela|Americas|UM
+EC|Ecuador|Americas|UM
+BO|Bolivia|Americas|LM
+PY|Paraguay|Americas|UM
+UY|Uruguay|Americas|H
+GY|Guyana|Americas|H
+SR|Suriname|Americas|UM
+GT|Guatemala|Americas|UM
+HN|Honduras|Americas|LM
+SV|El Salvador|Americas|LM
+NI|Nicaragua|Americas|LM
+CR|Costa Rica|Americas|UM
+PA|Panama|Americas|H
+CU|Cuba|Americas|UM
+DO|Dominican Republic|Americas|UM
+HT|Haiti|Americas|L
+JM|Jamaica|Americas|UM
+TT|Trinidad and Tobago|Americas|H
+BS|Bahamas|Americas|H
+BB|Barbados|Americas|H
+BZ|Belize|Americas|UM
+GB|United Kingdom|Europe|H
+FR|France|Europe|H
+DE|Germany|Europe|H
+IT|Italy|Europe|H
+ES|Spain|Europe|H
+PT|Portugal|Europe|H
+NL|Netherlands|Europe|H
+BE|Belgium|Europe|H
+LU|Luxembourg|Europe|H
+IE|Ireland|Europe|H
+CH|Switzerland|Europe|H
+AT|Austria|Europe|H
+SE|Sweden|Europe|H
+NO|Norway|Europe|H
+DK|Denmark|Europe|H
+FI|Finland|Europe|H
+IS|Iceland|Europe|H
+PL|Poland|Europe|H
+CZ|Czechia|Europe|H
+SK|Slovakia|Europe|H
+HU|Hungary|Europe|H
+RO|Romania|Europe|H
+BG|Bulgaria|Europe|UM
+GR|Greece|Europe|H
+HR|Croatia|Europe|H
+SI|Slovenia|Europe|H
+RS|Serbia|Europe|UM
+BA|Bosnia and Herzegovina|Europe|UM
+ME|Montenegro|Europe|UM
+MK|North Macedonia|Europe|UM
+AL|Albania|Europe|UM
+XK|Kosovo|Europe|UM
+UA|Ukraine|Europe|LM
+BY|Belarus|Europe|UM
+MD|Moldova|Europe|UM
+LT|Lithuania|Europe|H
+LV|Latvia|Europe|H
+EE|Estonia|Europe|H
+RU|Russia|Europe|UM
+VA|Vatican City|Europe|H
+MT|Malta|Europe|H
+CY|Cyprus|Europe|H
+AD|Andorra|Europe|H
+MC|Monaco|Europe|H
+SM|San Marino|Europe|H
+LI|Liechtenstein|Europe|H
+CN|China|Asia|UM
+JP|Japan|Asia|H
+KR|South Korea|Asia|H
+KP|North Korea|Asia|L
+IN|India|Asia|LM
+PK|Pakistan|Asia|LM
+BD|Bangladesh|Asia|LM
+LK|Sri Lanka|Asia|LM
+NP|Nepal|Asia|LM
+BT|Bhutan|Asia|LM
+MV|Maldives|Asia|UM
+AF|Afghanistan|Asia|L
+ID|Indonesia|Asia|UM
+MY|Malaysia|Asia|UM
+SG|Singapore|Asia|H
+TH|Thailand|Asia|UM
+VN|Vietnam|Asia|LM
+PH|Philippines|Asia|LM
+MM|Myanmar|Asia|LM
+KH|Cambodia|Asia|LM
+LA|Laos|Asia|LM
+BN|Brunei|Asia|H
+TL|Timor-Leste|Asia|LM
+TW|Taiwan|Asia|H
+MN|Mongolia|Asia|LM
+KZ|Kazakhstan|Asia|UM
+UZ|Uzbekistan|Asia|LM
+TM|Turkmenistan|Asia|UM
+KG|Kyrgyzstan|Asia|LM
+TJ|Tajikistan|Asia|LM
+SA|Saudi Arabia|Asia|H
+AE|United Arab Emirates|Asia|H
+QA|Qatar|Asia|H
+KW|Kuwait|Asia|H
+BH|Bahrain|Asia|H
+OM|Oman|Asia|H
+YE|Yemen|Asia|L
+IQ|Iraq|Asia|UM
+IR|Iran|Asia|LM
+SY|Syria|Asia|L
+JO|Jordan|Asia|LM
+LB|Lebanon|Asia|LM
+IL|Israel|Asia|H
+PS|Palestine|Asia|LM
+TR|Turkey|Asia|UM
+GE|Georgia|Asia|UM
+AM|Armenia|Asia|UM
+AZ|Azerbaijan|Asia|UM
+EG|Egypt|Africa|LM
+LY|Libya|Africa|UM
+TN|Tunisia|Africa|LM
+DZ|Algeria|Africa|LM
+MA|Morocco|Africa|LM
+SD|Sudan|Africa|L
+SS|South Sudan|Africa|L
+ET|Ethiopia|Africa|L
+ER|Eritrea|Africa|L
+DJ|Djibouti|Africa|LM
+SO|Somalia|Africa|L
+KE|Kenya|Africa|LM
+UG|Uganda|Africa|L
+TZ|Tanzania|Africa|LM
+RW|Rwanda|Africa|L
+BI|Burundi|Africa|L
+NG|Nigeria|Africa|LM
+GH|Ghana|Africa|LM
+CI|Cote d'Ivoire|Africa|LM
+SN|Senegal|Africa|LM
+ML|Mali|Africa|L
+BF|Burkina Faso|Africa|L
+NE|Niger|Africa|L
+TD|Chad|Africa|L
+MR|Mauritania|Africa|LM
+GN|Guinea|Africa|L
+SL|Sierra Leone|Africa|L
+LR|Liberia|Africa|L
+TG|Togo|Africa|L
+BJ|Benin|Africa|LM
+GM|Gambia|Africa|L
+GW|Guinea-Bissau|Africa|L
+CV|Cabo Verde|Africa|LM
+CM|Cameroon|Africa|LM
+CF|Central African Republic|Africa|L
+CG|Congo|Africa|LM
+CD|DR Congo|Africa|L
+GA|Gabon|Africa|UM
+GQ|Equatorial Guinea|Africa|UM
+ST|Sao Tome and Principe|Africa|LM
+AO|Angola|Africa|LM
+ZM|Zambia|Africa|LM
+ZW|Zimbabwe|Africa|LM
+MW|Malawi|Africa|L
+MZ|Mozambique|Africa|L
+BW|Botswana|Africa|UM
+NA|Namibia|Africa|UM
+ZA|South Africa|Africa|UM
+LS|Lesotho|Africa|LM
+SZ|Eswatini|Africa|LM
+MG|Madagascar|Africa|L
+MU|Mauritius|Africa|UM
+SC|Seychelles|Africa|H
+KM|Comoros|Africa|LM
+AU|Australia|Oceania|H
+NZ|New Zealand|Oceania|H
+PG|Papua New Guinea|Oceania|LM
+FJ|Fiji|Oceania|UM
+SB|Solomon Islands|Oceania|LM
+VU|Vanuatu|Oceania|LM
+WS|Samoa|Oceania|LM
+TO|Tonga|Oceania|UM
+KI|Kiribati|Oceania|LM
+FM|Micronesia|Oceania|LM
+MH|Marshall Islands|Oceania|UM
+PW|Palau|Oceania|H
+NR|Nauru|Oceania|H
+TV|Tuvalu|Oceania|UM
+`;
+
+export const COUNTRIES: Country[] = RAW.trim().split('\n').map((line) => {
+  const [iso, name, region, income] = line.split('|');
+  return { iso, name, region: region as Region, income: income as Income };
+});
+
+export const REGIONS: Region[] = ['Americas', 'Europe', 'Africa', 'Asia', 'Oceania'];

--- a/socioprophet-web/client-vue/src/data/dataSources.ts
+++ b/socioprophet-web/client-vue/src/data/dataSources.ts
@@ -1,50 +1,87 @@
-// The data catalog — every source the cockpit reads, registered in one place with
-// its live-adapter status. The #1 credibility gap is "fixtures vs. live feeds";
-// this registry is the seam: each source declares the real upstream it stands in
-// for, the surfaces it feeds, and whether the live adapter is wired yet.
+// The data catalog — every source the cockpit reads, registered in one place with its live-adapter
+// status, real upstream endpoint, license, geographic scope, and an HONEST quality grade. The #1
+// credibility gap is "fixtures vs. live feeds"; this registry is the seam. Graphical integrity is
+// the moat (Tufte): we grade our own data A–F and say plainly where it's thin. `scope` +
+// `coverageModel` drive the per-country grading in features/catalogue/coverage.ts.
 export type AdapterStatus = 'live' | 'fixture' | 'planned';
 export type SourceDomain = 'Civic' | 'Markets' | 'Real Estate' | 'Legal' | 'News' | 'Geospatial' | 'Graph' | 'Supply' | 'Economy' | 'Weather' | 'Identity';
+export type Grade = 'A' | 'B' | 'C' | 'D' | 'F';
+// Auth requirement — the moat is "no-key CORS": free open feeds we can call straight from the browser.
+export type KeyReq = 'none' | 'free-tier' | 'commercial' | 'sovereign';
+// How a source's coverage maps onto the world (see coverage.ts for the weighting math).
+//  us            — United States only (federal/agency data)
+//  us-metros     — a set of US metros only (GTFS-class)
+//  geo-global    — physical/model, genuinely uniform worldwide (earthquakes, weather, air)
+//  mapped-global — depends on human OSM mapping density; strong in cities, thin in poor/rural regions
+//  stats-global  — national statistics / structured data; tracks a state's statistical capacity
+//  media-global  — worldwide but thins in lower-income/less-covered countries (news, events, social)
+//  markets-global— market/econ data, strong in developed markets, thin in frontier
+//  sparse-global — technically worldwide, genuinely thin everywhere (niche panels)
+//  sovereign     — our own governed substrate, not a country-indexed feed
+export type CoverageModel = 'us' | 'us-metros' | 'geo-global' | 'mapped-global' | 'stats-global' | 'media-global' | 'sparse-global' | 'markets-global' | 'sovereign';
 
 export interface DataSource {
   id: string;
   name: string;
   domain: SourceDomain;
-  upstream: string;        // the real-world feed this represents
+  upstream: string;          // the real-world feed this represents
   status: AdapterStatus;
-  feeds: string[];         // surfaces / layers it powers
-  cadence: string;         // refresh cadence
+  feeds: string[];           // surfaces / layers it powers
+  cadence: string;           // refresh cadence
   license: string;
+  // Catalogue metadata (added in the catalogue build):
+  endpoint?: string;         // real upstream URL when live
+  adapter?: string;          // src/data/adapters/*.ts module backing it
+  scope: CoverageModel;      // geographic reach
+  keyReq: KeyReq;            // auth requirement to reach it
+  grade: Grade;              // honest overall data-quality grade for THIS source
+  gradeNote: string;         // one line: why that grade — the honest caveat
 }
 
 export const DATA_SOURCES: DataSource[] = [
-  // Civic (map layers)
-  { id: 'acs', name: 'Census ACS', domain: 'Civic', upstream: 'US Census American Community Survey', status: 'fixture', feeds: ['Map · People', 'Map · Economic', 'Map · Housing'], cadence: 'annual', license: 'public domain' },
-  { id: 'cdc-places', name: 'CDC PLACES', domain: 'Civic', upstream: 'CDC PLACES health measures', status: 'fixture', feeds: ['Map · Health'], cadence: 'annual', license: 'public domain' },
-  { id: 'doj-ucr', name: 'DOJ / FBI UCR', domain: 'Civic', upstream: 'FBI Uniform Crime Reporting', status: 'fixture', feeds: ['Map · Public Safety'], cadence: 'annual', license: 'public domain' },
-  { id: 'nces', name: 'NCES / DOE', domain: 'Civic', upstream: 'Dept. of Education NCES', status: 'fixture', feeds: ['Map · Education'], cadence: 'annual', license: 'public domain' },
-  { id: 'mobility', name: 'Mobility panel', domain: 'Civic', upstream: 'Placer / SafeGraph-class mobility', status: 'planned', feeds: ['Map · Foot Traffic', 'Site selection'], cadence: 'daily', license: 'commercial' },
-  { id: 'epa-aqi', name: 'EPA AirNow', domain: 'Civic', upstream: 'EPA AirNow AQI', status: 'fixture', feeds: ['Map · Environment'], cadence: 'hourly', license: 'public domain' },
-  { id: 'gtfs', name: 'Transit GTFS', domain: 'Civic', upstream: 'Agency GTFS feeds', status: 'planned', feeds: ['Map · Mobility'], cadence: 'live', license: 'open' },
-  { id: 'civic-cal', name: 'Civic calendar', domain: 'Civic', upstream: 'Permits / civic event calendars', status: 'fixture', feeds: ['Map · Community events'], cadence: 'daily', license: 'open' },
-  // Real estate
-  { id: 'mls', name: 'MLS / property', domain: 'Real Estate', upstream: 'MLS + CoStar-class property data', status: 'planned', feeds: ['Map · Real Estate', 'Site selection'], cadence: 'daily', license: 'commercial' },
-  // Markets / economy
-  { id: 'markets', name: 'Market data', domain: 'Markets', upstream: 'Exchange / Bloomberg-class feed', status: 'fixture', feeds: ['Market Monitor', 'Portfolio', 'Algo'], cadence: 'realtime', license: 'commercial' },
-  { id: 'fred', name: 'FRED / BLS', domain: 'Economy', upstream: 'St. Louis Fed FRED + BLS', status: 'fixture', feeds: ['Economy', 'Value Drivers'], cadence: 'monthly', license: 'public domain' },
-  // Legal
-  { id: 'fedreg', name: 'Federal Register', domain: 'Legal', upstream: 'federalregister.gov + Cornell LII', status: 'fixture', feeds: ['Law & Regulation'], cadence: 'daily', license: 'public domain' },
-  { id: 'courts', name: 'Court dockets', domain: 'Legal', upstream: 'PACER / court docket feeds', status: 'planned', feeds: ['Law · Case law'], cadence: 'daily', license: 'mixed' },
-  // News / social
-  { id: 'rss', name: 'RSS / Atom', domain: 'News', upstream: 'Publisher RSS/Atom/JSON Feed', status: 'fixture', feeds: ['News'], cadence: 'live', license: 'open' },
-  { id: 'bsky', name: 'Bluesky (ATProto)', domain: 'News', upstream: 'Bluesky AppView / PDS firehose', status: 'planned', feeds: ['News · Social'], cadence: 'live', license: 'open' },
-  // Geospatial + graph
-  { id: 'osm', name: 'OpenStreetMap', domain: 'Geospatial', upstream: 'OSM tiles + Overpass', status: 'live', feeds: ['Map basemap'], cadence: 'live', license: 'ODbL' },
-  { id: 'gaia', name: 'GAIA world model', domain: 'Geospatial', upstream: 'GAIA OSM ingest / tile catalog', status: 'fixture', feeds: ['Map · GAIA layers'], cadence: 'batch', license: 'ODbL' },
-  { id: 'hellgraph', name: 'HellGraph', domain: 'Graph', upstream: 'Sovereign federated hypergraph (Hypercore/Autobase)', status: 'live', feeds: ['Graph dock', 'PersonGraph', 'KnowledgeGraph'], cadence: 'live', license: 'sovereign' },
-  // Supply / weather / identity
-  { id: 'logistics', name: 'Logistics telemetry', domain: 'Supply', upstream: 'project44 / FourKites-class', status: 'planned', feeds: ['Supply Chain', 'Digital Twin'], cadence: 'live', license: 'commercial' },
-  { id: 'nws', name: 'NWS / NOAA', domain: 'Weather', upstream: 'National Weather Service', status: 'fixture', feeds: ['Weather', 'Land & Resources'], cadence: 'hourly', license: 'public domain' },
-  { id: 'holographme', name: 'HolographMe', domain: 'Identity', upstream: 'HolographMe reputation lattice', status: 'planned', feeds: ['People', 'News', 'Marketplace'], cadence: 'live', license: 'sovereign' },
+  // ── Civic / demographics (US federal + agency) ─────────────────────────────
+  { id: 'acs', name: 'Census ACS', domain: 'Civic', upstream: 'US Census American Community Survey (ACS5) + TIGERweb tracts', status: 'live', adapter: 'censusLive', endpoint: 'https://api.census.gov/data/2023/acs/acs5', scope: 'us', keyReq: 'none', cadence: 'annual', license: 'public domain', grade: 'A', feeds: ['Map · People', 'Map · Economic', 'Map · Housing'], gradeNote: 'Gold-standard US demographics at tract resolution; ~1yr lag, US-only.' },
+  { id: 'fips', name: 'FCC / Census FIPS', domain: 'Civic', upstream: 'FCC Census Block API (lat/lon → FIPS)', status: 'live', adapter: 'fipsLive', endpoint: 'https://geo.fcc.gov/api/census/area', scope: 'us', keyReq: 'none', cadence: 'static', license: 'public domain', grade: 'A', feeds: ['Geocoding · FIPS', 'Map join keys'], gradeNote: 'Authoritative US block/county FIPS resolver; US-only reference data.' },
+  { id: 'aqi', name: 'Air quality (Open-Meteo)', domain: 'Civic', upstream: 'Open-Meteo Air Quality (CAMS/GEOS-CF)', status: 'live', adapter: 'airLive', endpoint: 'https://air-quality-api.open-meteo.com/v1/air-quality', scope: 'geo-global', keyReq: 'none', cadence: 'hourly', license: 'CC-BY 4.0', grade: 'B', feeds: ['Map · Environment', 'Weather'], gradeNote: 'Global modeled AQI, hourly; model output not ground sensors, so local spikes can be smoothed.' },
+  { id: 'crime', name: 'Crime incidents', domain: 'Civic', upstream: 'Open municipal crime feeds (Socrata-class)', status: 'live', adapter: 'crimeLive', scope: 'us', keyReq: 'none', cadence: 'daily', license: 'open / public domain', grade: 'C', feeds: ['Map · Public Safety'], gradeNote: 'Only the US cities that publish open feeds; no national coverage, definitions vary by city.' },
+  { id: 'cdc-places', name: 'CDC PLACES', domain: 'Civic', upstream: 'CDC PLACES health measures', status: 'fixture', scope: 'us', keyReq: 'none', cadence: 'annual', license: 'public domain', grade: 'B', feeds: ['Map · Health'], gradeNote: 'Modeled small-area health estimates; not yet wired to a live adapter.' },
+  { id: 'nces', name: 'NCES / DOE', domain: 'Civic', upstream: 'Dept. of Education NCES', status: 'fixture', scope: 'us', keyReq: 'none', cadence: 'annual', license: 'public domain', grade: 'C', feeds: ['Map · Education'], gradeNote: 'US school data; fixture only for now, annual lag.' },
+  { id: 'mobility', name: 'Mobility panel', domain: 'Civic', upstream: 'Placer / SafeGraph-class mobility', status: 'planned', scope: 'sparse-global', keyReq: 'commercial', cadence: 'daily', license: 'commercial', grade: 'D', feeds: ['Map · Foot Traffic', 'Site selection'], gradeNote: 'Commercial panel, no free adapter; sampled not census — inferential only.' },
+  // ── Geospatial (OpenStreetMap family — global) ─────────────────────────────
+  { id: 'osm', name: 'OpenStreetMap basemap', domain: 'Geospatial', upstream: 'OSM raster/vector tiles', status: 'live', adapter: '(MapLibre)', endpoint: 'https://tile.openstreetmap.org', scope: 'mapped-global', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'A', feeds: ['Map basemap'], gradeNote: 'Best open global basemap; density varies — sparse in rural low-income regions.' },
+  { id: 'overpass', name: 'Overpass (OSM query)', domain: 'Geospatial', upstream: 'Overpass API over OSM', status: 'live', adapter: 'overpassLive', endpoint: 'https://overpass-api.de/api/interpreter', scope: 'mapped-global', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'B', feeds: ['Map · POIs', 'Land mask'], gradeNote: 'Global feature queries; completeness tracks OSM mapping density, thin outside cities.' },
+  { id: 'streets', name: 'Street network', domain: 'Geospatial', upstream: 'Overpass ways → routing graph', status: 'live', adapter: 'streetsLive', endpoint: 'https://overpass-api.de/api/interpreter', scope: 'mapped-global', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'B', feeds: ['Isochrones', 'Map · Streets'], gradeNote: 'Real routable graph where OSM is well-mapped; degrades in poorly-mapped areas.' },
+  { id: 'geocode', name: 'Nominatim geocoder', domain: 'Geospatial', upstream: 'OSM Nominatim', status: 'live', adapter: 'geocodeLive', endpoint: 'https://nominatim.openstreetmap.org/search', scope: 'mapped-global', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'B', feeds: ['Search · Places'], gradeNote: 'Global forward/reverse geocoding; 1 req/s courtesy limit, address coverage uneven.' },
+  { id: 'wikidata', name: 'Wikidata', domain: 'Geospatial', upstream: 'Wikidata entities/SPARQL', status: 'live', adapter: 'wikidataLive', endpoint: 'https://www.wikidata.org/w/api.php', scope: 'stats-global', keyReq: 'none', cadence: 'live', license: 'CC0', grade: 'B', feeds: ['Entity enrichment', 'Graph'], gradeNote: 'Global structured entities, CC0; coverage/quality varies by topic and language.' },
+  { id: 'gaia', name: 'GAIA world model', domain: 'Geospatial', upstream: 'GAIA OSM ingest / WorldClaim tile catalog', status: 'fixture', scope: 'mapped-global', keyReq: 'sovereign', cadence: 'batch', license: 'ODbL + sovereign', grade: 'C', feeds: ['Map · GAIA layers'], gradeNote: 'Our governed world-model layer; ingest pipeline live, cockpit still reads fixtures.' },
+  // ── Weather / hazards (NOAA + Open-Meteo) ──────────────────────────────────
+  { id: 'weather', name: 'Weather forecast', domain: 'Weather', upstream: 'Open-Meteo forecast (multi-model)', status: 'live', adapter: 'weatherLive', endpoint: 'https://api.open-meteo.com/v1/forecast', scope: 'geo-global', keyReq: 'none', cadence: 'hourly', license: 'CC-BY 4.0', grade: 'A', feeds: ['Weather', 'Land & Resources'], gradeNote: 'Global hourly forecast, no key; excellent coverage, model resolution varies by region.' },
+  { id: 'nws-alerts', name: 'NWS active alerts', domain: 'Weather', upstream: 'NWS/NOAA active alerts API', status: 'live', adapter: 'nwsAlertsLive', endpoint: 'https://api.weather.gov/alerts/active', scope: 'us', keyReq: 'none', cadence: 'live', license: 'public domain', grade: 'A', feeds: ['Weather · Alerts', 'Supply · Disruption'], gradeNote: 'Authoritative real-time US watches/warnings; US + territories only.' },
+  { id: 'flood', name: 'FEMA flood zones (NFHL)', domain: 'Weather', upstream: 'FEMA National Flood Hazard Layer', status: 'live', adapter: 'floodLive', endpoint: 'https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHL/MapServer', scope: 'us', keyReq: 'none', cadence: 'quarterly', license: 'public domain', grade: 'B', feeds: ['Map · Flood risk', 'Real Estate · Risk'], gradeNote: 'Official US flood zones; not all counties mapped, panels updated on a rolling basis.' },
+  { id: 'quakes', name: 'USGS earthquakes', domain: 'Weather', upstream: 'USGS earthquake GeoJSON feed', status: 'live', adapter: 'quakesLive', endpoint: 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson', scope: 'geo-global', keyReq: 'none', cadence: 'live', license: 'public domain', grade: 'A', feeds: ['Map · Seismic', 'Supply · Disruption'], gradeNote: 'Authoritative global seismicity, near-real-time; small-magnitude completeness best over instrumented regions.' },
+  // ── Markets / economy ──────────────────────────────────────────────────────
+  { id: 'markets', name: 'Crypto & FX spot', domain: 'Markets', upstream: 'CoinGecko (crypto) + Frankfurter/ECB (FX)', status: 'live', adapter: 'marketsLive', endpoint: 'https://api.coingecko.com/api/v3/simple/price', scope: 'markets-global', keyReq: 'none', cadence: 'realtime', license: 'open / attribution', grade: 'B', feeds: ['Market Monitor', 'Portfolio', 'Algo'], gradeNote: 'Real no-key crypto + ECB FX. Equities/futures still need a licensed feed — that class is fixture.' },
+  { id: 'treasury', name: 'US Treasury yield curve', domain: 'Markets', upstream: 'US Treasury daily par yield curve (XML)', status: 'live', adapter: 'treasuryLive', endpoint: 'https://home.treasury.gov/resource-center/data-chart-center/interest-rates/pages/xml', scope: 'us', keyReq: 'none', cadence: 'daily', license: 'public domain', grade: 'A', feeds: ['Rates', 'Economy', 'Value Drivers'], gradeNote: 'Authoritative daily US par-yield curve; US sovereign rates only.' },
+  { id: 'worldbank', name: 'World Bank indicators', domain: 'Economy', upstream: 'World Bank Open Data API v2', status: 'live', adapter: 'worldBankLive', endpoint: 'https://api.worldbank.org/v2', scope: 'stats-global', keyReq: 'none', cadence: 'annual', license: 'CC-BY 4.0', grade: 'B', feeds: ['Economy', 'Country profiles', 'Value Drivers'], gradeNote: 'Best free all-country macro panel; many indicators lag 1–2yr and are sparse for low-income states.' },
+  { id: 'labor', name: 'Labor / job market', domain: 'Economy', upstream: 'Remotive remote-jobs API', status: 'live', adapter: 'laborLive', endpoint: 'https://remotive.com/api/remote-jobs', scope: 'sparse-global', keyReq: 'none', cadence: 'daily', license: 'open / attribution', grade: 'C', feeds: ['Labor', 'Economy'], gradeNote: 'Real live listings but a narrow slice (remote/tech); not a representative labor-market panel.' },
+  { id: 'fred', name: 'FRED / BLS', domain: 'Economy', upstream: 'St. Louis Fed FRED + BLS', status: 'fixture', scope: 'us', keyReq: 'free-tier', cadence: 'monthly', license: 'public domain', grade: 'A', feeds: ['Economy', 'Value Drivers'], gradeNote: 'Deep US macro series; key-gated, so wired as fixture pending key-minting in CI.' },
+  // ── Legal / regulatory ─────────────────────────────────────────────────────
+  { id: 'fedreg', name: 'Federal Register', domain: 'Legal', upstream: 'federalregister.gov API v1', status: 'live', adapter: 'federalRegisterLive', endpoint: 'https://www.federalregister.gov/api/v1/documents.json', scope: 'us', keyReq: 'none', cadence: 'daily', license: 'public domain', grade: 'A', feeds: ['Law & Regulation'], gradeNote: 'Authoritative daily US federal rules/notices; US federal executive only.' },
+  { id: 'courts', name: 'Court dockets', domain: 'Legal', upstream: 'PACER / CourtListener', status: 'planned', scope: 'us', keyReq: 'free-tier', cadence: 'daily', license: 'mixed', grade: 'C', feeds: ['Law · Case law'], gradeNote: 'CourtListener is free-tier; PACER is paywalled. Not yet wired.' },
+  // ── News / social ──────────────────────────────────────────────────────────
+  { id: 'gdelt', name: 'GDELT global news', domain: 'News', upstream: 'GDELT 2.0 Doc API', status: 'live', adapter: 'gdeltLive', endpoint: 'https://api.gdeltproject.org/api/v2/doc/doc', scope: 'media-global', keyReq: 'none', cadence: 'live', license: 'open', grade: 'B', feeds: ['News', 'Events'], gradeNote: 'Worldwide event/news monitoring; English-media skew, thinner for low-coverage countries.' },
+  { id: 'hn-news', name: 'HN / tech news', domain: 'News', upstream: 'Hacker News (Algolia) search', status: 'live', adapter: 'newsLive', endpoint: 'https://hn.algolia.com/api/v1/search_by_date', scope: 'media-global', keyReq: 'none', cadence: 'live', license: 'open', grade: 'C', feeds: ['News · Tech'], gradeNote: 'Live but a narrow tech/startup slice, not general news.' },
+  { id: 'bsky', name: 'Bluesky (ATProto)', domain: 'News', upstream: 'Bluesky public AppView searchPosts', status: 'live', adapter: 'blueskyLive', endpoint: 'https://public.api.bsky.app/xrpc/app.bsky.feed.searchPosts', scope: 'media-global', keyReq: 'none', cadence: 'live', license: 'open', grade: 'C', feeds: ['News · Social'], gradeNote: 'Real live social; a single network — sample, not the whole social graph.' },
+  // ── Supply / logistics ─────────────────────────────────────────────────────
+  { id: 'transit', name: 'Transit (GTFS via OSM)', domain: 'Supply', upstream: 'Overpass public_transport routes', status: 'live', adapter: 'transitLive', endpoint: 'https://overpass-api.de/api/interpreter', scope: 'us-metros', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'C', feeds: ['Map · Mobility', 'Supply'], gradeNote: 'OSM-derived transit lines; not schedule-accurate GTFS, coverage best in mapped metros.' },
+  { id: 'cowork', name: 'Coworking / workspace', domain: 'Supply', upstream: 'Overpass office=coworking POIs', status: 'live', adapter: 'coworkLive', endpoint: 'https://overpass-api.de/api/interpreter', scope: 'sparse-global', keyReq: 'none', cadence: 'live', license: 'ODbL', grade: 'D', feeds: ['Workspace', 'Site selection'], gradeNote: 'OSM POI tag — very incomplete; presence ≠ full inventory.' },
+  { id: 'delivery', name: 'Delivery excellence', domain: 'Supply', upstream: 'Composite (quakes + NWS + provider geo)', status: 'live', adapter: 'deliveryExcellenceLive', scope: 'sparse-global', keyReq: 'none', cadence: 'live', license: 'mixed', grade: 'C', feeds: ['Supply Chain', 'Digital Twin'], gradeNote: 'Derived disruption signal joining hazards to provider geo; heuristic, not carrier telemetry.' },
+  { id: 'logistics', name: 'Carrier telemetry', domain: 'Supply', upstream: 'project44 / FourKites-class', status: 'planned', scope: 'markets-global', keyReq: 'commercial', cadence: 'live', license: 'commercial', grade: 'D', feeds: ['Supply Chain', 'Digital Twin'], gradeNote: 'True shipment telemetry is commercial; no free adapter.' },
+  // ── Graph / identity (sovereign) ───────────────────────────────────────────
+  { id: 'controlplane', name: 'Noetica governance', domain: 'Graph', upstream: 'Noetica Agent Machine governance API', status: 'live', adapter: 'controlPlaneLive', endpoint: 'http://localhost:8080/api/governance', scope: 'sovereign', keyReq: 'sovereign', cadence: 'live', license: 'sovereign', grade: 'A', feeds: ['Control Plane'], gradeNote: 'Our own governed agent-machine; authoritative for the estate, read + write.' },
+  { id: 'hellgraph', name: 'HellGraph', domain: 'Graph', upstream: 'Sovereign federated hypergraph (Hypercore/Autobase)', status: 'live', adapter: '(hellgraph client)', scope: 'sovereign', keyReq: 'sovereign', cadence: 'live', license: 'sovereign', grade: 'B', feeds: ['Graph dock', 'PersonGraph', 'KnowledgeGraph'], gradeNote: 'Our federated hypergraph; authoritative for what we ingest, coverage grows with ingest.' },
+  { id: 'holographme', name: 'HolographMe', domain: 'Identity', upstream: 'HolographMe reputation lattice', status: 'planned', scope: 'sovereign', keyReq: 'sovereign', cadence: 'live', license: 'sovereign', grade: 'D', feeds: ['People', 'News', 'Marketplace'], gradeNote: 'Reputation lattice; design-stage, not yet wired.' },
 ];
 
 export const sourcesByStatus = (s: AdapterStatus) => DATA_SOURCES.filter((d) => d.status === s);
+export const GRADE_ORDER: Grade[] = ['A', 'B', 'C', 'D', 'F'];

--- a/socioprophet-web/client-vue/src/features/acquisition/egress.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/egress.ts
@@ -1,0 +1,71 @@
+// Egress / proxy pool (acquisition I4) — resolves an EgressIdentity to a concrete proxy endpoint at
+// fetch time, health-tracks endpoints, and fails over. VENDOR-AGNOSTIC by design: a proxy is just a
+// URL + class + geo, so Bright Data, Oxylabs, SOAX, IPRoyal or a self-hosted pool are all "config,
+// not code" (design doc §04). The pool never appears in call sites — the transport asks it for an
+// endpoint that matches the identity's egress class + geo.
+import type { EgressClass, EgressIdentity } from './reputation';
+
+export interface ProxyEndpoint {
+  id: string;
+  url: string;              // full proxy URL incl. creds, e.g. http://user:pass@host:port
+  class: EgressClass;
+  geo: string;              // ISO country the egress exits from
+}
+
+export interface ProxyPool {
+  // Resolve a concrete endpoint for an identity, or null if none is healthy/available.
+  acquire(identity: Pick<EgressIdentity, 'egressClass' | 'geo'>): ProxyEndpoint | null;
+  report(endpointId: string, ok: boolean): void;
+}
+
+interface Health { downUntil: number; fails: number }
+
+// A static, health-tracked pool built from a configured endpoint list. Round-robins within a
+// matching {class, geo} bucket, benches an endpoint after repeated failures with exponential cool-off.
+export class StaticProxyPool implements ProxyPool {
+  private health = new Map<string, Health>();
+  private cursor = new Map<string, number>();
+  constructor(
+    private endpoints: ProxyEndpoint[],
+    private now: () => number = Date.now,
+    private benchAfter = 3,
+    private maxCoolOffMs = 300_000,
+  ) {}
+
+  private healthy(e: ProxyEndpoint): boolean {
+    const h = this.health.get(e.id);
+    return !h || h.downUntil <= this.now();
+  }
+
+  acquire(identity: Pick<EgressIdentity, 'egressClass' | 'geo'>): ProxyEndpoint | null {
+    // 'direct' means no proxy — the transport fetches straight out.
+    if (identity.egressClass === 'direct') return null;
+    const exactGeo = this.endpoints.filter((e) => e.class === identity.egressClass && e.geo === identity.geo && this.healthy(e));
+    const anyGeo = this.endpoints.filter((e) => e.class === identity.egressClass && this.healthy(e));
+    const bucket = exactGeo.length ? exactGeo : anyGeo;
+    if (!bucket.length) return null;
+    const key = `${identity.egressClass}:${identity.geo}`;
+    const i = (this.cursor.get(key) ?? 0) % bucket.length;
+    this.cursor.set(key, i + 1);
+    return bucket[i];
+  }
+
+  report(endpointId: string, ok: boolean): void {
+    const h = this.health.get(endpointId) ?? { downUntil: 0, fails: 0 };
+    if (ok) { this.health.set(endpointId, { downUntil: 0, fails: 0 }); return; }
+    h.fails += 1;
+    if (h.fails >= this.benchAfter) {
+      const cool = Math.min(this.maxCoolOffMs, 2 ** (h.fails - this.benchAfter) * 5_000);
+      h.downUntil = this.now() + cool;
+    }
+    this.health.set(endpointId, h);
+  }
+
+  // Observability: how many endpoints are currently benched.
+  benchedCount(): number {
+    const t = this.now();
+    let n = 0;
+    for (const h of this.health.values()) if (h.downUntil > t) n += 1;
+    return n;
+  }
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/fetcher.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/fetcher.ts
@@ -1,0 +1,140 @@
+// GovernedFetcher (acquisition I2) — the orchestrator that turns I1 (policy) + I3 (reputation) +
+// robots + rate governing into ONE governed request. This is the chokepoint every acquisition flows
+// through: evaluate posture → pick an identity → check robots → wait for the rate governor →
+// conditional GET → record provenance → learn from the outcome. The actual network client and the
+// content hasher are INJECTED, so the whole pipeline is unit-testable without a socket (and so the
+// real backend worker can plug in a curl-impersonate / Playwright transport for TLS realism).
+import { evaluateJob, type JobEnvelope, type ProvenanceRecord, type PolicyResult } from './policy';
+import { selectIdentity, scoreOutcome, type EgressIdentity, type FetchOutcome } from './reputation';
+import { RateGovernor } from './rateGovernor';
+import { isAllowed, crawlDelayFor, type RobotsRules } from './robots';
+
+export interface NetResponse { status: number; headers: Record<string, string>; body: string }
+export type NetFetch = (url: string, opts: { headers: Record<string, string>; identity: EgressIdentity }) => Promise<NetResponse>;
+
+export interface FetcherDeps {
+  net: NetFetch;
+  hash: (body: string) => string;                 // content hash (sha256 in prod, injectable for tests)
+  robotsFor?: (origin: string) => RobotsRules | null; // resolved robots.txt for an origin
+  governor?: RateGovernor;
+  now?: () => number;
+}
+
+export interface FetchRequest {
+  url: string;
+  job: JobEnvelope;
+  identityPool: EgressIdentity[];
+  userAgent: string;
+  sessionBindings?: Record<string, string>;
+  geo?: string;
+}
+
+export type FetchStatus = 'ok' | 'not-modified' | 'blocked' | 'rate-limited' | 'no-identity' | 'robots-denied' | 'error';
+export interface FetchResult {
+  status: FetchStatus;
+  httpStatus?: number;
+  body?: string;
+  provenance?: ProvenanceRecord;
+  identity?: EgressIdentity;   // post-outcome (reputation updated) — caller should persist it
+  retryAfterMs?: number;
+  reason?: string;
+}
+
+function originOf(url: string): { origin: string; host: string; path: string } {
+  const u = new URL(url);
+  return { origin: u.origin, host: u.host, path: u.pathname + u.search };
+}
+
+function outcomeFor(status: number): FetchOutcome {
+  if (status >= 200 && status < 400) return 'success';
+  if (status === 429 || status === 403 || status === 503) return 'challenge';
+  if (status === 401 || status === 451 || status === 402) return 'block';
+  return 'error';
+}
+
+export class GovernedFetcher {
+  private governor: RateGovernor;
+  private now: () => number;
+  // conditional-GET cache: url → validators, so repeat fetches are free (a 304 costs nothing).
+  private validators = new Map<string, { etag?: string; lastModified?: string }>();
+
+  constructor(private deps: FetcherDeps) {
+    this.governor = deps.governor ?? new RateGovernor();
+    this.now = deps.now ?? Date.now;
+  }
+
+  async fetch(req: FetchRequest): Promise<FetchResult> {
+    // 1) Policy — posture resolution + the line. A block here never touches the network.
+    const policy: PolicyResult = evaluateJob(req.job);
+    if (policy.decision === 'block') return { status: 'blocked', reason: policy.reasons.join('; ') };
+
+    const { origin, host, path } = originOf(req.url);
+
+    // 2) robots.txt (advisory records a warning; enforced already blocked disallowed above via policy
+    //    if the source policy said so — this is the per-PATH check the source-level policy can't do).
+    const robots = this.deps.robotsFor?.(origin);
+    if (robots && !isAllowed(robots, req.userAgent, path)) {
+      if (policy.posture === 'enforced' && !policy.overrideApplied) {
+        return { status: 'robots-denied', reason: `robots.txt disallows ${path}` };
+      }
+      policy.warnings.push(`robots.txt disallows ${path} (advisory)`);
+    }
+    if (robots) {
+      const cd = crawlDelayFor(robots, req.userAgent);
+      if (cd) this.governor.setCrawlDelay(host, cd);
+    }
+
+    // 3) Identity — cheapest egress that meets the tier + reputation floor; sticky per session.
+    const sel = selectIdentity(req.identityPool, { tier: req.job.tier, geo: req.geo, session: req.sessionBindings ? Object.keys(req.sessionBindings)[0] : undefined }, req.sessionBindings);
+    if (!sel.identity) return { status: 'no-identity', reason: sel.reason };
+    const identity = sel.identity;
+
+    // 4) Rate governor — wait-or-defer. We defer (return retryAfter) rather than block the caller.
+    const wait = this.governor.msUntilReady(host);
+    if (wait > 0) return { status: 'rate-limited', retryAfterMs: wait, identity };
+    this.governor.take(host);
+
+    // 5) Conditional GET — send validators if we have them.
+    const headers: Record<string, string> = { 'User-Agent': req.userAgent };
+    const v = this.validators.get(req.url);
+    if (v?.etag) headers['If-None-Match'] = v.etag;
+    if (v?.lastModified) headers['If-Modified-Since'] = v.lastModified;
+
+    let res: NetResponse;
+    try {
+      res = await this.deps.net(req.url, { headers, identity });
+    } catch (e) {
+      const updated = scoreOutcome(identity, 'error', this.now());
+      return { status: 'error', identity: updated, reason: e instanceof Error ? e.message : 'network error' };
+    }
+    this.governor.onResult(host, res.status);
+
+    // capture validators for next time
+    const etag = res.headers['etag'] ?? res.headers['ETag'];
+    const lastMod = res.headers['last-modified'] ?? res.headers['Last-Modified'];
+    if (etag || lastMod) this.validators.set(req.url, { etag, lastModified: lastMod });
+
+    const outcome = outcomeFor(res.status);
+    const updated = scoreOutcome(identity, res.status === 304 ? 'success' : outcome, this.now());
+
+    const provenance: ProvenanceRecord = {
+      sourceId: req.job.sourceId,
+      url: req.url,
+      fetchedAt: new Date(this.now()).toISOString(),
+      httpStatus: res.status,
+      contentHash: res.status === 304 ? (v ? `unchanged` : '') : this.deps.hash(res.body),
+      tier: req.job.tier,
+      renderMode: 'http',
+      egress: { class: identity.egressClass, geo: identity.geo },
+      posture: policy.posture,
+      policy: req.job.policy,
+      override: req.job.override ?? null,
+      accountClass: req.job.accountClass,
+      warnings: policy.warnings,
+    };
+
+    if (res.status === 304) return { status: 'not-modified', httpStatus: 304, provenance, identity: updated };
+    if (outcome === 'success') return { status: 'ok', httpStatus: res.status, body: res.body, provenance, identity: updated };
+    return { status: 'error', httpStatus: res.status, provenance, identity: updated, reason: `http ${res.status}` };
+  }
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/fetcher.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/fetcher.ts
@@ -4,13 +4,13 @@
 // conditional GET → record provenance → learn from the outcome. The actual network client and the
 // content hasher are INJECTED, so the whole pipeline is unit-testable without a socket (and so the
 // real backend worker can plug in a curl-impersonate / Playwright transport for TLS realism).
-import { evaluateJob, type JobEnvelope, type ProvenanceRecord, type PolicyResult } from './policy';
+import { evaluateJob, type JobEnvelope, type ProvenanceRecord, type PolicyResult, type AcquisitionTier } from './policy';
 import { selectIdentity, scoreOutcome, type EgressIdentity, type FetchOutcome } from './reputation';
 import { RateGovernor } from './rateGovernor';
 import { isAllowed, crawlDelayFor, type RobotsRules } from './robots';
 
 export interface NetResponse { status: number; headers: Record<string, string>; body: string }
-export type NetFetch = (url: string, opts: { headers: Record<string, string>; identity: EgressIdentity }) => Promise<NetResponse>;
+export type NetFetch = (url: string, opts: { headers: Record<string, string>; identity: EgressIdentity; tier: AcquisitionTier }) => Promise<NetResponse>;
 
 export interface FetcherDeps {
   net: NetFetch;
@@ -102,7 +102,7 @@ export class GovernedFetcher {
 
     let res: NetResponse;
     try {
-      res = await this.deps.net(req.url, { headers, identity });
+      res = await this.deps.net(req.url, { headers, identity, tier: req.job.tier });
     } catch (e) {
       const updated = scoreOutcome(identity, 'error', this.now());
       return { status: 'error', identity: updated, reason: e instanceof Error ? e.message : 'network error' };

--- a/socioprophet-web/client-vue/src/features/acquisition/policy.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/policy.ts
@@ -1,0 +1,153 @@
+// The governed acquisition plane — policy engine (Increment 1, the spine).
+//
+// This encodes the account-tiered posture from the design doc: capability is maximal, but
+// ENFORCEMENT is contextual. Sovereign / research / own-estate jobs run in `advisory` mode
+// (compliance signals are captured as provenance, not blocked); a job billed to a `commercial`
+// account runs `enforced` (public-only, robots/ToS/rate honored, aggressive tiers T2–T4 need a
+// signed, time-boxed override). One exception is absolute in EVERY posture — "the line": we never
+// defeat authentication to reach non-public data. That is not a policy toggle; it is a hard block.
+import type { Grade } from '../../data/dataSources';
+
+export type AccountClass = 'sovereign' | 'research' | 'own-estate' | 'commercial';
+export type Posture = 'advisory' | 'enforced';
+// Acquisition tier — match the tool to the target's difficulty (doc §02). T0 = official API/dump …
+// T4 = managed unblocker for anti-bot walls. Higher tier = more cost + detection surface.
+export type AcquisitionTier = 'T0' | 'T1' | 'T2' | 'T3' | 'T4';
+export const TIER_ORDER: AcquisitionTier[] = ['T0', 'T1', 'T2', 'T3', 'T4'];
+
+export type RobotsPolicy = 'allowed' | 'disallowed' | 'unknown';
+export type TosClass = 'public' | 'restricted' | 'auth-gated';
+
+export interface SourcePolicy {
+  robots: RobotsPolicy;      // what the target's robots.txt says about our paths
+  tos: TosClass;             // is the data public, restricted, or behind a login?
+  pii: boolean;              // does it contain personal data (GDPR/CCPA duties)?
+  legalBasis: string;        // e.g. 'public-data', 'licensed', 'consent', 'contract'
+}
+
+// A signed, time-boxed acceptance of a documented risk (doc §01, override row).
+export interface Override {
+  by: string;                // who accepted it
+  reason: string;            // why
+  expiresAt: string;         // ISO — overrides are never open-ended
+}
+
+// The unit the engine evaluates. Enforcement is a property of the envelope, resolved once.
+export interface JobEnvelope {
+  accountClass: AccountClass;
+  sourceId: string;
+  policy: SourcePolicy;
+  tier: AcquisitionTier;
+  override?: Override | null;
+  now?: string;              // ISO, injectable for tests; defaults to Date.now()
+}
+
+export type Decision = 'allow' | 'block';
+export interface PolicyResult {
+  decision: Decision;
+  posture: Posture;
+  reasons: string[];         // why blocked (empty when allowed)
+  warnings: string[];        // advisory-mode notes captured into provenance
+  overrideApplied: boolean;
+}
+
+// Commercial jobs are enforced; everything else is advisory. This is the whole switch.
+export function resolvePosture(accountClass: AccountClass): Posture {
+  return accountClass === 'commercial' ? 'enforced' : 'advisory';
+}
+
+function overrideValid(o: Override | null | undefined, now: number): boolean {
+  if (!o) return false;
+  const exp = Date.parse(o.expiresAt);
+  return Number.isFinite(exp) && exp > now && !!o.by && !!o.reason;
+}
+
+// The single chokepoint. Call at job-submit; the result decides allow/block and what provenance
+// carries. Advisory never blocks except on "the line"; enforced blocks unless a valid override lifts it.
+export function evaluateJob(job: JobEnvelope): PolicyResult {
+  const posture = resolvePosture(job.accountClass);
+  const now = Date.parse(job.now ?? new Date().toISOString());
+  const hasOverride = overrideValid(job.override, now);
+  const reasons: string[] = [];
+  const warnings: string[] = [];
+
+  // ── The line (§12) — absolute in every posture, override cannot lift it ──────────────
+  // We do not defeat authentication to reach non-public data. Public-data scraping has legal
+  // shelter (hiQ, Van Buren); auth-walled data does not, and it contaminates provenance.
+  if (job.policy.tos === 'auth-gated') {
+    return {
+      decision: 'block', posture, overrideApplied: false,
+      reasons: ['auth-gated: outside the public-data shelter — defeating access controls is not supported (the line)'],
+      warnings,
+    };
+  }
+
+  if (posture === 'advisory') {
+    // Advisory captures compliance as provenance, not as a block.
+    if (job.policy.robots === 'disallowed') warnings.push('robots.txt disallows these paths (advisory)');
+    if (job.policy.robots === 'unknown') warnings.push('robots.txt not resolved (advisory)');
+    if (job.policy.tos === 'restricted') warnings.push('ToS marks this data restricted (advisory)');
+    if (job.policy.pii) warnings.push('source contains PII — minimization/retention duties apply (advisory)');
+    return { decision: 'allow', posture, reasons, warnings, overrideApplied: false };
+  }
+
+  // ── Enforced (commercial) — compliant by default, overrides lift specific gates ──────
+  if (job.policy.robots === 'disallowed' && !hasOverride) reasons.push('robots.txt disallows these paths');
+  if (job.policy.tos === 'restricted' && !hasOverride) reasons.push('ToS marks this data restricted');
+  if (job.policy.pii && job.policy.legalBasis === 'public-data' && !hasOverride) {
+    reasons.push('PII present without a stronger legal basis than "public-data"');
+  }
+  const tierIdx = TIER_ORDER.indexOf(job.tier);
+  if (tierIdx >= TIER_ORDER.indexOf('T2') && !hasOverride) {
+    reasons.push(`tier ${job.tier} (proxy/anti-bot) requires a logged override in enforced mode`);
+  }
+
+  if (reasons.length === 0) {
+    return { decision: 'allow', posture, reasons, warnings, overrideApplied: hasOverride };
+  }
+  // If an override is present and valid it clears the gates it's allowed to clear (all but the line).
+  if (hasOverride) {
+    return { decision: 'allow', posture, reasons: [], warnings: reasons.map((r) => `override: ${r}`), overrideApplied: true };
+  }
+  return { decision: 'block', posture, reasons, warnings, overrideApplied: false };
+}
+
+// The record every fetch emits — the artifact that makes the data defensible (doc §08). Feeds the
+// WorldClaim / verified-compute chain and the catalogue's compliance grade.
+export interface ProvenanceRecord {
+  sourceId: string;
+  url: string;
+  fetchedAt: string;         // ISO
+  httpStatus: number;
+  contentHash: string;       // sha256:… — dedup + integrity
+  tier: AcquisitionTier;
+  renderMode: 'http' | 'playwright' | 'unblocker' | 'api';
+  egress: { class: 'datacenter' | 'residential' | 'mobile' | 'direct'; geo: string };
+  posture: Posture;
+  policy: SourcePolicy;
+  override: Override | null;
+  accountClass: AccountClass;
+  warnings: string[];        // advisory notes carried from evaluateJob
+}
+
+// A source's acquisition profile, attached to a catalogue DataSource.
+export interface AcquisitionProfile {
+  tier: AcquisitionTier;
+  policy: SourcePolicy;
+  egressDefault: ProvenanceRecord['egress']['class'];
+  freshness: string;         // human cadence, mirrors DataSource.cadence
+}
+
+// Derive a compliance grade A–F for a source from its acquisition profile — a sibling to the
+// quality grade. Clean public APIs grade A; anything auth-gated is F (we won't take it).
+export function complianceGrade(p: AcquisitionProfile): Grade {
+  if (p.policy.tos === 'auth-gated') return 'F';
+  let score = 5; // start at A
+  if (p.policy.tos === 'restricted') score -= 2;
+  if (p.policy.robots === 'disallowed') score -= 2;
+  else if (p.policy.robots === 'unknown') score -= 1;
+  if (p.policy.pii && p.policy.legalBasis === 'public-data') score -= 1;
+  if (p.tier === 'T4') score -= 1;               // hardest walls = more fragile right-to-acquire
+  score = Math.max(1, Math.min(5, score));
+  return (['F', 'D', 'C', 'B', 'A'] as Grade[])[score - 1];
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/rateGovernor.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/rateGovernor.ts
@@ -1,0 +1,90 @@
+// Per-domain rate governor (design doc §04, "adaptive rate"). A token bucket per host honors
+// crawl-delay, caps concurrency implicitly via spacing, and backs off exponentially when a domain
+// starts returning 429/403 — then circuit-breaks a domain that keeps challenging. Deterministic:
+// the clock is injectable so the whole thing is unit-testable without real time.
+
+export interface DomainState {
+  tokens: number;
+  lastRefill: number;    // epoch ms
+  nextAllowedAt: number; // epoch ms — earliest next request (crawl-delay + backoff)
+  backoffMs: number;     // current backoff, doubles on throttle, resets on success
+  consecutiveThrottles: number;
+  broken: boolean;       // circuit-broken until backoff elapses
+}
+
+export interface GovernorConfig {
+  ratePerSec: number;     // steady-state requests/sec/domain
+  burst: number;          // bucket capacity
+  minSpacingMs: number;   // hard floor between requests (crawl-delay maps here)
+  maxBackoffMs: number;   // cap
+  breakAfter: number;     // consecutive throttles before circuit-breaks
+}
+
+export const DEFAULT_GOVERNOR: GovernorConfig = {
+  ratePerSec: 1, burst: 4, minSpacingMs: 250, maxBackoffMs: 60_000, breakAfter: 4,
+};
+
+export class RateGovernor {
+  private state = new Map<string, DomainState>();
+  constructor(private cfg: GovernorConfig = DEFAULT_GOVERNOR, private now: () => number = Date.now) {}
+
+  private get(domain: string): DomainState {
+    let s = this.state.get(domain);
+    if (!s) { s = { tokens: this.cfg.burst, lastRefill: this.now(), nextAllowedAt: 0, backoffMs: 0, consecutiveThrottles: 0, broken: false }; this.state.set(domain, s); }
+    return s;
+  }
+
+  // Set a per-domain crawl-delay (seconds) discovered from robots.txt — raises the spacing floor.
+  setCrawlDelay(domain: string, seconds: number): void {
+    const s = this.get(domain);
+    s.nextAllowedAt = Math.max(s.nextAllowedAt, 0);
+    (s as DomainState & { crawlDelayMs?: number }).crawlDelayMs = seconds * 1000;
+  }
+
+  private spacing(domain: string): number {
+    const extra = (this.get(domain) as DomainState & { crawlDelayMs?: number }).crawlDelayMs ?? 0;
+    return Math.max(this.cfg.minSpacingMs, extra);
+  }
+
+  // How long to wait (ms) before a request to this domain is allowed. 0 = go now.
+  msUntilReady(domain: string): number {
+    const s = this.get(domain);
+    const t = this.now();
+    // refill tokens
+    const elapsed = t - s.lastRefill;
+    if (elapsed > 0) {
+      s.tokens = Math.min(this.cfg.burst, s.tokens + (elapsed / 1000) * this.cfg.ratePerSec);
+      s.lastRefill = t;
+    }
+    const gate = Math.max(s.nextAllowedAt - t, 0);
+    if (s.broken) return gate > 0 ? gate : 0;
+    if (s.tokens < 1) return Math.max(gate, (1 - s.tokens) / this.cfg.ratePerSec * 1000);
+    return gate;
+  }
+
+  // Consume a slot (call right before issuing the request). Assumes msUntilReady()===0.
+  take(domain: string): void {
+    const s = this.get(domain);
+    s.tokens = Math.max(0, s.tokens - 1);
+    s.nextAllowedAt = this.now() + this.spacing(domain);
+  }
+
+  // Feed back the outcome. 429/403 (or any throttle) doubles backoff and may break the circuit;
+  // success resets backoff and closes the circuit.
+  onResult(domain: string, status: number): void {
+    const s = this.get(domain);
+    const throttled = status === 429 || status === 403 || status === 503;
+    if (throttled) {
+      s.consecutiveThrottles += 1;
+      s.backoffMs = Math.min(this.cfg.maxBackoffMs, s.backoffMs ? s.backoffMs * 2 : 1000);
+      s.nextAllowedAt = this.now() + s.backoffMs;
+      if (s.consecutiveThrottles >= this.cfg.breakAfter) s.broken = true;
+    } else if (status >= 200 && status < 400) {
+      s.consecutiveThrottles = 0;
+      s.backoffMs = 0;
+      s.broken = false;
+    }
+  }
+
+  isBroken(domain: string): boolean { return this.get(domain).broken; }
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/reputation.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/reputation.ts
@@ -1,0 +1,159 @@
+// Reputation & Fingerprint plane (acquisition I3) — the in-house alternative to renting a managed
+// unblocker for PUBLIC data. The winning move against anti-bot systems isn't defeating challenges;
+// it's building enough egress + fingerprint + behavioral reputation that a public site never
+// challenges us in the first place (design doc §04/§05). This module is the pure, testable core:
+// identity/fingerprint modelling, target-difficulty matching, sticky-session selection, and a
+// reputation score that learns from fetch outcomes. The actual network client (a Node/backend
+// worker using curl-impersonate / Playwright) consumes these decisions — a browser can't spoof TLS,
+// so the realism lives where the fetch happens; the cockpit owns the policy + bookkeeping.
+//
+// Strictly for reaching PUBLIC data (see policy.ts "the line"): reputation avoids challenges, it
+// never circumvents an access control. auth-gated targets are refused upstream in the policy engine.
+import type { AcquisitionTier } from './policy';
+
+export type Browser = 'chrome' | 'firefox' | 'safari';
+export type OS = 'windows' | 'macos' | 'linux' | 'android' | 'ios';
+export type EgressClass = 'direct' | 'datacenter' | 'residential' | 'mobile';
+
+// A coherent browser identity. Coherence is the whole game: TLS impersonation target, HTTP version,
+// UA, Accept-Language, timezone and viewport must all agree, or the mismatch is itself the tell.
+export interface FingerprintProfile {
+  id: string;
+  browser: Browser;
+  os: OS;
+  tlsClient: string;        // curl-impersonate / curl_cffi target, e.g. 'chrome124'
+  httpVersion: 'h1' | 'h2' | 'h3';
+  uaFamily: string;         // e.g. 'Chrome/124'
+  acceptLanguage: string;   // must match the egress geo's locale
+  timezone: string;         // IANA, must match egress geo
+  viewport: { w: number; h: number };
+}
+
+// An egress identity = {proxy class/geo + fingerprint + cookie jar + earned reputation}. Held
+// stable for a session's lifetime — rotating mid-session is itself a detectable signal.
+export interface EgressIdentity {
+  id: string;
+  egressClass: EgressClass;
+  geo: string;              // ISO country of the egress
+  fingerprintId: string;
+  cookieJar: string;        // opaque handle to the persisted session state
+  reputation: number;       // 0..1, EWMA of outcomes; starts neutral at 0.5
+  successes: number;
+  challenges: number;
+  blocks: number;
+  lastUsedAt: number;       // epoch ms; 0 = never used
+}
+
+export type FetchOutcome = 'success' | 'challenge' | 'block' | 'error';
+
+// Minimum egress class + reputation a target difficulty demands. Harder targets need cleaner egress
+// and a more-trusted identity; sending a datacenter IP at a T4 wall just burns the identity.
+const TIER_REQUIREMENT: Record<AcquisitionTier, { minClass: EgressClass; minReputation: number }> = {
+  T0: { minClass: 'direct', minReputation: 0 },
+  T1: { minClass: 'direct', minReputation: 0.3 },
+  T2: { minClass: 'residential', minReputation: 0.5 },
+  T3: { minClass: 'residential', minReputation: 0.6 },
+  T4: { minClass: 'mobile', minReputation: 0.75 },
+};
+
+const CLASS_RANK: Record<EgressClass, number> = { direct: 0, datacenter: 1, residential: 2, mobile: 3 };
+// Cost order for picking the CHEAPEST identity that qualifies (direct is free, mobile is priciest).
+const CLASS_COST: Record<EgressClass, number> = { direct: 0, datacenter: 1, residential: 2, mobile: 3 };
+
+export interface SelectionContext {
+  tier: AcquisitionTier;
+  geo?: string;             // prefer an egress in this country (locale coherence)
+  session?: string;         // if set, reuse the identity already bound to this session (stickiness)
+}
+
+export interface SelectionResult {
+  identity: EgressIdentity | null;
+  reason: string;
+}
+
+// Pick the lowest-cost identity that satisfies the target's difficulty and reputation floor.
+// Honors sticky sessions: a session already bound to an identity keeps it (rotation is a signal).
+export function selectIdentity(
+  pool: EgressIdentity[],
+  ctx: SelectionContext,
+  sessionBindings: Record<string, string> = {},
+): SelectionResult {
+  if (ctx.session && sessionBindings[ctx.session]) {
+    const bound = pool.find((i) => i.id === sessionBindings[ctx.session!]);
+    if (bound) return { identity: bound, reason: 'sticky: reused session-bound identity' };
+  }
+  const req = TIER_REQUIREMENT[ctx.tier];
+  const qualified = pool.filter(
+    (i) => CLASS_RANK[i.egressClass] >= CLASS_RANK[req.minClass] && i.reputation >= req.minReputation,
+  );
+  if (qualified.length === 0) return { identity: null, reason: `no identity meets ${ctx.tier} (needs ≥${req.minClass}, rep ≥${req.minReputation})` };
+  // Prefer: matching geo, then cheapest egress class, then highest reputation, then least-recently-used.
+  const ranked = [...qualified].sort((a, b) => {
+    const geoA = ctx.geo && a.geo === ctx.geo ? 0 : 1;
+    const geoB = ctx.geo && b.geo === ctx.geo ? 0 : 1;
+    if (geoA !== geoB) return geoA - geoB;
+    if (CLASS_COST[a.egressClass] !== CLASS_COST[b.egressClass]) return CLASS_COST[a.egressClass] - CLASS_COST[b.egressClass];
+    if (a.reputation !== b.reputation) return b.reputation - a.reputation;
+    return a.lastUsedAt - b.lastUsedAt;
+  });
+  return { identity: ranked[0], reason: 'selected cheapest qualifying identity' };
+}
+
+// Learn from an outcome. Reputation is an EWMA toward a per-outcome target; challenges and blocks
+// pull it down hard (a block is the strongest negative signal), successes lift it gently.
+const OUTCOME_TARGET: Record<FetchOutcome, number> = { success: 1, error: 0.5, challenge: 0.2, block: 0 };
+const OUTCOME_ALPHA: Record<FetchOutcome, number> = { success: 0.15, error: 0.1, challenge: 0.4, block: 0.6 };
+
+export function scoreOutcome(identity: EgressIdentity, outcome: FetchOutcome, now = Date.now()): EgressIdentity {
+  const target = OUTCOME_TARGET[outcome];
+  const alpha = OUTCOME_ALPHA[outcome];
+  const reputation = clamp01(identity.reputation + alpha * (target - identity.reputation));
+  return {
+    ...identity,
+    reputation,
+    successes: identity.successes + (outcome === 'success' ? 1 : 0),
+    challenges: identity.challenges + (outcome === 'challenge' ? 1 : 0),
+    blocks: identity.blocks + (outcome === 'block' ? 1 : 0),
+    lastUsedAt: now,
+  };
+}
+
+export type ReputationTier = 'trusted' | 'warming' | 'neutral' | 'suspect' | 'burned';
+export function reputationTier(score: number): ReputationTier {
+  if (score >= 0.8) return 'trusted';
+  if (score >= 0.6) return 'warming';
+  if (score >= 0.4) return 'neutral';
+  if (score >= 0.2) return 'suspect';
+  return 'burned';
+}
+
+// An identity that keeps getting blocked/challenged should be retired, not reused — reusing a
+// burned IP just trains the target's reputation model against us.
+export function shouldRetire(identity: EgressIdentity): boolean {
+  return identity.reputation < 0.15 || (identity.blocks >= 3 && identity.reputation < 0.3);
+}
+
+// Human-motion parameters for a T3 browser fetch. Instantaneous coordinate jumps and fixed dwell
+// are classic behavioral tells; real interaction has eased paths and variable think-time. Deterministic
+// with a seed so a session replays consistently (another coherence signal).
+export interface MotionParams { dwellMs: number; steps: number; jitter: number; thinkMs: number }
+export function motionParams(seed: number): MotionParams {
+  const r = mulberry32(seed);
+  return {
+    dwellMs: 40 + Math.floor(r() * 120),   // pause on an element
+    steps: 12 + Math.floor(r() * 18),      // points along the eased mouse path
+    jitter: 0.5 + r() * 1.5,               // px of path noise
+    thinkMs: 300 + Math.floor(r() * 1400), // between-action think time
+  };
+}
+
+function clamp01(n: number): number { return Math.max(0, Math.min(1, n)); }
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/robots.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/robots.ts
@@ -1,0 +1,90 @@
+// robots.txt parsing + allow/deny — the first thing a polite fetcher checks (design doc §02, T1).
+// A small, correct subset of the Robots Exclusion Protocol (RFC 9309): group by User-agent, most-
+// specific match wins, longest matching Allow/Disallow path wins, with * and $ wildcards. Pure and
+// synchronous so the policy layer can consult it without a network round-trip once the file is fetched.
+
+export interface RobotsRules {
+  groups: { agents: string[]; rules: { allow: boolean; path: string }[] }[];
+  crawlDelay: Record<string, number>; // per user-agent, seconds
+  sitemaps: string[];
+}
+
+export function parseRobots(txt: string): RobotsRules {
+  const groups: RobotsRules['groups'] = [];
+  const crawlDelay: Record<string, number> = {};
+  const sitemaps: string[] = [];
+  let current: RobotsRules['groups'][number] | null = null;
+  let sawRule = false; // a new User-agent after a rule starts a new group
+
+  for (const raw of txt.split(/\r?\n/)) {
+    const line = raw.replace(/#.*$/, '').trim();
+    if (!line) continue;
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const field = line.slice(0, idx).trim().toLowerCase();
+    const value = line.slice(idx + 1).trim();
+
+    if (field === 'user-agent') {
+      if (!current || sawRule) { current = { agents: [], rules: [] }; groups.push(current); sawRule = false; }
+      current.agents.push(value.toLowerCase());
+    } else if (field === 'disallow' || field === 'allow') {
+      if (!current) { current = { agents: ['*'], rules: [] }; groups.push(current); }
+      current.rules.push({ allow: field === 'allow', path: value });
+      sawRule = true;
+    } else if (field === 'crawl-delay') {
+      const secs = Number(value);
+      if (Number.isFinite(secs) && current) for (const a of current.agents) crawlDelay[a] = secs;
+    } else if (field === 'sitemap') {
+      sitemaps.push(value);
+    }
+  }
+  return { groups, crawlDelay, sitemaps };
+}
+
+// Pick the group whose agent token best matches ours (exact substring beats '*'); default allow.
+function groupFor(rules: RobotsRules, userAgent: string): RobotsRules['groups'][number] | null {
+  const ua = userAgent.toLowerCase();
+  let star: RobotsRules['groups'][number] | null = null;
+  let best: { g: RobotsRules['groups'][number]; len: number } | null = null;
+  for (const g of rules.groups) {
+    for (const a of g.agents) {
+      if (a === '*') { star = g; continue; }
+      if (ua.includes(a) && (!best || a.length > best.len)) best = { g, len: a.length };
+    }
+  }
+  return best?.g ?? star;
+}
+
+// Translate a robots path pattern (with * and $) into a RegExp anchored at the path start.
+function patternToRe(pattern: string): RegExp {
+  let re = '';
+  for (const ch of pattern) {
+    if (ch === '*') re += '.*';
+    else if (ch === '$') re += '$';
+    else re += ch.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  }
+  return new RegExp('^' + re);
+}
+
+// Is `path` allowed for `userAgent`? Longest matching rule wins; Allow beats Disallow on a tie (RFC 9309).
+export function isAllowed(rules: RobotsRules, userAgent: string, path: string): boolean {
+  const group = groupFor(rules, userAgent);
+  if (!group) return true; // no applicable group → allowed
+  let decision: { allow: boolean; len: number } | null = null;
+  for (const r of group.rules) {
+    if (r.path === '') continue; // empty Disallow = allow all; contributes nothing
+    if (patternToRe(r.path).test(path)) {
+      const len = r.path.length;
+      if (!decision || len > decision.len || (len === decision.len && r.allow)) {
+        decision = { allow: r.allow, len };
+      }
+    }
+  }
+  return decision ? decision.allow : true;
+}
+
+export function crawlDelayFor(rules: RobotsRules, userAgent: string): number | undefined {
+  const ua = userAgent.toLowerCase();
+  for (const a of Object.keys(rules.crawlDelay)) if (a !== '*' && ua.includes(a)) return rules.crawlDelay[a];
+  return rules.crawlDelay['*'];
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/transport.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/transport.ts
@@ -1,0 +1,50 @@
+// Tiered transport (acquisition I4/I5 wiring) — builds the NetFetch the GovernedFetcher consumes,
+// routing each request by its tier: T0/T1 fetch direct, T2/T3 fetch through the proxy pool, T4 goes
+// to the managed unblocker. The actual socket work is delegated to an injected `directFetch` (a Node
+// backend supplies one with a proxy agent + curl-impersonate TLS realism; the browser supplies a
+// plain fetch wrapper), so this stays runtime-agnostic and unit-testable.
+import type { NetFetch, NetResponse } from './fetcher';
+import type { ProxyPool } from './egress';
+import type { Unblocker } from './unblocker';
+import { TIER_ORDER } from './policy';
+
+export interface DirectFetch {
+  (url: string, opts: { headers: Record<string, string>; proxyUrl?: string }): Promise<NetResponse>;
+}
+
+export interface TransportDeps {
+  directFetch: DirectFetch;
+  proxyPool?: ProxyPool;
+  unblocker?: Unblocker;
+}
+
+const idx = (t: string) => TIER_ORDER.indexOf(t as (typeof TIER_ORDER)[number]);
+
+export function makeTieredTransport(deps: TransportDeps): NetFetch {
+  return async (url, { headers, identity, tier }): Promise<NetResponse> => {
+    // T4 — hand the whole hard-wall problem to the managed unblocker (public URLs only).
+    if (tier === 'T4') {
+      if (!deps.unblocker) throw new Error('T4 requires an unblocker; none configured');
+      const r = await deps.unblocker.fetch({ url, render: true, geo: identity.geo, session: identity.cookieJar });
+      return { status: r.status, headers: { 'x-egress-geo': r.egressGeo }, body: r.html };
+    }
+
+    // T2/T3 (or any non-direct identity) — route through the proxy pool and report health.
+    const wantsProxy = idx(tier) >= idx('T2') || identity.egressClass !== 'direct';
+    if (wantsProxy && deps.proxyPool) {
+      const ep = deps.proxyPool.acquire(identity);
+      if (!ep && idx(tier) >= idx('T2')) throw new Error(`no ${identity.egressClass} proxy available for ${tier}`);
+      try {
+        const res = await deps.directFetch(url, { headers, proxyUrl: ep?.url });
+        if (ep) deps.proxyPool.report(ep.id, res.status < 500);
+        return res;
+      } catch (e) {
+        if (ep) deps.proxyPool.report(ep.id, false);
+        throw e;
+      }
+    }
+
+    // T0/T1 direct.
+    return deps.directFetch(url, { headers });
+  };
+}

--- a/socioprophet-web/client-vue/src/features/acquisition/unblocker.ts
+++ b/socioprophet-web/client-vue/src/features/acquisition/unblocker.ts
@@ -1,0 +1,55 @@
+// Managed unblocker adapter (acquisition I5) — the T4 fallback for anti-bot walls on PUBLIC pages
+// (design doc §07). BUY, don't build: a vendor (Zyte API, Bright Data Web Unlocker, ScrapingBee,
+// Oxylabs) resolves the challenge and returns the page, carrying that compliance itself. One stable
+// interface, so the vendor is config: swap impls without touching call sites. Only ever pointed at
+// public URLs — an unblocker fetching a public page is not defeating an access control.
+export interface UnblockerRequest {
+  url: string;
+  render?: boolean;    // execute JS
+  geo?: string;        // egress country
+  session?: string;    // sticky identity
+}
+export interface UnblockerResponse {
+  html: string;
+  status: number;
+  egressGeo: string;
+  cost: number;        // vendor spend for this request, for budget caps
+}
+export interface Unblocker {
+  fetch(req: UnblockerRequest): Promise<UnblockerResponse>;
+}
+
+// Generic HTTP unblocker — adapts ANY vendor whose API is "POST our params, get back the page".
+// buildRequest maps our request onto the vendor's HTTP call; parseResponse maps the vendor's reply
+// back onto UnblockerResponse. Zyte/BrightData/ScrapingBee differ only in these two functions.
+export interface HttpUnblockerConfig {
+  endpoint: string;
+  buildRequest: (req: UnblockerRequest) => { url: string; init: RequestInit };
+  parseResponse: (raw: { status: number; headers: Record<string, string>; body: string }) => UnblockerResponse;
+  fetchImpl?: typeof fetch;
+  costCapPerReq?: number;   // refuse a request whose parsed cost would exceed this
+}
+
+export class HttpUnblocker implements Unblocker {
+  constructor(private cfg: HttpUnblockerConfig) {}
+  async fetch(req: UnblockerRequest): Promise<UnblockerResponse> {
+    const f = this.cfg.fetchImpl ?? fetch;
+    const { url, init } = this.cfg.buildRequest(req);
+    const res = await f(url, init);
+    const body = await res.text();
+    const headers: Record<string, string> = {};
+    res.headers.forEach((v, k) => { headers[k] = v; });
+    const parsed = this.cfg.parseResponse({ status: res.status, headers, body });
+    if (this.cfg.costCapPerReq != null && parsed.cost > this.cfg.costCapPerReq) {
+      throw new Error(`unblocker cost ${parsed.cost} exceeds cap ${this.cfg.costCapPerReq}`);
+    }
+    return parsed;
+  }
+}
+
+// Default when no unblocker is configured — T4 is unavailable rather than silently degrading.
+export class NullUnblocker implements Unblocker {
+  async fetch(_req: UnblockerRequest): Promise<UnblockerResponse> {
+    throw new Error('no unblocker configured — T4 targets are unavailable');
+  }
+}

--- a/socioprophet-web/client-vue/src/features/catalogue/coverage.ts
+++ b/socioprophet-web/client-vue/src/features/catalogue/coverage.ts
@@ -1,0 +1,121 @@
+// Per-country data-quality grading — the honest half of the catalogue. For each of the world's
+// countries we compute how much real, obtainable data our registered sources actually give us, and
+// grade it A–F. This is graphical integrity as a feature (Tufte): the map is mostly NOT green, and
+// that's the truth. The US grades A because most of our authoritative feeds are US federal; a
+// low-income, lightly-mapped state grades D or F because the only data reaching it is a handful of
+// global feeds that thin out there. We say so rather than painting the world uniformly "covered".
+import { DATA_SOURCES, type DataSource, type Grade, type CoverageModel } from '../../data/dataSources';
+import { COUNTRIES, REGIONS, type Country, type Income, type Region } from '../../data/countries';
+
+// Base weight of a source, from its own honest quality grade.
+const GRADE_WEIGHT: Record<Grade, number> = { A: 5, B: 4, C: 3, D: 2, F: 1 };
+
+// Fraction of a source's value that actually reaches a given country, by coverage model × income.
+// Physical/geographic truth is near-uniform; media, markets and niche panels thin out in
+// lower-income and less-covered countries — which is real, not pessimism.
+const COVERAGE: Record<CoverageModel, { us: number; row: Record<Income, number> }> = {
+  'us':            { us: 1, row: { H: 0, UM: 0, LM: 0, L: 0 } },
+  'us-metros':     { us: 1, row: { H: 0, UM: 0, LM: 0, L: 0 } },
+  // Physical/model feeds are genuinely uniform — a satellite sees Chad as well as Germany.
+  'geo-global':    { us: 1, row: { H: 1, UM: 0.95, LM: 0.9, L: 0.85 } },
+  // OSM completeness is a function of who shows up to map. Rich, urban countries are richly
+  // mapped; poor, rural ones are sparse. This tier is where the honest gradient really lives.
+  'mapped-global': { us: 1, row: { H: 1, UM: 0.6, LM: 0.35, L: 0.15 } },
+  // National statistics track a state's statistical capacity — thin and lagged for low-income.
+  'stats-global':  { us: 1, row: { H: 1, UM: 0.75, LM: 0.5, L: 0.3 } },
+  'media-global':  { us: 1, row: { H: 1, UM: 0.7, LM: 0.4, L: 0.2 } },
+  'markets-global':{ us: 1, row: { H: 1, UM: 0.6, LM: 0.3, L: 0.12 } },
+  'sparse-global': { us: 1, row: { H: 0.5, UM: 0.3, LM: 0.15, L: 0.06 } },
+  'sovereign':     { us: 0, row: { H: 0, UM: 0, LM: 0, L: 0 } },
+};
+
+// A source counts toward country coverage only if the data is actually obtainable for us:
+// live (flowing) or fixture (real upstream, adapter pending). Planned sources don't exist for us
+// yet; sovereign sources aren't country-indexed. Both are excluded from the country grade.
+const gradedSources = DATA_SOURCES.filter((s) => s.status !== 'planned' && s.scope !== 'sovereign');
+
+function fraction(source: DataSource, iso: string, income: Income): number {
+  const cov = COVERAGE[source.scope];
+  return iso === 'US' ? cov.us : cov.row[income];
+}
+
+export interface SourceHit { id: string; name: string; fraction: number; weight: number; grade: Grade; live: boolean }
+export interface CountryCoverage {
+  iso: string; name: string; region: Region; income: Income;
+  grade: Grade; score: number; pct: number;      // pct is relative to the best-covered country
+  liveCount: number; totalCount: number;         // sources contributing (live vs. live+fixture)
+  hits: SourceHit[];                             // sources that actually reach this country, best first
+}
+
+function rawScore(iso: string, income: Income): { score: number; hits: SourceHit[]; liveCount: number } {
+  const hits: SourceHit[] = [];
+  let score = 0;
+  let liveCount = 0;
+  for (const s of gradedSources) {
+    const f = fraction(s, iso, income);
+    if (f <= 0) continue;
+    const w = GRADE_WEIGHT[s.grade] * f;
+    score += w;
+    const live = s.status === 'live';
+    if (live) liveCount += 1;
+    hits.push({ id: s.id, name: s.name, fraction: f, weight: w, grade: s.grade, live });
+  }
+  hits.sort((a, b) => b.weight - a.weight);
+  return { score, hits, liveCount };
+}
+
+// Grade thresholds are relative to the best-covered country (the US), so the scale is honest about
+// the ceiling: nobody but the US gets an A, because nobody else has the US federal stack.
+function gradeFromPct(pct: number): Grade {
+  if (pct >= 0.8) return 'A';   // only the US — the full federal stack
+  if (pct >= 0.48) return 'B';  // high-income, richly-mapped states
+  if (pct >= 0.32) return 'C';  // upper-middle income
+  if (pct >= 0.22) return 'D';  // lower-middle income
+  return 'F';                   // low-income / lightly-mapped — the data really is sparse
+}
+
+let _cache: CountryCoverage[] | null = null;
+export function allCoverage(): CountryCoverage[] {
+  if (_cache) return _cache;
+  const scored = COUNTRIES.map((c: Country) => ({ c, ...rawScore(c.iso, c.income) }));
+  const max = Math.max(...scored.map((s) => s.score)) || 1;
+  _cache = scored.map(({ c, score, hits, liveCount }) => {
+    const pct = score / max;
+    return {
+      iso: c.iso, name: c.name, region: c.region, income: c.income,
+      grade: gradeFromPct(pct), score: Math.round(score * 10) / 10, pct,
+      liveCount, totalCount: hits.length, hits,
+    };
+  });
+  return _cache;
+}
+
+export function coverageFor(iso: string): CountryCoverage | undefined {
+  return allCoverage().find((c) => c.iso === iso);
+}
+
+export interface RegionSummary { region: Region; countries: number; dist: Record<Grade, number>; medianGrade: Grade }
+export function regionSummaries(): RegionSummary[] {
+  const all = allCoverage();
+  return REGIONS.map((region) => {
+    const inRegion = all.filter((c) => c.region === region);
+    const dist: Record<Grade, number> = { A: 0, B: 0, C: 0, D: 0, F: 0 };
+    for (const c of inRegion) dist[c.grade] += 1;
+    // median grade by ordinal position
+    const order: Grade[] = ['A', 'B', 'C', 'D', 'F'];
+    const sorted = [...inRegion].sort((a, b) => order.indexOf(a.grade) - order.indexOf(b.grade));
+    const median = sorted.length ? sorted[Math.floor(sorted.length / 2)].grade : 'F';
+    return { region, countries: inRegion.length, dist, medianGrade: median };
+  });
+}
+
+export interface GradeTally { grade: Grade; count: number }
+export function worldGradeDistribution(): GradeTally[] {
+  const all = allCoverage();
+  const order: Grade[] = ['A', 'B', 'C', 'D', 'F'];
+  return order.map((grade) => ({ grade, count: all.filter((c) => c.grade === grade).length }));
+}
+
+export const GRADE_LABEL: Record<Grade, string> = {
+  A: 'Authoritative', B: 'Strong', C: 'Partial', D: 'Thin', F: 'Sparse',
+};

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -170,6 +170,7 @@ const explicitRoutes = [
   { path: '/discovery', component: Discovery },
   { path: '/data/search', component: DataSearch },
   { path: '/data/catalogue', component: () => import('./pages/DataCatalogue.vue') },
+  { path: '/data/acquisition', component: () => import('./pages/AcquisitionConsole.vue') },
   { path: '/knowledge/graph', component: KnowledgeGraph },
   { path: '/forge/import', component: ForgeImport },
   { path: '/sourceos/image-builder', component: ImageBuilder },

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -169,6 +169,7 @@ const explicitRoutes = [
   { path: '/studio', component: Studio },
   { path: '/discovery', component: Discovery },
   { path: '/data/search', component: DataSearch },
+  { path: '/data/catalogue', component: () => import('./pages/DataCatalogue.vue') },
   { path: '/knowledge/graph', component: KnowledgeGraph },
   { path: '/forge/import', component: ForgeImport },
   { path: '/sourceos/image-builder', component: ImageBuilder },

--- a/socioprophet-web/client-vue/src/pages/AcquisitionConsole.vue
+++ b/socioprophet-web/client-vue/src/pages/AcquisitionConsole.vue
@@ -1,0 +1,154 @@
+<template>
+  <section class="ac" aria-label="Governed acquisition console">
+    <header class="ac-head">
+      <div>
+        <p class="ac-eyebrow">SocioProphet · Governed Acquisition</p>
+        <h1>The gate, made visible</h1>
+        <p class="ac-lede">
+          Capability is maximal; <em>enforcement is contextual</em>. Pick an account class and watch every source's
+          acquisition verdict resolve live — the same <code>evaluateJob()</code> chokepoint the plane runs at submit
+          time. Flip to <strong>commercial</strong> and the aggressive tiers and restricted sources go compliant-by-default.
+        </p>
+      </div>
+      <span class="ac-asof">{{ asOf }}</span>
+    </header>
+
+    <div class="ac-controls">
+      <div class="ac-seg" role="tablist" aria-label="Account class">
+        <button v-for="a in accountClasses" :key="a" role="tab" :aria-selected="account === a" :class="{ on: account === a }" @click="account = a">
+          {{ accountLabel[a] }}
+        </button>
+      </div>
+      <div class="ac-posture" :class="posture">
+        <span class="ac-posture-dot"></span>
+        posture: <strong>{{ posture }}</strong>
+        <span class="ac-posture-note">{{ postureNote }}</span>
+      </div>
+    </div>
+
+    <div class="ac-summary">
+      <div class="ac-stat"><span class="ac-stat-n" :style="{ color: 'var(--up)' }">{{ counts.allow }}</span><span class="ac-stat-l">allowed</span></div>
+      <div class="ac-stat"><span class="ac-stat-n" :style="{ color: 'var(--down)' }">{{ counts.block }}</span><span class="ac-stat-l">blocked</span></div>
+      <div class="ac-stat"><span class="ac-stat-n" :style="{ color: 'var(--accent)' }">{{ counts.warned }}</span><span class="ac-stat-l">with advisories</span></div>
+      <div class="ac-stat"><span class="ac-stat-n">{{ rows.length }}</span><span class="ac-stat-l">sources</span></div>
+    </div>
+
+    <div class="ac-table-wrap">
+      <table class="ac-table">
+        <thead>
+          <tr><th>Source</th><th>Tier</th><th>ToS</th><th>robots</th><th>PII</th><th>Compliance</th><th>Verdict</th><th>Why</th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="r in rows" :key="r.id" :class="{ blocked: r.result.decision === 'block' }">
+            <td class="ac-td-name">{{ r.name }}</td>
+            <td><span class="ac-tier" :class="'t-' + r.tier">{{ r.tier }}</span></td>
+            <td><span class="ac-tos" :class="r.policy.tos">{{ r.policy.tos }}</span></td>
+            <td class="ac-mono">{{ r.policy.robots }}</td>
+            <td class="ac-mono">{{ r.policy.pii ? 'yes' : 'no' }}</td>
+            <td><span class="ac-grade" :class="'g-' + r.grade">{{ r.grade }}</span></td>
+            <td>
+              <span class="ac-verdict" :class="r.result.decision">
+                {{ r.result.decision === 'allow' ? '● allow' : '✕ block' }}
+              </span>
+            </td>
+            <td class="ac-why">
+              <span v-for="(x, i) in r.result.reasons" :key="'r' + i" class="ac-reason block">{{ x }}</span>
+              <span v-for="(x, i) in r.result.warnings" :key="'w' + i" class="ac-reason warn">{{ x }}</span>
+              <span v-if="!r.result.reasons.length && !r.result.warnings.length" class="ac-reason ok">clean</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="ac-note">
+      The line is absolute: an <code>auth-gated</code> source is blocked in <em>every</em> posture, un-liftable by an
+      override — defeating an access control is out of scope by design, not by toggle. In <strong>advisory</strong>
+      mode compliance signals are captured as provenance warnings rather than blocks; in <strong>enforced</strong>
+      (commercial) they become blocks unless a signed, time-boxed override lifts the specific gate.
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { DATA_SOURCES } from '../data/dataSources';
+import { acquisitionFor } from '../data/acquisitionProfiles';
+import { evaluateJob, resolvePosture, type AccountClass } from '../features/acquisition/policy';
+
+const accountClasses: AccountClass[] = ['sovereign', 'research', 'own-estate', 'commercial'];
+const accountLabel: Record<AccountClass, string> = {
+  sovereign: 'Sovereign', research: 'Research', 'own-estate': 'Own estate', commercial: 'Commercial',
+};
+const account = ref<AccountClass>('sovereign');
+const posture = computed(() => resolvePosture(account.value));
+const postureNote = computed(() =>
+  posture.value === 'enforced'
+    ? 'compliant by default — robots/ToS/rate honored, T2–T4 need a logged override'
+    : 'full capability — compliance captured as provenance, not blocked',
+);
+
+const rows = computed(() =>
+  DATA_SOURCES.map((s) => {
+    const { profile, grade } = acquisitionFor(s.id);
+    const result = evaluateJob({ accountClass: account.value, sourceId: s.id, policy: profile.policy, tier: profile.tier });
+    return { id: s.id, name: s.name, tier: profile.tier, policy: profile.policy, grade, result };
+  }),
+);
+
+const counts = computed(() => ({
+  allow: rows.value.filter((r) => r.result.decision === 'allow').length,
+  block: rows.value.filter((r) => r.result.decision === 'block').length,
+  warned: rows.value.filter((r) => r.result.warnings.length > 0).length,
+}));
+
+const asOf = new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+</script>
+
+<style scoped>
+.ac { height: 100%; min-height: 0; overflow-y: auto; padding: 1rem 1.2rem 2rem; background: var(--bg); color: var(--text); }
+.ac-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1.1rem; }
+.ac-eyebrow { margin: 0 0 0.15rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-3); }
+.ac-head h1 { margin: 0 0 0.35rem; font-size: 1.5rem; letter-spacing: -0.02em; font-weight: 660; }
+.ac-lede { margin: 0; max-width: 76ch; font-size: 0.86rem; line-height: 1.6; color: var(--text-2); }
+.ac-lede em { color: var(--text); font-style: normal; font-weight: 600; }
+.ac-asof { flex: 0 0 auto; font-size: 0.72rem; color: var(--text-3); font-family: ui-monospace, monospace; }
+
+.ac-controls { display: flex; align-items: center; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.ac-seg { display: inline-flex; border: 1px solid var(--line-2); border-radius: 10px; overflow: hidden; }
+.ac-seg button { border: none; background: var(--surface); color: var(--text-2); padding: 0.45rem 0.85rem; font: inherit; font-size: 0.8rem; font-weight: 600; cursor: pointer; border-right: 1px solid var(--line); }
+.ac-seg button:last-child { border-right: none; }
+.ac-seg button.on { background: var(--accent); color: #17130a; }
+.ac-posture { display: inline-flex; align-items: center; gap: 0.4rem; font-size: 0.78rem; color: var(--text-2); border: 1px solid var(--line-2); border-radius: 999px; padding: 0.3rem 0.75rem; }
+.ac-posture-dot { width: 8px; height: 8px; border-radius: 50%; }
+.ac-posture.advisory .ac-posture-dot { background: #6ea8fe; } .ac-posture.enforced .ac-posture-dot { background: var(--up); }
+.ac-posture strong { text-transform: uppercase; letter-spacing: 0.03em; font-size: 0.72rem; }
+.ac-posture-note { color: var(--text-3); font-size: 0.72rem; }
+
+.ac-summary { display: flex; gap: 0.6rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.ac-stat { border: 1px solid var(--line); border-radius: 12px; background: var(--surface); padding: 0.6rem 1rem; min-width: 6rem; }
+.ac-stat-n { display: block; font-size: 1.4rem; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+.ac-stat-l { font-size: 0.64rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); }
+
+.ac-table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); }
+.ac-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+.ac-table th { text-align: left; padding: 0.55rem 0.7rem; font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); border-bottom: 1px solid var(--line-2); background: var(--surface-2); position: sticky; top: 0; white-space: nowrap; }
+.ac-table td { padding: 0.5rem 0.7rem; border-bottom: 1px solid var(--line); color: var(--text-2); vertical-align: top; }
+.ac-table tr:last-child td { border-bottom: none; }
+.ac-table tr.blocked { background: rgba(240, 101, 106, 0.05); }
+.ac-td-name { color: var(--text); font-weight: 600; white-space: nowrap; }
+.ac-mono { font-family: ui-monospace, monospace; font-size: 0.72rem; color: var(--text-3); }
+.ac-tier { display: inline-grid; place-items: center; min-width: 1.7rem; height: 1.25rem; border-radius: 4px; font-size: 0.62rem; font-weight: 800; color: #0c0f14; }
+.ac-tier.t-T0 { background: #4bbf73; } .ac-tier.t-T1 { background: #7fca8f; } .ac-tier.t-T2 { background: #6ea8fe; } .ac-tier.t-T3 { background: #d8a250; } .ac-tier.t-T4 { background: #e5646a; }
+.ac-tos { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.03em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; }
+.ac-tos.public { color: #7ee2a8; background: rgba(75, 191, 115, 0.14); } .ac-tos.restricted { color: #f0883e; background: rgba(240, 136, 62, 0.14); } .ac-tos.auth-gated { color: var(--down); background: rgba(240, 101, 106, 0.16); }
+.ac-grade { display: inline-grid; place-items: center; min-width: 1.35rem; height: 1.35rem; border-radius: 5px; font-size: 0.74rem; font-weight: 800; color: #0c0f14; }
+.g-A { background: #4bbf73; } .g-B { background: #6ea8fe; } .g-C { background: #d8a250; } .g-D { background: #f0883e; } .g-F { background: #e5646a; }
+.ac-verdict { font-size: 0.7rem; font-weight: 700; white-space: nowrap; }
+.ac-verdict.allow { color: var(--up); } .ac-verdict.block { color: var(--down); }
+.ac-why { display: flex; flex-direction: column; gap: 0.2rem; }
+.ac-reason { font-size: 0.68rem; line-height: 1.35; }
+.ac-reason.block { color: #f0a0a3; } .ac-reason.warn { color: #e6c07a; } .ac-reason.ok { color: var(--text-3); }
+.ac-note { margin: 0.9rem 0 0; font-size: 0.74rem; line-height: 1.6; color: var(--text-3); max-width: 84ch; }
+.ac-note em { color: var(--text-2); font-style: normal; } .ac-note strong { color: var(--text-2); }
+</style>

--- a/socioprophet-web/client-vue/src/pages/DataCatalogue.vue
+++ b/socioprophet-web/client-vue/src/pages/DataCatalogue.vue
@@ -41,7 +41,7 @@
       <div class="dc-table-wrap">
         <table class="dc-table">
           <thead>
-            <tr><th>Source</th><th>Domain</th><th>Real upstream</th><th>Status</th><th>Grade</th><th>Scope</th><th>Key</th><th>License</th></tr>
+            <tr><th>Source</th><th>Domain</th><th>Real upstream</th><th>Status</th><th title="Data-quality grade">Quality</th><th title="How we acquire it (T0 API … T4 unblocker)">Tier</th><th title="Right-to-acquire / compliance grade">Compliance</th><th>Scope</th><th>Key</th></tr>
           </thead>
           <tbody>
             <tr v-for="s in filteredSources" :key="s.id">
@@ -54,11 +54,12 @@
               <td class="dc-td-up">{{ s.upstream }}<span class="dc-feeds">{{ s.feeds.join(' · ') }}</span></td>
               <td><span class="dc-status" :class="s.status">{{ s.status }}</span></td>
               <td><span class="dc-grade" :class="'g-' + s.grade" :title="s.gradeNote">{{ s.grade }}</span></td>
+              <td><span class="dc-tier" :class="'t-' + acq(s.id).profile.tier" :title="tierLabel[acq(s.id).profile.tier]">{{ acq(s.id).profile.tier }}</span></td>
+              <td><span class="dc-grade" :class="'g-' + acq(s.id).grade" :title="complianceNote(s.id)">{{ acq(s.id).grade }}</span></td>
               <td class="dc-td-scope">{{ scopeLabel[s.scope] }}</td>
               <td><span class="dc-key" :class="s.keyReq">{{ keyLabel[s.keyReq] }}</span></td>
-              <td class="dc-td-lic">{{ s.license }}</td>
             </tr>
-            <tr v-if="!filteredSources.length"><td colspan="8" class="dc-empty">No sources match those filters.</td></tr>
+            <tr v-if="!filteredSources.length"><td colspan="9" class="dc-empty">No sources match those filters.</td></tr>
           </tbody>
         </table>
       </div>
@@ -124,6 +125,8 @@ import { ref, computed } from 'vue';
 import { DATA_SOURCES, GRADE_ORDER, type Grade, type CoverageModel, type KeyReq, type SourceDomain } from '../data/dataSources';
 import type { Income } from '../data/countries';
 import { allCoverage, regionSummaries, worldGradeDistribution, GRADE_LABEL } from '../features/catalogue/coverage';
+import { acquisitionFor } from '../data/acquisitionProfiles';
+import type { AcquisitionTier } from '../features/acquisition/policy';
 
 const tab = ref<'sources' | 'world'>('sources');
 const sources = DATA_SOURCES;
@@ -175,6 +178,16 @@ const scopeLabel: Record<CoverageModel, string> = {
 const keyLabel: Record<KeyReq, string> = { 'none': 'no-key', 'free-tier': 'free key', 'commercial': 'paid', 'sovereign': 'sovereign' };
 const incomeLabel: Record<Income, string> = { H: 'high income', UM: 'upper-middle income', LM: 'lower-middle income', L: 'low income' };
 function epHost(url: string): string { try { return new URL(url).host; } catch { return url; } }
+const acq = (id: string) => acquisitionFor(id);
+const tierLabel: Record<AcquisitionTier, string> = {
+  T0: 'T0 — official API / open dump', T1: 'T1 — polite static HTTP', T2: 'T2 — rotating egress / proxy',
+  T3: 'T3 — headless browser', T4: 'T4 — managed unblocker (anti-bot wall)',
+};
+function complianceNote(id: string): string {
+  const { profile: p, grade } = acquisitionFor(id);
+  const bits = [`right-to-acquire ${grade}`, `robots ${p.policy.robots}`, `ToS ${p.policy.tos}`, p.policy.pii ? 'PII' : 'no PII', p.policy.legalBasis];
+  return bits.join(' · ');
+}
 const asOf = new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 </script>
 
@@ -222,6 +235,8 @@ const asOf = new Date().toLocaleString('en-US', { month: 'short', day: 'numeric'
 .dc-status.live { color: #7ee2a8; background: rgba(75, 191, 115, 0.15); } .dc-status.fixture { color: #f0c987; background: rgba(227, 179, 65, 0.15); } .dc-status.planned { color: #93b4ff; background: rgba(120, 160, 255, 0.15); }
 .dc-key { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.03em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; white-space: nowrap; }
 .dc-key.none { color: #7ee2a8; background: rgba(75, 191, 115, 0.12); } .dc-key.free-tier { color: #93b4ff; background: rgba(120, 160, 255, 0.12); } .dc-key.commercial { color: #f0883e; background: rgba(240, 136, 62, 0.14); } .dc-key.sovereign { color: var(--accent); background: var(--accent-soft); }
+.dc-tier { display: inline-grid; place-items: center; min-width: 1.7rem; height: 1.25rem; border-radius: 4px; font-size: 0.62rem; font-weight: 800; font-variant-numeric: tabular-nums; color: #0c0f14; }
+.dc-tier.t-T0 { background: #4bbf73; } .dc-tier.t-T1 { background: #7fca8f; } .dc-tier.t-T2 { background: #6ea8fe; } .dc-tier.t-T3 { background: #d8a250; } .dc-tier.t-T4 { background: #e5646a; }
 
 /* Grade chips — the single visual grammar shared by sources + countries */
 .dc-grade { display: inline-grid; place-items: center; min-width: 1.35rem; height: 1.35rem; border-radius: 5px; font-size: 0.74rem; font-weight: 800; color: #0c0f14; }

--- a/socioprophet-web/client-vue/src/pages/DataCatalogue.vue
+++ b/socioprophet-web/client-vue/src/pages/DataCatalogue.vue
@@ -1,0 +1,261 @@
+<template>
+  <section class="dc" aria-label="Data catalogue">
+    <header class="dc-head">
+      <div>
+        <p class="dc-eyebrow">SocioProphet · Data Catalogue</p>
+        <h1>Every source, graded honestly</h1>
+        <p class="dc-lede">
+          The whole registry the cockpit reads from — {{ sources.length }} sources, {{ liveCount }} live, feeding
+          {{ countries.length }} countries. We grade our own data A–F and say plainly where it's thin. The world
+          is mostly <em>not</em> an A — that's the truth, not a gap we hide.
+        </p>
+      </div>
+      <span class="dc-asof">{{ asOf }}</span>
+    </header>
+
+    <!-- honest world distribution: one glance says "coverage is uneven" -->
+    <div class="dc-dist" role="img" :aria-label="`World coverage: ${dist.map(d => d.count + ' ' + d.grade).join(', ')}`">
+      <span class="dc-dist-label">World coverage grade</span>
+      <div class="dc-dist-bar">
+        <span v-for="d in dist" :key="d.grade" class="dc-dist-seg" :class="'g-' + d.grade"
+              :style="{ flexGrow: d.count || 0.001 }" :title="`${d.count} countries graded ${d.grade} — ${gradeLabel[d.grade]}`">
+          <span v-if="d.count" class="dc-dist-seg-lbl">{{ d.grade }} · {{ d.count }}</span>
+        </span>
+      </div>
+    </div>
+
+    <nav class="dc-tabs">
+      <button :class="{ on: tab === 'sources' }" @click="tab = 'sources'">Sources <span class="dc-tab-n">{{ sources.length }}</span></button>
+      <button :class="{ on: tab === 'world' }" @click="tab = 'world'">World coverage <span class="dc-tab-n">{{ countries.length }}</span></button>
+    </nav>
+
+    <!-- ── SOURCES ─────────────────────────────────────────────────────── -->
+    <div v-if="tab === 'sources'" class="dc-panel">
+      <div class="dc-filters">
+        <input v-model="q" class="dc-search" type="search" placeholder="Search sources, upstreams, surfaces…" aria-label="Search sources" spellcheck="false" />
+        <select v-model="fDomain" aria-label="Filter by domain"><option value="">All domains</option><option v-for="d in domains" :key="d" :value="d">{{ d }}</option></select>
+        <select v-model="fStatus" aria-label="Filter by status"><option value="">All status</option><option value="live">Live</option><option value="fixture">Fixture</option><option value="planned">Planned</option></select>
+        <select v-model="fGrade" aria-label="Filter by grade"><option value="">All grades</option><option v-for="g in gradeOrder" :key="g" :value="g">Grade {{ g }}</option></select>
+        <span class="dc-count">{{ filteredSources.length }} / {{ sources.length }}</span>
+      </div>
+      <div class="dc-table-wrap">
+        <table class="dc-table">
+          <thead>
+            <tr><th>Source</th><th>Domain</th><th>Real upstream</th><th>Status</th><th>Grade</th><th>Scope</th><th>Key</th><th>License</th></tr>
+          </thead>
+          <tbody>
+            <tr v-for="s in filteredSources" :key="s.id">
+              <td class="dc-td-name">
+                <span class="dc-name">{{ s.name }}</span>
+                <a v-if="s.endpoint" class="dc-ep" :href="s.endpoint" target="_blank" rel="noopener">{{ epHost(s.endpoint) }} ↗</a>
+                <span v-else class="dc-ep muted">{{ s.adapter || '—' }}</span>
+              </td>
+              <td><span class="dc-dom">{{ s.domain }}</span></td>
+              <td class="dc-td-up">{{ s.upstream }}<span class="dc-feeds">{{ s.feeds.join(' · ') }}</span></td>
+              <td><span class="dc-status" :class="s.status">{{ s.status }}</span></td>
+              <td><span class="dc-grade" :class="'g-' + s.grade" :title="s.gradeNote">{{ s.grade }}</span></td>
+              <td class="dc-td-scope">{{ scopeLabel[s.scope] }}</td>
+              <td><span class="dc-key" :class="s.keyReq">{{ keyLabel[s.keyReq] }}</span></td>
+              <td class="dc-td-lic">{{ s.license }}</td>
+            </tr>
+            <tr v-if="!filteredSources.length"><td colspan="8" class="dc-empty">No sources match those filters.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="dc-note">
+        Grades are honest and specific — hover a grade for the caveat. “No-key” sources are free open feeds we call
+        straight from the browser; that’s the moat. Fixtures name the real upstream they stand in for.
+      </p>
+    </div>
+
+    <!-- ── WORLD COVERAGE ──────────────────────────────────────────────── -->
+    <div v-else class="dc-panel">
+      <div class="dc-regions">
+        <button v-for="r in regionRollup" :key="r.region" class="dc-region" :class="{ on: fRegion === r.region }"
+                @click="fRegion = fRegion === r.region ? '' : r.region">
+          <span class="dc-region-name">{{ r.region }}</span>
+          <span class="dc-region-median">median <span class="dc-grade sm" :class="'g-' + r.medianGrade">{{ r.medianGrade }}</span></span>
+          <span class="dc-region-mini">
+            <span v-for="g in gradeOrder" :key="g" v-show="r.dist[g]" class="dc-mini-seg" :class="'g-' + g" :style="{ flexGrow: r.dist[g] }" :title="`${r.dist[g]} ${g}`"></span>
+          </span>
+        </button>
+      </div>
+      <div class="dc-filters">
+        <input v-model="cq" class="dc-search" type="search" placeholder="Search a country…" aria-label="Search countries" spellcheck="false" />
+        <select v-model="fCGrade" aria-label="Filter countries by grade"><option value="">All grades</option><option v-for="g in gradeOrder" :key="g" :value="g">Grade {{ g }} — {{ gradeLabel[g] }}</option></select>
+        <span class="dc-count">{{ filteredCountries.length }} / {{ countries.length }}</span>
+      </div>
+      <div class="dc-countries">
+        <button v-for="c in filteredCountries" :key="c.iso" class="dc-country" :class="{ open: openIso === c.iso }" @click="openIso = openIso === c.iso ? '' : c.iso">
+          <span class="dc-grade" :class="'g-' + c.grade">{{ c.grade }}</span>
+          <span class="dc-country-name">{{ c.name }}</span>
+          <span class="dc-country-meta">{{ c.liveCount }} live · {{ c.totalCount }} sources</span>
+        </button>
+      </div>
+      <div v-if="openCountry" class="dc-detail">
+        <div class="dc-detail-head">
+          <span class="dc-grade lg" :class="'g-' + openCountry.grade">{{ openCountry.grade }}</span>
+          <div>
+            <strong>{{ openCountry.name }}</strong>
+            <span class="dc-detail-sub">{{ openCountry.region }} · {{ incomeLabel[openCountry.income] }} · {{ gradeLabel[openCountry.grade] }} coverage · {{ (openCountry.pct * 100).toFixed(0) }}% of the US ceiling</span>
+          </div>
+        </div>
+        <div class="dc-hits">
+          <div v-for="h in openCountry.hits" :key="h.id" class="dc-hit">
+            <span class="dc-grade sm" :class="'g-' + h.grade">{{ h.grade }}</span>
+            <span class="dc-hit-name">{{ h.name }}</span>
+            <span v-if="h.live" class="dc-live">live</span>
+            <span class="dc-hit-frac" :title="'coverage weight in this country'">{{ (h.fraction * 100).toFixed(0) }}%</span>
+          </div>
+        </div>
+      </div>
+      <p class="dc-note">
+        Country grades are <em>modeled</em>: each source’s real geographic scope × the country’s World-Bank income tier
+        (a proxy for open-data availability and OSM mapping density), normalised to the best-covered country (the US).
+        Only the US earns an A — it holds the US federal stack nobody else does. Low-income and conflict-affected states
+        grade D/F because the honest answer is the data there is sparse.
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { DATA_SOURCES, GRADE_ORDER, type Grade, type CoverageModel, type KeyReq, type SourceDomain } from '../data/dataSources';
+import type { Income } from '../data/countries';
+import { allCoverage, regionSummaries, worldGradeDistribution, GRADE_LABEL } from '../features/catalogue/coverage';
+
+const tab = ref<'sources' | 'world'>('sources');
+const sources = DATA_SOURCES;
+const countries = allCoverage();
+const dist = worldGradeDistribution();
+const regionRollup = regionSummaries();
+const gradeOrder = GRADE_ORDER;
+const gradeLabel = GRADE_LABEL;
+const liveCount = sources.filter((s) => s.status === 'live').length;
+const domains = computed(() => [...new Set(sources.map((s) => s.domain))].sort() as SourceDomain[]);
+
+// Sources filters
+const q = ref('');
+const fDomain = ref('');
+const fStatus = ref('');
+const fGrade = ref('');
+const filteredSources = computed(() => {
+  const needle = q.value.trim().toLowerCase();
+  return sources.filter((s) => {
+    if (fDomain.value && s.domain !== fDomain.value) return false;
+    if (fStatus.value && s.status !== fStatus.value) return false;
+    if (fGrade.value && s.grade !== fGrade.value) return false;
+    if (!needle) return true;
+    return (s.name + ' ' + s.upstream + ' ' + s.domain + ' ' + s.feeds.join(' ') + ' ' + (s.endpoint || '')).toLowerCase().includes(needle);
+  });
+});
+
+// Country filters
+const cq = ref('');
+const fRegion = ref('');
+const fCGrade = ref('');
+const openIso = ref('');
+const filteredCountries = computed(() => {
+  const needle = cq.value.trim().toLowerCase();
+  return countries.filter((c) => {
+    if (fRegion.value && c.region !== fRegion.value) return false;
+    if (fCGrade.value && c.grade !== fCGrade.value) return false;
+    if (!needle) return true;
+    return (c.name + ' ' + c.iso).toLowerCase().includes(needle);
+  });
+});
+const openCountry = computed(() => countries.find((c) => c.iso === openIso.value));
+
+const scopeLabel: Record<CoverageModel, string> = {
+  'us': 'US only', 'us-metros': 'US metros', 'geo-global': 'Global (physical)', 'mapped-global': 'Global (OSM)',
+  'stats-global': 'Global (stats)', 'media-global': 'Global (media)', 'markets-global': 'Global (markets)',
+  'sparse-global': 'Global (sparse)', 'sovereign': 'Sovereign',
+};
+const keyLabel: Record<KeyReq, string> = { 'none': 'no-key', 'free-tier': 'free key', 'commercial': 'paid', 'sovereign': 'sovereign' };
+const incomeLabel: Record<Income, string> = { H: 'high income', UM: 'upper-middle income', LM: 'lower-middle income', L: 'low income' };
+function epHost(url: string): string { try { return new URL(url).host; } catch { return url; } }
+const asOf = new Date().toLocaleString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+</script>
+
+<style scoped>
+.dc { height: 100%; min-height: 0; overflow-y: auto; padding: 1rem 1.2rem 2rem; background: var(--bg); color: var(--text); }
+.dc-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.dc-eyebrow { margin: 0 0 0.15rem; font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.12em; color: var(--text-3); }
+.dc-head h1 { margin: 0 0 0.35rem; font-size: 1.5rem; letter-spacing: -0.02em; font-weight: 660; }
+.dc-lede { margin: 0; max-width: 74ch; font-size: 0.86rem; line-height: 1.6; color: var(--text-2); }
+.dc-lede em { color: var(--text); font-style: normal; font-weight: 600; }
+.dc-asof { flex: 0 0 auto; font-size: 0.72rem; color: var(--text-3); font-family: ui-monospace, monospace; }
+
+.dc-dist { display: flex; align-items: center; gap: 0.8rem; margin-bottom: 1.1rem; padding: 0.7rem 0.9rem; border: 1px solid var(--line); border-radius: var(--radius); background: var(--surface); }
+.dc-dist-label { flex: 0 0 auto; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); }
+.dc-dist-bar { flex: 1; display: flex; height: 22px; border-radius: 6px; overflow: hidden; gap: 2px; }
+.dc-dist-seg { display: grid; place-items: center; min-width: 2px; transition: flex-grow 0.3s; }
+.dc-dist-seg-lbl { font-size: 0.58rem; font-weight: 700; letter-spacing: 0.02em; color: #0c0f14; white-space: nowrap; padding: 0 0.2rem; }
+
+.dc-tabs { display: flex; gap: 0.4rem; margin-bottom: 1rem; border-bottom: 1px solid var(--line); }
+.dc-tabs button { border: none; background: transparent; color: var(--text-3); padding: 0.5rem 0.2rem; margin-right: 0.8rem; font: inherit; font-size: 0.82rem; font-weight: 600; cursor: pointer; border-bottom: 2px solid transparent; margin-bottom: -1px; }
+.dc-tabs button.on { color: var(--text); border-bottom-color: var(--accent); }
+.dc-tab-n { font-size: 0.68rem; color: var(--text-3); font-variant-numeric: tabular-nums; margin-left: 0.2rem; }
+
+.dc-filters { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.8rem; }
+.dc-search { flex: 1; min-width: 200px; background: var(--surface); border: 1px solid var(--line-2); border-radius: 8px; color: var(--text); padding: 0.45rem 0.7rem; font: inherit; font-size: 0.84rem; }
+.dc-search::placeholder { color: var(--text-3); }
+.dc-filters select { background: var(--surface); border: 1px solid var(--line-2); border-radius: 8px; color: var(--text-2); padding: 0.45rem 0.55rem; font: inherit; font-size: 0.8rem; cursor: pointer; }
+.dc-count { font-size: 0.72rem; color: var(--text-3); font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+.dc-table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: var(--radius); }
+.dc-table { width: 100%; border-collapse: collapse; font-size: 0.78rem; }
+.dc-table th { text-align: left; padding: 0.55rem 0.7rem; font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); border-bottom: 1px solid var(--line-2); background: var(--surface-2); position: sticky; top: 0; z-index: 1; white-space: nowrap; }
+.dc-table td { padding: 0.5rem 0.7rem; border-bottom: 1px solid var(--line); color: var(--text-2); vertical-align: top; }
+.dc-table tr:last-child td { border-bottom: none; }
+.dc-table tbody tr:hover { background: var(--surface); }
+.dc-td-name { min-width: 12rem; }
+.dc-name { display: block; color: var(--text); font-weight: 620; }
+.dc-ep { font-size: 0.68rem; color: var(--accent); text-decoration: none; font-family: ui-monospace, monospace; }
+.dc-ep.muted { color: var(--text-3); } .dc-ep:hover:not(.muted) { text-decoration: underline; }
+.dc-dom { font-size: 0.68rem; color: var(--text-2); white-space: nowrap; }
+.dc-td-up { max-width: 24rem; }
+.dc-feeds { display: block; margin-top: 0.15rem; font-size: 0.68rem; color: var(--text-3); }
+.dc-td-scope, .dc-td-lic { font-size: 0.72rem; white-space: nowrap; color: var(--text-3); }
+.dc-status { font-size: 0.56rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; }
+.dc-status.live { color: #7ee2a8; background: rgba(75, 191, 115, 0.15); } .dc-status.fixture { color: #f0c987; background: rgba(227, 179, 65, 0.15); } .dc-status.planned { color: #93b4ff; background: rgba(120, 160, 255, 0.15); }
+.dc-key { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.03em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.35rem; white-space: nowrap; }
+.dc-key.none { color: #7ee2a8; background: rgba(75, 191, 115, 0.12); } .dc-key.free-tier { color: #93b4ff; background: rgba(120, 160, 255, 0.12); } .dc-key.commercial { color: #f0883e; background: rgba(240, 136, 62, 0.14); } .dc-key.sovereign { color: var(--accent); background: var(--accent-soft); }
+
+/* Grade chips — the single visual grammar shared by sources + countries */
+.dc-grade { display: inline-grid; place-items: center; min-width: 1.35rem; height: 1.35rem; border-radius: 5px; font-size: 0.74rem; font-weight: 800; color: #0c0f14; }
+.dc-grade.sm { min-width: 1.1rem; height: 1.1rem; font-size: 0.64rem; border-radius: 4px; }
+.dc-grade.lg { min-width: 2.4rem; height: 2.4rem; font-size: 1.2rem; border-radius: 8px; }
+.g-A { background: #4bbf73; } .g-B { background: #6ea8fe; } .g-C { background: #d8a250; } .g-D { background: #f0883e; } .g-F { background: #e5646a; }
+.dc-dist-seg.g-A { background: #4bbf73; } .dc-dist-seg.g-B { background: #6ea8fe; } .dc-dist-seg.g-C { background: #d8a250; } .dc-dist-seg.g-D { background: #f0883e; } .dc-dist-seg.g-F { background: #e5646a; }
+.dc-mini-seg.g-A { background: #4bbf73; } .dc-mini-seg.g-B { background: #6ea8fe; } .dc-mini-seg.g-C { background: #d8a250; } .dc-mini-seg.g-D { background: #f0883e; } .dc-mini-seg.g-F { background: #e5646a; }
+
+.dc-note { margin: 0.8rem 0 0; font-size: 0.74rem; line-height: 1.55; color: var(--text-3); max-width: 82ch; }
+.dc-note em { color: var(--text-2); font-style: normal; }
+.dc-empty { padding: 1.4rem; text-align: center; color: var(--text-3); }
+
+/* World coverage */
+.dc-regions { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.55rem; margin-bottom: 1rem; }
+.dc-region { text-align: left; border: 1px solid var(--line); border-radius: 10px; background: var(--surface); padding: 0.6rem 0.7rem; cursor: pointer; display: flex; flex-direction: column; gap: 0.4rem; }
+.dc-region.on { border-color: var(--accent); background: var(--surface-2); }
+.dc-region-name { font-size: 0.78rem; font-weight: 640; color: var(--text); }
+.dc-region-median { font-size: 0.64rem; color: var(--text-3); display: flex; align-items: center; gap: 0.3rem; }
+.dc-region-mini { display: flex; height: 5px; border-radius: 3px; overflow: hidden; gap: 1px; }
+.dc-mini-seg { min-width: 1px; }
+.dc-countries { display: grid; grid-template-columns: repeat(auto-fill, minmax(190px, 1fr)); gap: 0.4rem; }
+.dc-country { display: flex; align-items: center; gap: 0.5rem; text-align: left; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); padding: 0.4rem 0.5rem; cursor: pointer; }
+.dc-country:hover { background: var(--surface-2); }
+.dc-country.open { border-color: var(--accent); }
+.dc-country-name { font-size: 0.8rem; color: var(--text); font-weight: 560; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dc-country-meta { margin-left: auto; font-size: 0.62rem; color: var(--text-3); white-space: nowrap; font-variant-numeric: tabular-nums; }
+.dc-detail { margin-top: 0.9rem; border: 1px solid var(--line-2); border-radius: var(--radius); background: var(--surface); padding: 0.9rem 1rem; }
+.dc-detail-head { display: flex; align-items: center; gap: 0.7rem; margin-bottom: 0.8rem; }
+.dc-detail-head strong { display: block; font-size: 1rem; color: var(--text); }
+.dc-detail-sub { font-size: 0.72rem; color: var(--text-3); }
+.dc-hits { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 0.4rem; }
+.dc-hit { display: flex; align-items: center; gap: 0.45rem; padding: 0.35rem 0.5rem; border: 1px solid var(--line); border-radius: 7px; background: var(--bg); }
+.dc-hit-name { font-size: 0.76rem; color: var(--text-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dc-live { font-size: 0.52rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; color: #7ee2a8; background: rgba(75, 191, 115, 0.15); border-radius: 3px; padding: 0.02rem 0.25rem; }
+.dc-hit-frac { margin-left: auto; font-size: 0.68rem; color: var(--text-3); font-variant-numeric: tabular-nums; }
+</style>


### PR DESCRIPTION
Builds the **Data Catalogue** and, on top of it, the full **governed acquisition plane** — from the account-tiered policy gate down to the tiered fetch transport, plus an interactive console. All pure/testable logic; the browser-unsafe bits (TLS impersonation) are injected so a backend worker plugs in later.

### Data Catalogue (`/data/catalogue`)
- `dataSources.ts` — 24 no-key adapters registered with real endpoints, scope, key req, honest **A–F quality grade** + caveat.
- `coverage.ts` — grades all **191 countries** (scope × World-Bank income, normalised to the US). Honest & non-uniform: A=1, B=60, C=48, D=54, **F=28**.
- `DataCatalogue.vue` — searchable registry + world-coverage tab; shows acquisition **tier** + **compliance grade** beside quality.

### Governed acquisition plane (`features/acquisition/`)
- **I1 `policy.ts`** — account-tiered posture (commercial=enforced, else advisory), `evaluateJob()` chokepoint, provenance schema, compliance grade. "The line" (auth-gated) = hard block in every posture, un-liftable.
- **I2 `robots.ts` / `rateGovernor.ts` / `fetcher.ts`** — RFC 9309 robots subset; per-domain token bucket + backoff + circuit-break; `GovernedFetcher` composing policy → identity → robots → rate → conditional-GET → provenance → outcome.
- **I3 `reputation.ts`** — egress-identity + fingerprint model, EWMA reputation, tier-matched sticky selection, retire-when-burned, human-motion. The in-house "never get challenged" core (buy-not-rent for public data).
- **I4 `egress.ts`** — vendor-agnostic health-tracked proxy pool. **I5 `unblocker.ts`** — `Unblocker` interface + generic HTTP impl + cost cap. `transport.ts` — tiered NetFetch (T0/T1 direct, T2/T3 proxied, T4 unblocker).
- **Console `AcquisitionConsole.vue`** (`/data/acquisition`) — flip account class, watch every source's verdict re-resolve through the real `evaluateJob()`; advisory→enforced flips T2+/restricted/PII to blocked.

### Verification
- Typecheck clean · **863/863** tests green (catalogue grading + smoke, policy ×12, reputation ×9, fetcher/robots/rate ×~20, egress/unblocker/transport ×10, console smoke) · build OK (each surface code-splits).

> Note: this PR grew to cover the whole governed-acquisition arc. Happy to split catalogue vs. acquisition-plane vs. console into separate PRs if you'd prefer smaller review units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)