### PR TITLE
chore(hosting): cut over app Firebase target to the unified cockpit (client-vue)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -28,24 +28,14 @@
     },
     {
       "target": "app",
-      "public": "socioprophet-web/app-vue/dist",
-      "predeploy": [
-        "npm --prefix socioprophet-web/app-vue install",
-        "npm --prefix socioprophet-web/app-vue run build"
-      ],
+      "comment": "The app site (socioprophet-builder) now serves the unified cockpit (client-vue), not the retired app-vue builder. Mirrors the proven `cockpit` target: SPA rewrite only, and NO predeploy — deploy via socioprophet-web/deploy-cockpit.sh, which builds client-vue and injects the runtime Firebase config into dist AFTER the build (a predeploy rebuild here would wipe that injected firebase-config.js). The cockpit's backend calls resolve via window.__COCKPIT_CONFIG__ (sovereign) or the prophet-platform in-cluster proxies (connected) — never a Firebase /api rewrite.",
+      "public": "socioprophet-web/client-vue/dist",
       "ignore": [
         "firebase.json",
         "**/.*",
         "**/node_modules/**"
       ],
       "rewrites": [
-        {
-          "source": "/api/**",
-          "run": {
-            "serviceId": "builder-api",
-            "region": "us-central1"
-          }
-        },
         {
           "source": "**",
           "destination": "/index.html"


### PR DESCRIPTION
## What
Repoints the `app` Firebase hosting target (`socioprophet-builder` / `socioprophet-builder-dev`) from the retired **app-vue** builder to the unified **client-vue** cockpit — aligning `firebase.json` with what `deploy-cockpit.sh` already assumes.

## Details
- `public`: `socioprophet-web/app-vue/dist` → `socioprophet-web/client-vue/dist`
- **Removed the predeploy build** — mirrors the proven `cockpit` target. `deploy-cockpit.sh` builds client-vue and injects the runtime `firebase-config.js` into `dist` *after* the build; a predeploy rebuild would wipe that injected config.
- **Dropped the `/api → builder-api` rewrite** — builder-api is retired with app-vue. The cockpit's backend calls resolve via `window.__COCKPIT_CONFIG__` (sovereign) or the prophet-platform in-cluster proxies (connected), never a Firebase `/api` rewrite. SPA rewrite only.
- app-vue source left in place (now unused); deleting the 63 files is a separate deliberate step.

## Validation
- `firebase.json` validated as JSON; app target confirmed (public=client-vue/dist, no predeploy, SPA-only rewrite).
- Dev deploy pending a `firebase login --reauth` (CLI token expired) — config + local build are validated; deploy is a one-command `deploy-cockpit.sh dev` once re-authed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)