### PR TITLE
test(client-vue): Playwright route-smoke test across every registered route

### DIFF
--- a/socioprophet-web/client-vue/.gitignore
+++ b/socioprophet-web/client-vue/.gitignore
@@ -3,3 +3,9 @@ node_modules/
 dist/
 package-lock.json
 bun.lock
+
+# Playwright (e2e route smoke test) local run artifacts.
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/socioprophet-web/client-vue/e2e/routes.smoke.spec.ts
+++ b/socioprophet-web/client-vue/e2e/routes.smoke.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type ConsoleMessage } from '@playwright/test';
+import { ALL_ROUTES, UNKNOWN_ROUTE } from './routes';
+
+// Route smoke test: every registered route (see ./routes.ts for how the list
+// is assembled from src/main.ts + the nav configs it consumes) must render
+// with no browser console errors and no uncaught page errors.
+//
+// Auth: the dev server has no Firebase apiKey configured, so
+// src/stores/auth.ts's DEV_AUTH_BYPASS stubs a signed-in user and the router
+// guard in main.ts lets every non-public route through without a real login.
+//
+// "Rendered" is detected via `.sp-shell`, the one element App.vue always
+// renders (topbar + stage + RouterView) regardless of which route/component
+// is mounted inside it — no app source or markup was changed to add this
+// hook; it already wraps every route unconditionally.
+const APP_SHELL = '.sp-shell';
+
+// Benign noise that isn't a client-vue bug. Each entry must be justified —
+// this list must NOT grow to swallow real app errors.
+const ALLOWED_ERROR_PATTERNS: { pattern: RegExp; reason: string }[] = [
+  {
+    // This smoke test's webServer runs ONLY `vite` (see playwright.config.ts) —
+    // none of the ~10 backend microservices it proxies to (hellgraph, algo-engine,
+    // ie-engine, sherlock, holmes, synapse, the /api data + builder APIs, the
+    // /mesh passthrough) are started, in this sandbox or in CI. Every "live"
+    // surface that fetches on mount (map, knowledge graph, discovery, model
+    // board/tournament, algorithmic trading, economic prophet, provenance, …)
+    // therefore gets a connection-refused/502 on its API call, and Chromium's
+    // network layer itself — not any app code — logs that as a console error
+    // reading exactly "Failed to load resource: <net::ERR_* | status text>".
+    // Confirmed by hand for /ai/labs, /analytics/model-board, /knowledge/graph,
+    // /discovery, /control-plane/provenance, /economy/value-drivers, /map: in
+    // every case this was the ONLY console error, i.e. the Vue component itself
+    // rendered fine and degraded gracefully — it just couldn't reach a backend
+    // that was never started. The message is Chromium-authored and fixed-form,
+    // so it can't accidentally mask a real app error (those read as JS
+    // exceptions / "[Vue warn]" / stack traces, never this string).
+    pattern: /^Failed to load resource: /,
+    reason: 'no backend microservices are started for this frontend-only smoke run (local or CI) — proxied API calls 502/connection-refuse by design, logged by Chromium itself',
+  },
+];
+
+function isAllowed(text: string): boolean {
+  return ALLOWED_ERROR_PATTERNS.some(({ pattern }) => pattern.test(text));
+}
+
+async function assertRouteRendersCleanly(page: import('@playwright/test').Page, route: string) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  const onConsole = (msg: ConsoleMessage) => {
+    if (msg.type() === 'error' && !isAllowed(msg.text())) {
+      consoleErrors.push(msg.text());
+    }
+  };
+  const onPageError = (err: Error) => {
+    pageErrors.push(err.message);
+  };
+
+  page.on('console', onConsole);
+  page.on('pageerror', onPageError);
+
+  try {
+    await page.goto(route, { waitUntil: 'networkidle' });
+    await expect(page.locator(APP_SHELL)).toBeVisible();
+    // Let any deferred/async render-time console noise (post-networkidle
+    // microtasks, e.g. a chart library's next-tick warning) surface too.
+    await page.waitForTimeout(250);
+  } finally {
+    page.off('console', onConsole);
+    page.off('pageerror', onPageError);
+  }
+
+  expect(
+    pageErrors,
+    `route ${route} threw uncaught page error(s):\n${pageErrors.join('\n')}`,
+  ).toEqual([]);
+  expect(
+    consoleErrors,
+    `route ${route} logged console error(s):\n${consoleErrors.join('\n')}`,
+  ).toEqual([]);
+}
+
+for (const route of ALL_ROUTES) {
+  test(`route renders cleanly: ${route}`, async ({ page }) => {
+    await assertRouteRendersCleanly(page, route);
+  });
+}
+
+test(`unknown route falls back cleanly: ${UNKNOWN_ROUTE}`, async ({ page }) => {
+  await assertRouteRendersCleanly(page, UNKNOWN_ROUTE);
+});
+
+test('route inventory is non-trivial', () => {
+  // Guards against ./routes.ts silently resolving to an empty/near-empty
+  // list (e.g. a broken import) and every test above vacuously "passing".
+  expect(ALL_ROUTES.length).toBeGreaterThan(100);
+});

--- a/socioprophet-web/client-vue/e2e/routes.ts
+++ b/socioprophet-web/client-vue/e2e/routes.ts
@@ -1,0 +1,144 @@
+// Full route inventory for the Playwright route-smoke test.
+//
+// main.ts builds its final route table at runtime from three sources:
+//   1. `explicitRoutes` — a hand-authored array of {path, component} entries.
+//   2. `domainLeafRoutes` — every DOMAIN_MENU leaf (src/config/cockpitNav.ts)
+//      not already in (1), pointed at its domain's flagship component.
+//   3. `mockedSurfaceRoutes` — every domainSurfaces entry (src/config/domainRoutes.ts)
+//      not already covered by (1) or (2), pointed at the generic mocked surface.
+// Anything not covered by any of the three still resolves via the catch-all
+// `/:pathMatch(.*)*` route, so no leaf/surface path is ever a dead link.
+//
+// main.ts itself can't be imported here — its module body calls
+// `createApp(...).mount('#app')`, which requires a real DOM and would blow up
+// under Node. So this file rebuilds the same *path* inventory from two angles:
+//   - EXPLICIT_ROUTES is transcribed directly from main.ts's `explicitRoutes`
+//     (dynamic `:id` segments resolved to one concrete sample value — both
+//     components fall back to an <EmptyState> for an unrecognized id, so any
+//     sample value exercises the real "not found" render path).
+//   - NAV_ROUTES pulls live from the same config modules main.ts consumes
+//     (ALL_SURFACES already flattens+dedupes DOMAIN_MENU + DRAWER_SECTIONS;
+//     domainSurfaces covers the remaining mocked mega-menu leaves), so routes
+//     added to the nav automatically get picked up here without editing this
+//     file again.
+// The two sets are unioned and deduped below.
+import { domainSurfaces } from '../src/config/domainRoutes';
+import { ALL_SURFACES } from '../src/config/cockpitNav';
+
+const SAMPLE_ID = 'smoke-test-sample';
+
+export const EXPLICIT_ROUTES: string[] = [
+  '/login',
+  '/capability/dashboard',
+  '/agentic-os',
+  '/marketplace',
+  '/people/labor-market',
+  '/delivery/wbs',
+  '/delivery/cowork',
+  '/capability/portfolios',
+  '/operator/holograph-me',
+  `/operator/${SAMPLE_ID}`,
+  '/ontology',
+  '/universe',
+  '/space',
+  '/situations',
+  '/marketplace/orchestrate',
+  '/capability/algorithmic-trading',
+  '/capability/nlp-information-extraction',
+  '/knowledge/studio',
+  '/delivery',
+  '/delivery/estate',
+  '/capability/experiments-simulations',
+  '/capability/behavioral-analytics',
+  '/capability/mobile-app-development',
+  '/analytics/supply-chain',
+  '/analytics/digital-twin',
+  '/analytics/twin-workshop',
+  '/analytics/model-tournament',
+  '/analytics/model-board',
+  '/professional-intelligence/competitive/model-platforms',
+  '/analytics/twin-world-model',
+  '/weather/natural-resources',
+  '/analytics/trending-infographics',
+  '/analytics/charts-graphs',
+  '/analytics',
+  '/capability/entity-analytics',
+  '/capability/sentiment-analytics',
+  '/capability/ontology-epistemology',
+  '/capability/economic-prophet',
+  '/research',
+  '/professional-intelligence/competitive',
+  '/professional-intelligence/competitive/features',
+  '/professional-intelligence/competitive/markets',
+  '/professional-intelligence/competitive/enterprise',
+  '/professional-intelligence/competitive/boards',
+  `/professional-intelligence/competitive/${SAMPLE_ID}`,
+  '/professional-intelligence',
+  '/control-plane',
+  '/control-plane/org',
+  '/control-plane/executions',
+  '/control-plane/containment',
+  '/nlboot',
+  '/reader',
+  '/journal',
+  '/code',
+  '/person-graph',
+  '/map',
+  '/feed',
+  '/workbench',
+  '/workbench/scope-d',
+  '/workstation/pipelines',
+  '/workstation/deploy',
+  '/workstation/services',
+  '/workstation/terminal',
+  '/ai/labs',
+  '/studio',
+  '/discovery',
+  '/data/search',
+  '/data/catalogue',
+  '/knowledge/graph',
+  '/forge/import',
+  '/sourceos/image-builder',
+  '/sourceos/builds',
+  '/sourceos/fleet',
+  '/sourceos/cloud',
+  '/mail',
+  '/news',
+  '/markets/indices-funds',
+  '/economy/macro-economics',
+  '/economy/value-drivers',
+  '/economy/causal-valuation',
+  '/settings',
+  '/control-plane/provenance',
+  '/people/search',
+  '/people/social-networks',
+  '/law/international-law',
+  '/noetica',
+  '/noetica/reasoning-chain',
+  '/weather/forecast',
+];
+
+// Nav-derived paths, pulled live so newly added menu/mega-menu leaves and
+// mocked domain surfaces are covered automatically.
+const NAV_ROUTES: string[] = [
+  ...ALL_SURFACES.map((s) => s.to),
+  ...domainSurfaces.map((s) => s.route),
+];
+
+// One path that matches nothing above, to exercise the `/:pathMatch(.*)*`
+// catch-all -> DomainSurfacePage render (kept out of ALL_ROUTES proper since
+// it's not "a route" so much as a probe of the fallback itself).
+export const UNKNOWN_ROUTE = '/this-route-does-not-exist-smoke-probe';
+
+// Note: Studio's `?section=` deep links (e.g. `/studio?section=graph`) all
+// resolve to the same `/studio` Vue Router route, but each is still a
+// distinct URL a user can land on directly (bookmarked, linked from the
+// Operator mega-menu) and a distinct client-side render branch inside
+// Studio.vue — ALL_SURFACES lists them individually, so they're kept as
+// separate test cases here rather than collapsed into one.
+
+function dedupe(paths: string[]): string[] {
+  return Array.from(new Set(paths)).sort();
+}
+
+export const ALL_ROUTES: string[] = dedupe([...EXPLICIT_ROUTES, ...NAV_ROUTES]);

--- a/socioprophet-web/client-vue/package.json
+++ b/socioprophet-web/client-vue/package.json
@@ -11,6 +11,7 @@
     "typecheck": "vue-tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "verify": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "@types/markdown-it": "14.1.2",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/test-utils": "^2.4.9",

--- a/socioprophet-web/client-vue/playwright.config.ts
+++ b/socioprophet-web/client-vue/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Fixed port distinct from the interactive dev default (5174) so a smoke-test
+// run never collides with (or reuses) a developer's own `npm run dev` session.
+const PORT = 5175;
+const BASE_URL = `http://localhost:${PORT}`;
+
+// Route smoke test: boots the Vite dev server (auth is bypassed in dev when no
+// Firebase apiKey is configured — see src/stores/auth.ts DEV_AUTH_BYPASS) and
+// drives a real Chromium instance across every registered route, asserting
+// each renders with no console errors / uncaught page errors. No backend
+// services (hellgraph, algo-engine, etc.) are started, so any surface that
+// depends on one is exercised against a dev server with everything else dark —
+// see e2e/routes.smoke.spec.ts for how that's handled.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  timeout: 30_000,
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: `npx vite --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a Playwright browser smoke test (`e2e/routes.smoke.spec.ts` + `e2e/routes.ts`) that navigates every registered client-vue route — 148 paths assembled from `main.ts`'s explicit route table plus the same nav configs it consumes (`src/config/domainRoutes.ts`, `src/config/cockpitNav.ts`), so newly added nav leaves get covered automatically — plus one catch-all "unknown route" probe.
- Each route asserts: the app shell (`.sp-shell`, already rendered unconditionally by `App.vue` for every route — no app markup was changed) becomes visible, no `pageerror`, and no `console` errors, with a narrow single allow-listed pattern for Chromium's own `Failed to load resource: ...` network-layer log line (fires when a route's backend microservice isn't running — this smoke test's `webServer` starts only `vite`, no backend services, in local or CI). Verified by hand across 7+ affected routes that this was the *only* console message in every case — the Vue component itself always rendered and degraded cleanly.
- Adds `npm run test:e2e` (`playwright test`) and a fixed-port `playwright.config.ts` (`webServer` -> `vite --port 5175 --strictPort`, `reuseExistingServer` outside CI).
- Auth: dev has no Firebase `apiKey`, so `src/stores/auth.ts`'s `DEV_AUTH_BYPASS` stubs a signed-in user and the router guard passes every non-public route through without a real login.

Base is `feat/data-catalogue-coverage-grading` (stacked PR — merge that one first).

## Test plan
- [x] `npx tsc --noEmit` scoped to the new e2e files — compiles clean.
- [x] `npm run typecheck` (full `vue-tsc`) — passes.
- [x] `npx playwright install chromium` + `npm run test:e2e` — **150/150 passed** locally (148 routes + unknown-route fallback + an inventory sanity check).
- [ ] CI: `npx playwright install --with-deps chromium` needs to be added to the `client-vue-product-build` workflow (or a new job) before `test:e2e` can run there — browsers aren't vendored in the repo.