### PR TITLE
feat(builder): govern OS-image builds through the capability membrane (closure #1)

### DIFF
--- a/.github/workflows/builder-contract-tests.yml
+++ b/.github/workflows/builder-contract-tests.yml
@@ -18,9 +18,11 @@ on:
       - "socioprophet-web/server/src/routes/boot-route.ts"
       - "socioprophet-web/server/src/services/bootServer.ts"
       - "socioprophet-web/server/src/services/bootAttestation.ts"
+      - "socioprophet-web/server/src/services/buildAdmission.ts"
       - "socioprophet-web/server/src/services/deviceEnrollment.ts"
       - "socioprophet-web/server/src/services/quorum.ts"
       - "socioprophet-web/server/test/contracts.test.mjs"
+      - "socioprophet-web/server/test/admission.test.mjs"
       - "socioprophet-web/server/test/boot-attestation.test.mjs"
       - "socioprophet-web/server/test/device-enrollment.test.mjs"
       - ".github/workflows/builder-contract-tests.yml"
@@ -31,9 +33,11 @@ on:
       - "socioprophet-web/server/src/routes/boot-route.ts"
       - "socioprophet-web/server/src/services/bootServer.ts"
       - "socioprophet-web/server/src/services/bootAttestation.ts"
+      - "socioprophet-web/server/src/services/buildAdmission.ts"
       - "socioprophet-web/server/src/services/deviceEnrollment.ts"
       - "socioprophet-web/server/src/services/quorum.ts"
       - "socioprophet-web/server/test/contracts.test.mjs"
+      - "socioprophet-web/server/test/admission.test.mjs"
       - "socioprophet-web/server/test/boot-attestation.test.mjs"
       - "socioprophet-web/server/test/device-enrollment.test.mjs"
 
@@ -56,3 +60,5 @@ jobs:
         run: npm run test:boot
       - name: Verify device enrollment gate (attested boot × validator quorum, fail-closed)
         run: npm run test:enroll
+      - name: Validate build admission (membrane gate + sealed admission receipt)
+        run: npm run test:admission

--- a/socioprophet-web/server/package.json
+++ b/socioprophet-web/server/package.json
@@ -45,6 +45,7 @@
     "dev": "nodemon src/server.ts",
     "test:contracts": "node test/contracts.test.mjs",
     "test:boot": "node test/boot-attestation.test.mjs",
+    "test:admission": "node test/admission.test.mjs",
     "test:delivery": "node test/delivery.reconcile.test.mjs",
     "test:mirror": "node test/githubMirror.test.mjs",
     "test:enroll": "node test/device-enrollment.test.mjs",

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -26,6 +26,7 @@ const validatorNames = [
   "ControlNodeProfile", "DesktopProfile", "Offer", "WorkOrder",
   "UsageReceipt", "SettlementEvent", "EventEnvelope",
   "QuorumProof",
+  "AutonomyAdmissionReceipt.v0.2",
 ];
 const validators: Record<string, any> = {};
 for (const n of validatorNames) validators[n] = ajv.getSchema(idByName[n]);

--- a/socioprophet-web/server/src/contracts/schemas/AutonomyAdmissionReceipt.v0.2.PROVENANCE.txt
+++ b/socioprophet-web/server/src/contracts/schemas/AutonomyAdmissionReceipt.v0.2.PROVENANCE.txt
@@ -1,0 +1,7 @@
+AutonomyAdmissionReceipt.v0.2.json
+Source of truth: SourceOS-Linux/prophet-platform :: contracts/AutonomyAdmissionReceipt.v0.2.json
+(the authoritative autonomy-admission contract emitted by the capability membrane).
+Vendored verbatim, hash-pinned. DO NOT edit here — reconcile from prophet-platform.
+Rationale: the image-builder admits every OS build through the SAME contract the
+membrane uses, so a build receipt is comparable to any other admission in the estate.
+Conform, don't invent.

--- a/socioprophet-web/server/src/contracts/schemas/AutonomyAdmissionReceipt.v0.2.json
+++ b/socioprophet-web/server/src/contracts/schemas/AutonomyAdmissionReceipt.v0.2.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/AutonomyAdmissionReceipt.v0.2.json",
+  "title": "AutonomyAdmissionReceipt",
+  "description": "Runtime evidence receipt emitted when prophet-platform admits, demotes, or denies a choir role operating at a requested AI-driven-development autonomy level. v0.2 binds the decision to the capability-membrane kernel (tools/capability_membrane.py): when an operation context is supplied, the canonical role-aware ladder decision is wrapped by the membrane's four fail-closed layers (surface class, capability radius + tension-member presence, membrane policy verdict, autonomy ladder) and collapsed into one sourceos ExecutionDecision. The membrane block records that decision and the sealHash of the sibling sealed AgentMachineReceipt, making the composed admission tamper-evident.",
+  "type": "object",
+  "required": [
+    "version",
+    "receipt_id",
+    "created_at",
+    "service_ref",
+    "role",
+    "requested_level",
+    "granted_level",
+    "decision",
+    "gate",
+    "evidence_required",
+    "trust_kernel_gate_order",
+    "subject_ref",
+    "membrane",
+    "hash",
+    "hash_algo"
+  ],
+  "properties": {
+    "version": { "const": "0.2" },
+    "receipt_id": { "type": "string" },
+    "created_at": { "type": "string" },
+    "service_ref": { "type": "string" },
+    "role": {
+      "type": "string",
+      "description": "Choir role requesting autonomy (e.g. conductor, coding, research)."
+    },
+    "requested_level": { "type": "string", "pattern": "^L[0-5]$" },
+    "granted_level": { "type": "string", "pattern": "^L[0-5]$" },
+    "role_ceiling": { "type": "string", "pattern": "^L[0-5]$" },
+    "decision": { "type": "string", "enum": ["admit", "demote", "deny"] },
+    "gate": {
+      "type": "string",
+      "description": "Name of the gate that governs the granted level."
+    },
+    "evidence_required": { "type": "string" },
+    "evidence_refs": { "type": "array", "items": { "type": "string" } },
+    "reason": { "type": "string" },
+    "trust_kernel_gate_order": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "prefixItems": [
+        { "const": "identity" },
+        { "const": "policy" },
+        { "const": "evidence" },
+        { "const": "attestation" },
+        { "const": "revocation" },
+        { "const": "audit" }
+      ],
+      "items": false
+    },
+    "subject_ref": { "type": "string" },
+    "envelope_ref": { "type": "string" },
+    "policy_refs": { "type": "array", "items": { "type": "string" } },
+    "membrane": {
+      "type": "object",
+      "description": "The capability-membrane resolution that governs this admission. execution_decision is the collapsed sourceos ExecutionDecision across all four fail-closed layers; a non-allow value forces decision=deny and granted_level=L0.",
+      "required": [
+        "execution_decision",
+        "verdict",
+        "capability_radius",
+        "missing_tension",
+        "membrane_decision",
+        "enforced",
+        "seal_hash"
+      ],
+      "properties": {
+        "execution_decision": {
+          "type": "string",
+          "enum": ["allow", "deny", "ask", "defer", "rewrite"]
+        },
+        "verdict": {
+          "type": "string",
+          "enum": ["allowed", "denied", "deferred", "failed", "observed"]
+        },
+        "capability_radius": { "type": "string", "pattern": "^R[0-5]$" },
+        "missing_tension": { "type": "array", "items": { "type": "string" } },
+        "membrane_decision": {
+          "type": "string",
+          "enum": ["ALLOW", "DENY", "QUARANTINE", "REDACT", "REQUIRE_SIGNATURE"]
+        },
+        "enforced": { "type": "boolean" },
+        "seal_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "agent_machine_receipt_ref": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "hash": { "type": "string" },
+    "hash_algo": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/socioprophet-web/server/src/routes/api/builds-route.ts
+++ b/socioprophet-web/server/src/routes/api/builds-route.ts
@@ -6,6 +6,7 @@ export {};
 const express = require("express");
 const { socbaseAdmin } = require("../../middleware/auth");
 const { dispatchBuild, readBuildStatus } = require("../../services/buildOrchestrator");
+const { admitBuild } = require("../../services/buildAdmission");
 const contracts = require("../../contracts");
 const { emitEvent } = require("../../services/events");
 
@@ -80,6 +81,25 @@ router.post("/", async (req: any, res: any) => {
     const wo = contracts.workOrder(doc.id, uid, spec.edition || "desktop");
     const woErrors = contracts.validate("WorkOrder", wo);
     if (!woErrors.length) await update({ workOrder: wo });
+
+    // Govern: admit the build through the capability membrane and seal an
+    // AutonomyAdmissionReceipt. Advisory by default (records + emits, never blocks);
+    // BUILD_ADMISSION_ENFORCE=true makes a deny fail-closed. Either way no OS image is
+    // built without a governance decision on record.
+    const admission = await admitBuild(uid, doc.id, spec, tier);
+    const admErrors = contracts.validate("AutonomyAdmissionReceipt.v0.2", admission.receipt);
+    if (admErrors.length) {
+      // our OWN receipt must conform; a non-conformant receipt is a bug, fail-closed.
+      await update({ status: "error", error: "AutonomyAdmissionReceipt not conformant: " + admErrors.join("; ") });
+      return res.status(500).json({ error: "internal: non-conformant admission receipt", details: admErrors });
+    }
+    await update({ admissionReceipt: admission.receipt, admissionDecision: admission.decision });
+    await emitEvent("srcos.builder.admission.decided", `urn:srcos:user:${uid}`,
+      buildRequest.id, { decision: admission.decision, enforced: admission.enforce, receiptId: admission.receipt.receipt_id }, "fog");
+    if (admission.blocked) {
+      await update({ status: "denied", error: "admission denied: " + admission.receipt.reason });
+      return res.status(403).json({ error: "build denied by governance membrane", decision: admission.decision, receipt: admission.receipt });
+    }
 
     try {
       const dispatch = await dispatchBuild(uid, doc.id, spec, tier);

--- a/socioprophet-web/server/src/services/buildAdmission.ts
+++ b/socioprophet-web/server/src/services/buildAdmission.ts
@@ -1,0 +1,159 @@
+export {};
+// Governed admission for OS-image builds.
+//
+// Before an image is built, the request is admitted through the AUTHORITATIVE capability
+// membrane (SourceOS-Linux/prophet-platform :: tools/capability_membrane.py) and the decision
+// is sealed into an AutonomyAdmissionReceipt (the same contract the membrane emits estate-wide
+// — vendored under contracts/schemas/). We NEVER re-implement the membrane decision here; we
+// call it and record what it said. Two properties make this safe to land on a live pipeline:
+//
+//   * ADVISORY BY DEFAULT. Every build gets a decision + a sealed receipt, but the build is
+//     never blocked unless BUILD_ADMISSION_ENFORCE=true. Flip enforcement on only once the
+//     membrane transport is confirmed in the deploy — so wiring this cannot break builds.
+//   * FAIL-CLOSED WHEN ENFORCING. Under enforcement, an unreachable/unwired membrane denies
+//     (never fails open). Under advisory, an unwired membrane admits but the receipt says so.
+//
+// Transport is injectable/config-driven: MEMBRANE_GATE_URL (HTTP POST the CapabilityRequest)
+// or MEMBRANE_GATE_CMD (the membrane CLI: JSON in on stdin, decision JSON on stdout, exit
+// 0=allow / 3=deny). Absent both, we are in advisory-no-transport mode.
+
+const crypto = require("crypto");
+const { execFile } = require("child_process");
+
+const ROLE_CEILING = "L2"; // builder role's autonomy ceiling
+// canonical trust-kernel gate order (AutonomyAdmissionReceipt.v0.2 requires exactly these six)
+const TRUST_KERNEL_GATE_ORDER = ["identity", "policy", "evidence", "attestation", "revocation", "audit"];
+
+// ---- compose the membrane CapabilityRequest for a build -------------------------------
+const riskForSpec = (spec: any, tier: string): string => {
+  if (spec && typeof spec.module === "string" && spec.module.trim().length > 0) return "high"; // raw Nix module
+  if (Array.isArray(spec?.users) && spec.users.some((u: any) => u?.privileged || u?.sudo)) return "high";
+  if (tier === "premium") return "medium";
+  return "low";
+};
+
+const composeCapabilityRequest = (uid: string, buildId: string, spec: any, tier: string) => ({
+  surface: "sourceos.os-image-build",
+  action: "builder.image.build",
+  access_level: "write",
+  subject_ref: `urn:srcos:user:${uid}`,
+  object_ref: `urn:srcos:build:${buildId}`,
+  scope: "global_platform",            // an OS artifact is published platform-wide
+  owned: true,
+  requested_autonomy_level: tier === "free" ? "L1" : "L2",
+  autonomy_evidence: [`tier:${tier}`],
+  membrane_decision: "ALLOW",
+  policy_refs: [`policy://sourceos/builder/tier/${tier}`],
+  risk_level: riskForSpec(spec, tier),
+  may_transmit_content: true,          // the build ships an artifact to GCS
+  machine_ref: "urn:srcos:agent-machine:builder",
+});
+
+// ---- call the authoritative membrane (transport is config-driven) ---------------------
+const shellMembrane = (cmd: string, request: any): Promise<any> =>
+  new Promise((resolve, reject) => {
+    const parts = cmd.split(/\s+/);
+    const child = execFile(parts[0], parts.slice(1), { timeout: 8000 }, (err: any, stdout: string) => {
+      // exit 0 = allow, 3 = deny — both carry a JSON decision on stdout; other codes are errors.
+      const code = err && typeof err.code === "number" ? err.code : 0;
+      if (code !== 0 && code !== 3) return reject(err || new Error(`membrane cli exit ${code}`));
+      try { resolve(JSON.parse(stdout || "{}")); } catch (e) { reject(e); }
+    });
+    child.stdin.end(JSON.stringify(request));
+  });
+
+const callMembrane = async (request: any): Promise<any | null> => {
+  const url = process.env.MEMBRANE_GATE_URL;
+  if (url) {
+    const r = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    if (!r.ok) throw new Error(`membrane gate HTTP ${r.status}`);
+    return await r.json();
+  }
+  const cmd = process.env.MEMBRANE_GATE_CMD;
+  if (cmd) return await shellMembrane(cmd, request);
+  return null; // no transport configured
+};
+
+const canon = (obj: any): string =>
+  JSON.stringify(obj, Object.keys(obj).sort()); // stable top-level key order for the seal
+
+// ---- compose the sealed AutonomyAdmissionReceipt (AutonomyAdmissionReceipt.v0.2) -------
+const composeReceipt = (request: any, d: any) => {
+  const membrane = d.membrane || {};
+  const admitted = d.decision === "admit";
+  const base: any = {
+    version: "0.2",
+    receipt_id: `urn:srcos:admission:${crypto.randomUUID()}`,
+    created_at: new Date().toISOString(),
+    service_ref: "urn:srcos:service:image-builder",
+    role: "builder",
+    requested_level: request.requested_autonomy_level,
+    granted_level: admitted ? request.requested_autonomy_level : "L0",
+    role_ceiling: ROLE_CEILING,
+    decision: d.decision,                 // admit | demote | deny
+    gate: "capability-membrane",
+    evidence_required: "none",
+    evidence_refs: [],
+    reason: d.reason || `membrane ${d.execution_decision}`,
+    trust_kernel_gate_order: TRUST_KERNEL_GATE_ORDER,
+    subject_ref: request.subject_ref,
+    policy_refs: request.policy_refs,
+    membrane: {
+      execution_decision: d.execution_decision,
+      verdict: d.verdict,
+      capability_radius: membrane.capability_radius || "R0",
+      missing_tension: membrane.missing_tension || [],
+      membrane_decision: membrane.membrane_decision || request.membrane_decision || "ALLOW",
+      enforced: !!d.enforced,
+      // when the membrane didn't return its own seal (advisory), seal the request itself so
+      // the field is always a real digest, never a placeholder.
+      seal_hash: membrane.seal_hash
+        || ("sha256:" + crypto.createHash("sha256").update(canon(request)).digest("hex")),
+    },
+    hash_algo: "sha256",
+  };
+  base.hash = "sha256:" + crypto.createHash("sha256").update(canon(base)).digest("hex");
+  return base;
+};
+
+// ---- the admission gate ---------------------------------------------------------------
+const admitBuild = async (uid: string, buildId: string, spec: any, tier: string) => {
+  const request = composeCapabilityRequest(uid, buildId, spec, tier);
+  const enforce = process.env.BUILD_ADMISSION_ENFORCE === "true";
+
+  let membrane: any = null;
+  let error: string | undefined;
+  try {
+    membrane = await callMembrane(request);
+  } catch (e: any) {
+    error = String(e?.message || e);
+  }
+
+  let decision: string, execution_decision: string, verdict: string, enforced: boolean;
+  if (membrane && membrane.execution_decision) {
+    execution_decision = membrane.execution_decision;             // allow|deny|ask|defer|rewrite
+    verdict = membrane.verdict || "observed";
+    enforced = membrane.enforced !== undefined ? !!membrane.enforced : true;
+    decision = execution_decision === "allow" ? "admit"
+      : execution_decision === "rewrite" ? "demote" : "deny";
+  } else {
+    // no usable membrane result: advisory admits, enforcement fails closed.
+    execution_decision = "defer";
+    verdict = "observed";
+    enforced = false;
+    decision = enforce ? "deny" : "admit";
+    if (!error) error = "membrane transport not configured — advisory admission";
+  }
+
+  const receipt = composeReceipt(request, {
+    decision, execution_decision, verdict, enforced, membrane, reason: error,
+  });
+  const blocked = enforce && decision !== "admit";
+  return { decision, blocked, enforce, receipt, request };
+};
+
+module.exports = { admitBuild, composeCapabilityRequest, composeReceipt, riskForSpec };

--- a/socioprophet-web/server/test/admission.test.mjs
+++ b/socioprophet-web/server/test/admission.test.mjs
@@ -1,0 +1,83 @@
+// Admission test: every OS build is admitted through the capability membrane and seals a
+// contract-conformant AutonomyAdmissionReceipt. Advisory-by-default never blocks; enforcement
+// fails closed. Self-contained — transpiles the TS on the fly (no loader), like contracts.test.
+// Run: node test/admission.test.mjs
+import { createRequire } from "module";
+import path from "path";
+import os from "os";
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const fs = require("fs");
+const Module = require("module");
+
+const load = (rel, name) => {
+  const src = fs.readFileSync(rel, "utf8");
+  const js = ts.transpileModule(src, { compilerOptions: { module: "commonjs", target: "es2020" } }).outputText;
+  const m = new Module(name);
+  m.filename = path.resolve(rel.replace(/\.ts$/, ".js"));
+  m.paths = Module._nodeModulePaths(path.dirname(m.filename));
+  m._compile(js, m.filename);
+  return m.exports;
+};
+
+const c = load("src/contracts/index.ts", "contracts");
+const adm = load("src/services/buildAdmission.ts", "buildAdmission");
+
+let fail = 0;
+const ck = (n, ok) => { console.log((ok ? "ok  " : "FAIL ") + n); if (!ok) fail++; };
+const conforms = (r) => c.validate("AutonomyAdmissionReceipt.v0.2", r).length === 0;
+const spec = { edition: "desktop", arch: "x86_64", hostname: "h", packages: [], users: [] };
+
+const cli = (name, body) => {
+  const p = path.join(os.tmpdir(), name);
+  fs.writeFileSync(p, `let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{${body}});`);
+  return `node ${p}`;
+};
+const reset = () => { delete process.env.MEMBRANE_GATE_URL; delete process.env.MEMBRANE_GATE_CMD; delete process.env.BUILD_ADMISSION_ENFORCE; };
+
+// 1. Advisory, no transport: admits, never blocks, receipt conforms + is sealed.
+reset();
+let r = await adm.admitBuild("u1", "b1", spec, "free");
+ck("advisory (no transport) admits, not blocked", r.decision === "admit" && r.blocked === false);
+ck("  receipt conforms to AutonomyAdmissionReceipt.v0.2", conforms(r.receipt));
+ck("  receipt is sealed (sha256)", /^sha256:[0-9a-f]{64}$/.test(r.receipt.hash));
+ck("  advisory receipt marks membrane unenforced", r.receipt.membrane.enforced === false);
+
+// 2. Enforce, no transport: fails closed (deny + blocked), receipt still conforms.
+reset(); process.env.BUILD_ADMISSION_ENFORCE = "true";
+r = await adm.admitBuild("u1", "b2", spec, "free");
+ck("enforce + no transport fails CLOSED (deny + blocked)", r.decision === "deny" && r.blocked === true);
+ck("  denied receipt still conforms", conforms(r.receipt));
+ck("  granted_level demoted to L0 on deny", r.receipt.granted_level === "L0");
+
+// 3. CLI transport ALLOW (exit 0): admit, not blocked, membrane fields carried through.
+reset();
+process.env.MEMBRANE_GATE_CMD = cli("membrane-allow.mjs",
+  "process.stdout.write(JSON.stringify({execution_decision:'allow',verdict:'allowed',enforced:true,capability_radius:'R2',missing_tension:[],membrane_decision:'ALLOW',seal_hash:'sha256:'+'a'.repeat(64)}));process.exit(0)");
+r = await adm.admitBuild("u1", "b3", spec, "premium");
+ck("cli allow -> admit, not blocked", r.decision === "admit" && r.blocked === false);
+ck("  granted_level == requested on admit", r.receipt.granted_level === r.request.requested_autonomy_level);
+ck("  carries membrane radius + seal", r.receipt.membrane.capability_radius === "R2" && r.receipt.membrane.enforced === true);
+
+// 4. CLI transport DENY (exit 3) under enforcement: deny + blocked.
+reset(); process.env.BUILD_ADMISSION_ENFORCE = "true";
+process.env.MEMBRANE_GATE_CMD = cli("membrane-deny.mjs",
+  "process.stdout.write(JSON.stringify({execution_decision:'deny',verdict:'denied',enforced:true,capability_radius:'R0',missing_tension:['consent'],membrane_decision:'DENY',seal_hash:'sha256:'+'b'.repeat(64)}));process.exit(3)");
+r = await adm.admitBuild("u1", "b4", spec, "premium");
+ck("cli deny (exit 3) + enforce -> deny + blocked", r.decision === "deny" && r.blocked === true);
+ck("  denied receipt conforms", conforms(r.receipt));
+
+// 5. CLI DENY but ADVISORY: records the deny, does NOT block (pipeline unbroken).
+reset(); // enforce off
+process.env.MEMBRANE_GATE_CMD = cli("membrane-deny2.mjs",
+  "process.stdout.write(JSON.stringify({execution_decision:'deny',verdict:'denied',enforced:true,capability_radius:'R0',missing_tension:['consent'],membrane_decision:'DENY',seal_hash:'sha256:'+'c'.repeat(64)}));process.exit(3)");
+r = await adm.admitBuild("u1", "b5", spec, "free");
+ck("cli deny + ADVISORY records deny but does NOT block", r.decision === "deny" && r.blocked === false);
+
+// 6. Risk classification: a raw Nix module snippet is high-risk.
+reset();
+ck("riskForSpec(raw module) == high", adm.riskForSpec({ module: "{ boot.loader.grub.enable = true; }" }, "free") === "high");
+ck("riskForSpec(plain free) == low", adm.riskForSpec(spec, "free") === "low");
+
+console.log(fail ? `\n${fail} FAILED` : "\nadmission: all checks pass");
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary
Closes the biggest governance gap the OS-build survey found: the image-build path is self-governed by `sourceos-spec` contracts but **never passes through the estate's autonomy-governance fabric** — a build could dispatch with no membrane decision on record. This admits **every build through the authoritative capability membrane before dispatch** and seals the decision into an `AutonomyAdmissionReceipt` (the same contract the membrane emits estate-wide).

## Safe to land on a live pipeline
- **Advisory by default** — every build gets a decision + a sealed receipt, but is **never blocked** unless `BUILD_ADMISSION_ENFORCE=true`. So wiring this cannot break the currently-shipped build loop. Flip enforcement on once the membrane transport is confirmed in the deploy.
- **Fail-closed when enforcing** — an unreachable/unwired membrane **denies**, never opens.
- **Conform, don't invent** — the membrane decision is **called**, not re-implemented; the receipt schema is vendored verbatim + hash-pinned from `prophet-platform`.

## Changes
- `src/services/buildAdmission.ts` — compose a membrane `CapabilityRequest` (surface `sourceos.os-image-build`, tier→autonomy level, spec→risk), call the authoritative membrane over a config-driven transport (`MEMBRANE_GATE_URL` HTTP / `MEMBRANE_GATE_CMD` CLI: JSON in, decision out, exit 0=allow/3=deny), seal an `AutonomyAdmissionReceipt.v0.2`.
- `routes/api/builds-route.ts` — admit **before** `dispatchBuild`: validate the receipt against the vendored schema, persist it + emit `srcos.builder.admission.decided`, and on an enforced deny return `403` without dispatching.
- `contracts/schemas/AutonomyAdmissionReceipt.v0.2.json` (+ PROVENANCE) — vendored from prophet-platform, registered in the contracts validator.
- `test/admission.test.mjs` — advisory-admits / enforce-fails-closed / CLI allow+deny / advisory-records-deny-without-blocking / risk / receipt conformance + seal. Gated in `builder-contract-tests.yml`. Existing contract test stays green.

## Follow-ups
- **Deploy:** set `MEMBRANE_GATE_URL|CMD` in the builder env, confirm decisions, then `BUILD_ADMISSION_ENFORCE=true` to make governance binding.
- **Closure #2** (separate): point `ControlPlaneLifecycle.vue`'s evidence-gate view at the live GCS-emitted evidence bundles instead of fixtures.

Touches a workflow — flagged for human review; not auto-merging.