### PR TITLE
feat(client-vue): Assay Fleet Dashboard — cloud-mesh verdict surface

### DIFF
--- a/socioprophet-web/client-vue/src/__tests__/AssayFleetFixture.test.ts
+++ b/socioprophet-web/client-vue/src/__tests__/AssayFleetFixture.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { demoAssayFleetSnapshot } from '../services/assayApi';
+
+// The client fixture must obey the same aggregation invariants the sourceos-spec
+// AssayRollup validator enforces — a broken fixture would render a lie.
+describe('demoAssayFleetSnapshot', () => {
+  const snap = demoAssayFleetSnapshot();
+
+  it('distribution sums to totalAssays', () => {
+    const { ok, sad, bad } = snap.rollup.distribution;
+    expect(ok + sad + bad).toBe(snap.rollup.totalAssays);
+  });
+
+  it('unassayedReasons never exceed the sad band', () => {
+    const reasons = snap.rollup.unassayedReasons ?? {};
+    const sum = Object.values(reasons).reduce((a, b) => a + b, 0);
+    expect(sum).toBeLessThanOrEqual(snap.rollup.distribution.sad);
+  });
+
+  it('standardAdoption node counts match scope.nodeCount', () => {
+    const adoption = snap.rollup.standardAdoption ?? [];
+    const sum = adoption.reduce((a, x) => a + x.nodeCount, 0);
+    expect(sum).toBe(snap.rollup.scope.nodeCount);
+  });
+
+  it('driftDetected agrees with the adoption table', () => {
+    const adoption = snap.rollup.standardAdoption ?? [];
+    const versions = new Set(adoption.map((a) => a.calibrationRef));
+    const anyUncalibrated = adoption.some((a) => !a.calibrated);
+    expect(snap.rollup.driftDetected).toBe(versions.size > 1 || anyUncalibrated);
+  });
+
+  it('rollout rolloutPct matches the promoted/observing node share', () => {
+    const cohorts = snap.rollout.cohorts;
+    const total = cohorts.reduce((a, c) => a + c.nodeCount, 0);
+    const onNew = cohorts
+      .filter((c) => c.state === 'promoted' || c.state === 'observing')
+      .reduce((a, c) => a + c.nodeCount, 0);
+    expect(Math.abs((snap.rollout.rolloutPct ?? 0) - (100 * onNew) / total)).toBeLessThan(0.5);
+  });
+
+  it('carries the two real calibrated standards', () => {
+    const real = snap.standards.filter((s) => s.real && s.calibrated).map((s) => s.verifierId);
+    expect(real).toContain('narration-fidelity');
+    expect(real).toContain('nl-lexical-baseline');
+  });
+});

--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -20,6 +20,19 @@ export type RouteRegistryEntry = {
 
 export const routeRegistry: RouteRegistryEntry[] = [
   {
+    path: '/capability/assay-fleet',
+    label: 'Assay Fleet',
+    domain: 'Capability',
+    maturity: 'L2',
+    stateMode: 'live-fallback',
+    navTier: 'tab-only',
+    userJob: 'See verdict health across the cloud-mesh fleet — the ok/sad/bad distribution, which verifier standards are actually calibrated and live (calibration drift), and any AssayStandard rollout in flight.',
+    ownerPlane: 'client-vue AssayFleetDashboard over prophet-mesh AssayRollup; live via the /svc/assay endpoint (:8780, opt-in, fails closed to a fixture carrying the real calibrated standards)',
+    boundary: 'Cloud-mesh only. A single-user local deployment never instantiates the fleet aggregation path, so this surface is structurally absent on-device. No writeback or rollout-control authority is active; live pull fails closed to the fixture.',
+    primaryObject: 'assay rollup',
+    breadcrumbs: ['Capability', 'Assay Fleet'],
+  },
+  {
     path: '/delivery/wbs',
     label: 'Delivery Excellence',
     domain: 'Delivery Excellence',

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -57,6 +57,7 @@ import CompetitiveIntelligenceEnterprise from './pages/CompetitiveIntelligenceEn
 import CompetitiveIntelligenceBoards from './pages/CompetitiveIntelligenceBoards.vue';
 import Reader from './pages/Reader.vue';
 import OperatorDashboard from './pages/OperatorDashboard.vue';
+import AssayFleetDashboard from './pages/AssayFleetDashboard.vue';
 import AlgoTradingBoard from './pages/AlgoTradingBoard.vue';
 import PortfolioBoard from './pages/PortfolioBoard.vue';
 import OperatorSurface from './pages/OperatorSurface.vue';
@@ -96,6 +97,7 @@ const explicitRoutes = [
   { path: '/', redirect: '/capability/dashboard' },
   { path: '/login', component: Login, meta: { public: true } },
   { path: '/capability/dashboard', component: OperatorDashboard },
+  { path: '/capability/assay-fleet', component: AssayFleetDashboard },
   { path: '/agentic-os', component: AgenticOS },
   { path: '/marketplace', component: Marketplace },
   { path: '/people/labor-market', component: LaborMarket },

--- a/socioprophet-web/client-vue/src/pages/AssayFleetDashboard.vue
+++ b/socioprophet-web/client-vue/src/pages/AssayFleetDashboard.vue
@@ -1,0 +1,320 @@
+<template>
+  <section class="af-page" aria-labelledby="af-title">
+    <header class="af-hero">
+      <div>
+        <p class="af-kicker">prophet-mesh · cloud-mesh · {{ mode }}</p>
+        <h1 id="af-title">Assay Fleet Dashboard</h1>
+        <p class="af-lede">
+          Verdict health across the fleet: how claims are projecting, which verifier standards are
+          actually live, and the standard rollout in flight. Every <code>ok</code> is earned behind a
+          measured verifier — never asserted.
+        </p>
+      </div>
+      <div class="af-scorecard" aria-label="Window summary">
+        <span class="af-score">{{ rollup.totalAssays }}</span>
+        <span class="af-score-label">assays · {{ rollup.scope.nodeCount }} nodes · 1h window</span>
+      </div>
+    </header>
+
+    <BoundaryNotice
+      :label="mode === 'live' ? 'live' : 'fixture'"
+      :message="mode === 'live'
+        ? 'Live AssayRollup from prophet-mesh (cloud-mesh).'
+        : 'Fixture rollup with the real calibrated standards. Wire VITE_ASSAY_BASE to the prophet-mesh rollup endpoint (:8780) for live fleet data.'"
+    />
+
+    <RouteStatePanel
+      :state="mode === 'live' ? 'ready' : 'mock'"
+      :title="mode === 'live' ? 'Live fleet' : 'Fixture fleet'"
+      :message="loadError
+        ? `Backend unavailable (${loadError}); showing the fixture rollup with real standards.`
+        : `${rollup.totalAssays} verdicts across ${rollup.scope.nodeCount} nodes${rollup.driftDetected ? ' — calibration drift detected' : ''}.`"
+    />
+
+    <!-- KPI row -->
+    <section class="af-kpis" aria-label="Verdict distribution">
+      <article class="af-kpi af-ok">
+        <span class="af-big">{{ pct(rollup.distribution.ok) }}%</span>
+        <span class="af-lbl">ok</span>
+        <span class="af-sub">{{ rollup.distribution.ok }} · supported, inline, calibrated</span>
+      </article>
+      <article class="af-kpi af-sad">
+        <span class="af-big">{{ pct(rollup.distribution.sad) }}%</span>
+        <span class="af-lbl">unassayed · sad</span>
+        <span class="af-sub">{{ rollup.distribution.sad }} · not yet settled</span>
+      </article>
+      <article class="af-kpi af-bad">
+        <span class="af-big">{{ pct(rollup.distribution.bad) }}%</span>
+        <span class="af-lbl">bad</span>
+        <span class="af-sub">{{ rollup.distribution.bad }} · refuted / broken</span>
+      </article>
+      <article class="af-kpi af-sig">
+        <span class="af-big">{{ standards.length }}</span>
+        <span class="af-lbl">standards live</span>
+        <span class="af-sub">{{ calibratedCount }} calibrated</span>
+      </article>
+    </section>
+
+    <!-- distribution bar -->
+    <section class="af-panel" aria-label="Distribution bar">
+      <div class="af-distbar">
+        <span class="af-seg af-seg-ok" :style="{ width: pct(rollup.distribution.ok) + '%' }">{{ rollup.distribution.ok }}</span>
+        <span class="af-seg af-seg-sad" :style="{ width: pct(rollup.distribution.sad) + '%' }">{{ rollup.distribution.sad }}</span>
+        <span class="af-seg af-seg-bad" :style="{ width: pct(rollup.distribution.bad) + '%' }">{{ rollup.distribution.bad }}</span>
+      </div>
+      <div class="af-legend">
+        <span><i class="af-dot af-ok" /> ok — supported, inline-bound, calibrated verifier</span>
+        <span><i class="af-dot af-sad" /> sad — unassayed / unresolved</span>
+        <span><i class="af-dot af-bad" /> bad — refuted or authority-broken</span>
+      </div>
+    </section>
+
+    <div class="af-two">
+      <section class="af-panel" aria-label="Why amber">
+        <h2>Why the fleet is amber</h2>
+        <div v-for="row in reasonRows" :key="row.label" class="af-barrow">
+          <span class="af-k">{{ row.label }}</span>
+          <span class="af-track"><span class="af-fill af-fill-sad" :style="{ width: row.pct + '%' }" /></span>
+          <span class="af-v">{{ row.value }}</span>
+        </div>
+        <p class="af-note">The amber band is <em>earned</em>: each sad verdict names its unresolved condition.</p>
+      </section>
+
+      <section class="af-panel" aria-label="By method">
+        <h2>By method</h2>
+        <div v-for="row in methodRows" :key="row.label" class="af-barrow">
+          <span class="af-k">{{ row.label }}</span>
+          <span class="af-track"><span class="af-fill" :class="row.cls" :style="{ width: row.pct + '%' }" /></span>
+          <span class="af-v">{{ row.value }}</span>
+        </div>
+        <p class="af-note">Computed + retrieved are attestable and can reach ok; generated cannot on its own.</p>
+      </section>
+    </div>
+
+    <!-- calibration drift -->
+    <section class="af-panel" aria-label="Calibration drift">
+      <h2>
+        Calibration drift — which standards are live
+        <span v-if="rollup.driftDetected" class="af-warn">⚠ drift detected</span>
+      </h2>
+      <p class="af-note">
+        The fleet's {{ pct(rollup.distribution.ok) }}% ok is weaker than it looks:
+        {{ uncalibratedNodes }} of {{ rollup.scope.nodeCount }} nodes verify against an uncalibrated standard,
+        so their verdicts can never legitimately reach ok.
+      </p>
+      <table class="af-table">
+        <thead>
+          <tr><th>AssayStandard (verifier · version)</th><th>nodes</th><th>F1</th><th>κ</th><th>status</th></tr>
+        </thead>
+        <tbody>
+          <tr v-for="s in standardRows" :key="s.id">
+            <td class="af-mono">
+              {{ s.verifierId }} : {{ s.version }}
+              <span v-if="s.real" class="af-real">● real</span>
+            </td>
+            <td>{{ s.nodeCount }}</td>
+            <td class="af-num">{{ s.f1.toFixed(2) }}</td>
+            <td class="af-num">{{ s.kappa.toFixed(2) }} <span class="af-muted">{{ s.kappaLabel }}</span></td>
+            <td>
+              <span :class="['af-chip', s.calibrated ? 'af-chip-ok' : 'af-chip-sad']">
+                {{ s.calibrated ? 'calibrated' : 'uncalibrated' }}
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="af-note">
+        The two calibrated standards are <strong>real measurements</strong>: narration-fidelity from the
+        SP-TRACE-CFR eval (F1 1.0, n=42), nl-lexical-baseline from a labelled NL corpus (F1 0.71, n=32).
+      </p>
+    </section>
+
+    <!-- rollout -->
+    <section class="af-panel" aria-label="Standard rollout">
+      <div class="af-rollout-head">
+        <span class="af-mono">
+          {{ rollout.supersedes ? shortVer(rollout.supersedes) : '—' }} →
+          <strong class="af-accent">{{ shortVer(rollout.standardRef) }}</strong>
+        </span>
+        <span class="af-phase">{{ rollout.strategy }} · {{ rollout.phase }}</span>
+      </div>
+      <div class="af-pcttrack"><div class="af-pctfill" :style="{ width: (rollout.rolloutPct || 0) + '%' }" /></div>
+      <p class="af-mono af-sub2">
+        {{ (rollout.rolloutPct || 0).toFixed(1) }}% of fleet on new standard · guard:
+        <code>{{ rollout.guard?.metric }}</code> →
+        <span :class="rollout.guard?.decision === 'continue' ? 'af-good' : 'af-warn'">{{ rollout.guard?.decision }}</span>
+      </p>
+      <div class="af-cohorts">
+        <div v-for="c in rollout.cohorts" :key="c.cohortId" :class="['af-cohort', `af-cohort-${c.state}`]">
+          <span class="af-cid">{{ c.cohortId }}</span>
+          <span class="af-nodes">{{ c.nodeCount }} nodes · {{ c.state }}</span>
+        </div>
+      </div>
+      <p class="af-note">
+        Widening is gated on the canary's observed rollup — <strong>no promotion-by-hope</strong>. A new
+        verifier standard is never switched on fleet-wide at once.
+      </p>
+    </section>
+
+    <section class="af-panel af-local" aria-label="Local mode">
+      <h2>The local contrast</h2>
+      <p class="af-note">
+        A <strong>single-user local</strong> deployment runs the same Assay framework — verdicts, projection,
+        the resolver gate — but this dashboard does not exist there. On <code>local</code> /
+        <code>trusted_private</code> loci the fleet aggregation path is never instantiated. No fleet dashboards
+        for a single user is a <strong>structural</strong> guarantee, not a setting.
+      </p>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import BoundaryNotice from '../components/BoundaryNotice.vue';
+import RouteStatePanel from '../components/RouteStatePanel.vue';
+import {
+  demoAssayFleetSnapshot,
+  fetchAssayFleetWithFallback,
+  type AssayFleetSnapshot,
+  type AssayMode,
+} from '../services/assayApi';
+
+const snapshot = ref<AssayFleetSnapshot>(demoAssayFleetSnapshot());
+const mode = ref<AssayMode>('fixture');
+const loadError = ref<string | undefined>(undefined);
+
+onMounted(async () => {
+  const result = await fetchAssayFleetWithFallback();
+  snapshot.value = result.snapshot;
+  mode.value = result.mode;
+  loadError.value = result.error;
+});
+
+const rollup = computed(() => snapshot.value.rollup);
+const rollout = computed(() => snapshot.value.rollout);
+const standards = computed(() => snapshot.value.standards);
+
+function pct(n: number): number {
+  const total = rollup.value.totalAssays || 1;
+  return Math.round((n / total) * 1000) / 10;
+}
+
+const calibratedCount = computed(() => standards.value.filter((s) => s.calibrated).length);
+
+const methodColour: Record<string, string> = {
+  computed: 'af-fill-ok',
+  retrieved: 'af-fill-sig',
+  generated: 'af-fill-muted',
+};
+
+const reasonRows = computed(() => {
+  const reasons = rollup.value.unassayedReasons || {};
+  const max = Math.max(1, ...Object.values(reasons));
+  return Object.entries(reasons).map(([label, value]) => ({ label, value, pct: (value / max) * 100 }));
+});
+
+const methodRows = computed(() => {
+  const methods = rollup.value.byMethod || {};
+  const max = Math.max(1, ...Object.values(methods));
+  return Object.entries(methods)
+    .sort((a, b) => b[1] - a[1])
+    .map(([label, value]) => ({ label, value, pct: (value / max) * 100, cls: methodColour[label] || 'af-fill-muted' }));
+});
+
+// join adoption node counts with the standard summaries for the drift table
+const standardRows = computed(() => {
+  const adoption = rollup.value.standardAdoption || [];
+  return standards.value.map((s) => {
+    const a = adoption.find((x) => x.calibrationRef === s.id);
+    return { ...s, nodeCount: a?.nodeCount ?? 0 };
+  });
+});
+
+const uncalibratedNodes = computed(() =>
+  (rollup.value.standardAdoption || []).filter((a) => !a.calibrated).reduce((sum, a) => sum + a.nodeCount, 0),
+);
+
+function shortVer(ref: string): string {
+  const parts = ref.split(':');
+  return `${parts[parts.length - 2]}:${parts[parts.length - 1]}`;
+}
+</script>
+
+<style scoped>
+.af-page { display: flex; flex-direction: column; gap: 1.1rem; padding: 1.5rem; max-width: 1080px; margin: 0 auto; }
+.af-hero { display: flex; justify-content: space-between; align-items: flex-start; gap: 1.5rem; flex-wrap: wrap; }
+.af-kicker { font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent); margin: 0 0 0.3rem; }
+.af-hero h1 { margin: 0; font-size: clamp(1.5rem, 3.5vw, 2.1rem); }
+.af-lede { color: var(--text-2); max-width: 60ch; margin: 0.5rem 0 0; }
+.af-scorecard { display: flex; flex-direction: column; align-items: flex-end; }
+.af-score { font-size: 2.2rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.af-score-label { font-size: 0.74rem; color: var(--text-3); }
+code { background: var(--surface-2); border: 1px solid var(--line); padding: 0.03rem 0.32rem; border-radius: 6px; font-size: 0.86em; }
+
+.af-kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 0.7rem; }
+.af-kpi { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius-sm, 10px); padding: 0.9rem 1rem; border-top: 3px solid var(--neutral); }
+.af-kpi.af-ok { border-top-color: var(--up); }
+.af-kpi.af-sad { border-top-color: var(--amber); }
+.af-kpi.af-bad { border-top-color: var(--down); }
+.af-kpi.af-sig { border-top-color: var(--info); }
+.af-big { font-size: 2rem; font-weight: 700; line-height: 1; font-variant-numeric: tabular-nums; display: block; }
+.af-ok .af-big { color: var(--up); }
+.af-sad .af-big { color: var(--amber); }
+.af-bad .af-big { color: var(--down); }
+.af-lbl { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); margin-top: 0.35rem; display: block; }
+.af-sub { font-size: 0.72rem; color: var(--text-2); margin-top: 0.15rem; display: block; }
+
+.af-panel { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius, 14px); padding: 1.1rem 1.2rem; }
+.af-panel h2 { font-size: 0.95rem; margin: 0 0 0.7rem; }
+.af-two { display: grid; grid-template-columns: 1fr; gap: 0.9rem; }
+@media (min-width: 760px) { .af-two { grid-template-columns: 1fr 1fr; } }
+
+.af-distbar { display: flex; height: 2.3rem; border-radius: 8px; overflow: hidden; border: 1px solid var(--line); margin-bottom: 0.7rem; }
+.af-seg { display: flex; align-items: center; justify-content: center; font-variant-numeric: tabular-nums; font-weight: 700; color: #0c0d11; min-width: 2rem; font-size: 0.8rem; }
+.af-seg-ok { background: var(--up); }
+.af-seg-sad { background: var(--amber); }
+.af-seg-bad { background: var(--down); }
+.af-legend { display: flex; gap: 1.2rem; flex-wrap: wrap; font-size: 0.76rem; color: var(--text-2); }
+.af-dot { display: inline-block; width: 0.7rem; height: 0.7rem; border-radius: 3px; vertical-align: middle; margin-right: 0.3rem; }
+.af-dot.af-ok { background: var(--up); }
+.af-dot.af-sad { background: var(--amber); }
+.af-dot.af-bad { background: var(--down); }
+
+.af-barrow { display: grid; grid-template-columns: 12ch 1fr 3ch; gap: 0.7rem; align-items: center; margin: 0.35rem 0; font-size: 0.8rem; }
+.af-track { height: 0.7rem; background: var(--surface-2); border-radius: 4px; overflow: hidden; }
+.af-fill { height: 100%; border-radius: 4px; display: block; }
+.af-fill-sad { background: var(--amber); }
+.af-fill-ok { background: var(--up); }
+.af-fill-sig { background: var(--info); }
+.af-fill-muted { background: var(--neutral); }
+.af-k { color: var(--text-2); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.af-v { color: var(--text-3); text-align: right; font-variant-numeric: tabular-nums; }
+.af-note { font-size: 0.8rem; color: var(--text-2); margin: 0.7rem 0 0; }
+
+.af-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; margin-top: 0.4rem; }
+.af-table th, .af-table td { text-align: left; padding: 0.5rem 0.6rem; border-bottom: 1px solid var(--line); }
+.af-table th { font-size: 0.68rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-3); }
+.af-mono { font-family: var(--font-mono, ui-monospace, monospace); }
+.af-num { font-variant-numeric: tabular-nums; }
+.af-muted { color: var(--text-3); font-size: 0.9em; }
+.af-real { color: var(--up); font-size: 0.72rem; margin-left: 0.3rem; }
+.af-chip { display: inline-block; font-size: 0.66rem; padding: 0.1rem 0.5rem; border-radius: 5px; border: 1px solid currentColor; text-transform: uppercase; letter-spacing: 0.04em; }
+.af-chip-ok { color: var(--up); }
+.af-chip-sad { color: var(--amber); }
+.af-warn { color: var(--down); font-size: 0.78rem; }
+.af-good { color: var(--up); }
+
+.af-rollout-head { display: flex; justify-content: space-between; align-items: baseline; flex-wrap: wrap; gap: 0.5rem; }
+.af-accent { color: var(--accent); }
+.af-phase { font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent); }
+.af-pcttrack { height: 0.6rem; background: var(--surface-2); border: 1px solid var(--line); border-radius: 6px; overflow: hidden; margin: 0.5rem 0 0.3rem; }
+.af-pctfill { height: 100%; background: linear-gradient(90deg, var(--accent-soft), var(--accent)); }
+.af-sub2 { font-size: 0.76rem; color: var(--text-2); margin: 0 0 0.7rem; }
+.af-cohorts { display: flex; flex-direction: column; gap: 0.5rem; }
+.af-cohort { display: flex; justify-content: space-between; background: var(--surface-2); border-left: 2px solid var(--neutral); border-radius: 0 6px 6px 0; padding: 0.5rem 0.8rem; }
+.af-cohort-promoted { border-left-color: var(--up); }
+.af-cohort-pending { border-left-color: var(--neutral); }
+.af-cid { font-family: var(--font-mono, ui-monospace, monospace); font-size: 0.82rem; }
+.af-nodes { font-size: 0.74rem; color: var(--text-3); }
+.af-local { border-style: dashed; }
+</style>

--- a/socioprophet-web/client-vue/src/services/assayApi.ts
+++ b/socioprophet-web/client-vue/src/services/assayApi.ts
@@ -1,0 +1,137 @@
+// Assay Fleet API client.
+//
+// Fronts prophet-mesh's cloud-mesh rollup: an AssayRollup (fleet verdict
+// distribution + calibration drift) plus the AssayStandardRollout in flight and a
+// summary of the verifier standards live across the fleet. Mirrors the
+// personGraphApi pattern: an env-configured base via resolveBase, a getJson
+// wrapper, and a *WithFallback variant that returns a deterministic fixture (the
+// real calibrated standards) so the SPA renders in fixture mode with no backend.
+import { resolveBase } from '../config/cockpitRuntime';
+
+const BASE = resolveBase('assay', 'VITE_ASSAY_BASE', '/svc/assay');
+
+export type AssayState = 'ok' | 'sad' | 'bad';
+export type AssayMode = 'live' | 'fixture';
+
+export interface StandardAdoption {
+  calibrationRef: string;
+  nodeCount: number;
+  calibrated: boolean;
+}
+
+export interface AssayRollup {
+  id: string;
+  scope: { mode: 'node' | 'cohort' | 'fleet'; nodeCount: number; cohortId?: string };
+  window: { from: string; to: string };
+  totalAssays: number;
+  distribution: Record<AssayState, number>;
+  byMethod?: Record<string, number>;
+  unassayedReasons?: Record<string, number>;
+  standardAdoption?: StandardAdoption[];
+  driftDetected?: boolean;
+  capturedAt: string;
+}
+
+// Display summary of an AssayStandard (the measured reliability of a verifier).
+export interface AssayStandardSummary {
+  id: string;
+  verifierId: string;
+  version: string;
+  f1: number;
+  kappa: number;
+  kappaLabel: string;
+  calibrated: boolean;
+  sampleSize: number;
+  real: boolean; // measured from a real calibration run vs a placeholder
+}
+
+export interface AssayStandardRollout {
+  id: string;
+  standardRef: string;
+  supersedes?: string;
+  strategy: 'canary' | 'staged' | 'immediate';
+  phase: 'canary' | 'widening' | 'complete' | 'halted' | 'rolled-back';
+  cohorts: Array<{ cohortId: string; nodeCount: number; state: string }>;
+  guard?: { observedRollupRef?: string; metric?: string; decision?: 'continue' | 'hold' | 'rollback' };
+  rolloutPct?: number;
+}
+
+export interface AssayFleetSnapshot {
+  rollup: AssayRollup;
+  rollout: AssayStandardRollout;
+  standards: AssayStandardSummary[];
+}
+
+export interface AssayFleetLoadResult {
+  snapshot: AssayFleetSnapshot;
+  mode: AssayMode;
+  error?: string;
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${BASE}${path}`, { headers: { accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText} for ${path}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchAssayFleetSnapshot(): Promise<AssayFleetSnapshot> {
+  return getJson<AssayFleetSnapshot>('/fleet/rollup');
+}
+
+export async function fetchAssayFleetWithFallback(): Promise<AssayFleetLoadResult> {
+  try {
+    const snapshot = await fetchAssayFleetSnapshot();
+    return { snapshot, mode: 'live' };
+  } catch (error) {
+    return {
+      snapshot: demoAssayFleetSnapshot(),
+      mode: 'fixture',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// ── Fixture — real calibrated standards + a representative fleet window ──
+const NF = 'urn:srcos:assay-standard:narration-fidelity:cfr-eval-001';
+const NL = 'urn:srcos:assay-standard:nl-lexical-baseline:v1';
+const NLI = 'urn:srcos:assay-standard:deployed-nli:0.1.0';
+
+export function demoAssayFleetSnapshot(): AssayFleetSnapshot {
+  const rollup: AssayRollup = {
+    id: 'urn:srcos:assay-rollup:fleet-demo',
+    scope: { mode: 'fleet', nodeCount: 12 },
+    window: { from: '2026-07-05T00:00:00Z', to: '2026-07-05T01:00:00Z' },
+    totalAssays: 100,
+    distribution: { ok: 40, sad: 55, bad: 5 },
+    byMethod: { generated: 45, computed: 30, retrieved: 25 },
+    unassayedReasons: { 'post-hoc-binding': 30, 'uncalibrated-verifier': 15, 'correlated-arms': 10 },
+    standardAdoption: [
+      { calibrationRef: NF, nodeCount: 5, calibrated: true },
+      { calibrationRef: NL, nodeCount: 4, calibrated: true },
+      { calibrationRef: NLI, nodeCount: 3, calibrated: false },
+    ],
+    driftDetected: true,
+    capturedAt: '2026-07-05T01:00:01Z',
+  };
+  const rollout: AssayStandardRollout = {
+    id: 'urn:srcos:assay-standard-rollout:narration-fidelity-next',
+    standardRef: 'urn:srcos:assay-standard:narration-fidelity:cfr-eval-002',
+    supersedes: NF,
+    strategy: 'canary',
+    phase: 'widening',
+    cohorts: [
+      { cohortId: 'canary-a', nodeCount: 2, state: 'promoted' },
+      { cohortId: 'fleet-remainder', nodeCount: 10, state: 'pending' },
+    ],
+    guard: { observedRollupRef: 'urn:srcos:assay-rollup:fleet-demo', metric: 'bad_rate_delta', decision: 'continue' },
+    rolloutPct: 16.7,
+  };
+  const standards: AssayStandardSummary[] = [
+    { id: NF, verifierId: 'narration-fidelity', version: 'cfr-eval-001', f1: 1.0, kappa: 1.0, kappaLabel: 'almost-perfect', calibrated: true, sampleSize: 42, real: true },
+    { id: NL, verifierId: 'nl-lexical-baseline', version: 'v1', f1: 0.706, kappa: 0.375, kappaLabel: 'fair', calibrated: true, sampleSize: 32, real: true },
+    { id: NLI, verifierId: 'deployed-nli', version: '0.1.0', f1: 0.26, kappa: 0.19, kappaLabel: 'slight', calibrated: false, sampleSize: 100, real: false },
+  ];
+  return { rollup, rollout, standards };
+}

--- a/socioprophet-web/client-vue/vite.config.ts
+++ b/socioprophet-web/client-vue/vite.config.ts
@@ -77,6 +77,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/sherlock/, ''),
         },
+        // prophet-mesh cloud-mesh Assay rollup endpoint. Strip the /svc/assay prefix.
+        '/svc/assay': {
+          target: env.VITE_ASSAY_BASE || 'http://localhost:8780',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/assay/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',


### PR DESCRIPTION
The visible cloud-mesh surface for the Assay framework, at **`/capability/assay-fleet`**. Renders an `AssayRollup` from prophet-mesh:

- **KPI row + distribution bar** — ok/sad/bad across the fleet
- **Why-amber breakdown** (`unassayedReasons`) and **by-method**
- **Calibration drift table** — which verifier standards are live and whether they're calibrated; surfaces the case where a fleet looks green but some nodes verify against an uncalibrated standard
- **`AssayStandardRollout` in flight** — canary → widen, gated on the observed rollup (no promotion-by-hope)
- **Local-mode contrast** — on `local`/`trusted_private` this surface is structurally absent

## Follows the house pattern (no invention)
- `src/services/assayApi.ts` with `fetch…WithFallback` via `resolveBase('assay','VITE_ASSAY_BASE','/svc/assay')` → `:8780`
- fixture-seeded `onMounted` swap (screen never blank), `RouteStatePanel` + `BoundaryNotice` for live/fixture provenance
- ok/sad/bad mapped onto the existing `--up`/`--amber`/`--down` tokens — **no hardcoded hex**
- route in `main.ts`, `routeRegistry` entry (`live-fallback`), `/svc/assay` dev proxy

## Real data offline
The fixture carries the **two real calibrated standards** (`narration-fidelity` F1 1.0 from the SP-TRACE-CFR eval; `nl-lexical-baseline` F1 0.71 from a labelled NL corpus), so it renders truthfully with no backend. A vitest asserts the fixture obeys the same aggregation invariants the sourceos-spec `AssayRollup` validator enforces.

## Verified
`vue-tsc --noEmit` clean · `vitest` 6/6 · `vite build` OK · dev server serves **HTTP 200 on :5174** with the SFC + API module transforming cleanly.

Consumes prophet-mesh #23 (impl + calibration) and sourceos-spec #279 (`AssayRollup`). Live wiring: point `VITE_ASSAY_BASE` at a prophet-mesh rollup endpoint.