### PR TITLE
feat(acquire-worker): real Node worker — live fetch through the governed plane

### DIFF
--- a/socioprophet-web/acquire-worker/.gitignore
+++ b/socioprophet-web/acquire-worker/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+landed/
+*.jsonl
+dist/

--- a/socioprophet-web/acquire-worker/README.md
+++ b/socioprophet-web/acquire-worker/README.md
@@ -1,0 +1,51 @@
+# @socioprophet/acquire-worker
+
+The **real** Node worker for the governed acquisition plane — not pretty logic in a repo, an actual
+process that fetches live public data through the same governance the cockpit unit-tests, and lands
+it **local or cloud** with an intact provenance chain.
+
+It reuses the canonical plane core from `../client-vue/src/features/acquisition/*` (one source of
+truth — no duplication) and adds only the parts that need a real runtime:
+
+- **`nodeTransport.ts`** — live `fetch` (undici), optional per-request proxy egress (undici
+  `ProxyAgent`), real `robots.txt` fetch, real SHA-256 provenance hashing (`node:crypto`).
+- **`sinks.ts`** — where data lands: `LocalFileSink` (content-addressed body + provenance sidecar),
+  `JsonlLedgerSink` (append-only audit trail), `HttpSink` (cloud bucket / **prophet-mesh** ingest),
+  `MultiSink` (land local **and** cloud at once).
+- **`service.ts`** — `AcquisitionService`, the API the estate calls. Runs policy → identity → robots
+  → rate (honored for real, with bounded waits) → conditional-GET → provenance → sink.
+- **`bearBrowserTransport.ts`** — the seam where **BearBrowser** becomes the agentic-ops browser: bind
+  a `BearBrowserHost` render bridge and it drops in as the T2/T3 `DirectFetch`.
+- **`cli.ts`** / **`server.ts`** — a CLI and an HTTP endpoint (`POST /acquire`).
+
+## Run it
+
+```bash
+npm install
+# live fetch, land locally + to a ledger:
+npm run acquire -- https://en.wikipedia.org/wiki/Web_scraping --sink local:./landed,ledger:./acquire-ledger.jsonl
+# land to the mesh / a cloud endpoint instead:
+npm run acquire -- https://example.com --sink http:https://mesh.internal/ingest
+# as a service:
+npm run serve   # POST :8790/acquire { "url": "...", "accountClass": "commercial", "tier": "T1", "sink": "local:./landed" }
+npm test        # network-free governance + landing tests
+```
+
+Verified live: a real fetch of the Wikipedia article returns HTTP 200 / ~239 KB, lands the body +
+provenance to disk, appends the ledger, and the recomputed SHA-256 matches the provenance hash.
+
+## Meta-surface integration seams
+
+| Surface | Seam |
+|---|---|
+| **BearBrowser** | `BearBrowserHost.render` → `bearBrowserDirectFetch` (T2/T3 transport; agentic-ops browser by default) |
+| **Turtle Terminal** | `acquire` CLI as a first-class shell verb |
+| **GooseNotes** | `AcquisitionService.acquire` → note capture with provenance |
+| **Noetica** | governed invocation via the account-tiered policy + provenance record |
+| **prophet-mesh** | `HttpSink` → mesh ingest; policy/provenance map onto the mesh trust kernel |
+
+## Note
+
+Short-term the plane core lives in `client-vue` and is imported here. The clean long-term home is a
+shared sovereign package (e.g. `prophet-core-ingest`) both the cockpit and this worker depend on;
+tracked as a convergence follow-up.

--- a/socioprophet-web/acquire-worker/package-lock.json
+++ b/socioprophet-web/acquire-worker/package-lock.json
@@ -1,0 +1,564 @@
+{
+  "name": "@socioprophet/acquire-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@socioprophet/acquire-worker",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "undici": "^6.19.8"
+      },
+      "bin": {
+        "acquire": "src/cli.ts"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    }
+  }
+}

--- a/socioprophet-web/acquire-worker/package.json
+++ b/socioprophet-web/acquire-worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@socioprophet/acquire-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Real Node worker for the governed acquisition plane — live fetch, robots, rate, provenance, local/cloud sinks.",
+  "license": "MIT",
+  "bin": { "acquire": "src/cli.ts" },
+  "scripts": {
+    "acquire": "tsx src/cli.ts",
+    "serve": "tsx src/server.ts",
+    "test": "tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "undici": "^6.19.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/socioprophet-web/acquire-worker/src/bearBrowserTransport.ts
+++ b/socioprophet-web/acquire-worker/src/bearBrowserTransport.ts
@@ -1,0 +1,32 @@
+// BearBrowser transport seam — where "the browser is used by our agentic ops by default" lands.
+// For T3 (JS-rendered) and hard targets, instead of a headless Playwright we drive BearBrowser, our
+// own sovereign browser, over a host-provided render hook. This is a real seam, not a stub: bind a
+// BearBrowserHost (the CDP/embed bridge the BearBrowser process exposes) and this becomes a live
+// DirectFetch the AcquisitionService uses in place of the plain Node transport. Until a host is
+// bound it fails loudly rather than silently degrading — no pretend rendering.
+import type { DirectFetch } from '../../client-vue/src/features/acquisition/transport';
+import type { NetResponse } from '../../client-vue/src/features/acquisition/fetcher';
+
+// What the BearBrowser process must provide (implemented on the BearBrowser side of the bridge):
+// render a URL in a real, fingerprint-realistic browser context and return the resulting document.
+export interface BearBrowserHost {
+  render(url: string, opts: {
+    headers: Record<string, string>;
+    proxyUrl?: string;
+    waitFor?: 'load' | 'networkidle' | string; // selector or lifecycle
+    timeoutMs?: number;
+  }): Promise<{ status: number; html: string; finalUrl: string }>;
+}
+
+// Turn a bound BearBrowser host into a DirectFetch the governed plane can use for T2/T3.
+export function bearBrowserDirectFetch(host: BearBrowserHost, opts: { waitFor?: string; timeoutMs?: number } = {}): DirectFetch {
+  return async (url, { headers, proxyUrl }) => {
+    const r = await host.render(url, { headers, proxyUrl, waitFor: opts.waitFor ?? 'networkidle', timeoutMs: opts.timeoutMs });
+    return { status: r.status, headers: { 'x-final-url': r.finalUrl }, body: r.html } satisfies NetResponse;
+  };
+}
+
+// Placeholder host that makes the missing wiring explicit — bind the real one from BearBrowser.
+export const unboundBearBrowserHost: BearBrowserHost = {
+  async render() { throw new Error('BearBrowser host not bound — wire the CDP/embed bridge from the BearBrowser process'); },
+};

--- a/socioprophet-web/acquire-worker/src/cli.ts
+++ b/socioprophet-web/acquire-worker/src/cli.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S npx tsx
+// acquire — CLI for the governed acquisition worker. Fetches a live URL through the full plane and
+// lands it. Usage:
+//   acquire <url> [--account sovereign|research|own-estate|commercial] [--tier T0..T4]
+//                 [--sink local:<dir> | ledger:<file> | http:<url>] [--geo US] [--dry]
+import { AcquisitionService } from './service';
+import { LocalFileSink, JsonlLedgerSink, HttpSink, MemorySink, MultiSink, type Sink } from './sinks';
+import type { AccountClass, AcquisitionTier } from '../../client-vue/src/features/acquisition/policy';
+
+function arg(flag: string, def?: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+function makeSink(spec: string | undefined): Sink {
+  if (!spec || spec === 'dry') return new MemorySink();
+  return new MultiSink(spec.split(',').map((s) => {
+    const [kind, ...rest] = s.split(':');
+    const target = rest.join(':');
+    if (kind === 'local') return new LocalFileSink(target || './landed');
+    if (kind === 'ledger') return new JsonlLedgerSink(target || './acquire-ledger.jsonl');
+    if (kind === 'http') return new HttpSink(target);
+    throw new Error(`unknown sink '${s}' (use local:<dir> | ledger:<file> | http:<url>)`);
+  }));
+}
+
+async function main() {
+  const url = process.argv[2];
+  if (!url || url.startsWith('--')) { console.error('usage: acquire <url> [--account ..] [--tier ..] [--sink local:<dir>]'); process.exit(2); }
+  const sink = makeSink(arg('--dry') !== undefined ? 'dry' : arg('--sink', 'local:./landed'));
+  const svc = new AcquisitionService();
+  const res = await svc.acquire(url, {
+    accountClass: (arg('--account', 'sovereign') as AccountClass),
+    tier: (arg('--tier', 'T1') as AcquisitionTier),
+    geo: arg('--geo', 'US'),
+    sink,
+  });
+
+  const p = res.provenance;
+  console.log(JSON.stringify({
+    status: res.status,
+    httpStatus: res.httpStatus,
+    bytes: res.body?.length ?? 0,
+    landed: res.landed,
+    sink: res.sink,
+    reason: res.reason,
+    provenance: p && { url: p.url, fetchedAt: p.fetchedAt, httpStatus: p.httpStatus, contentHash: p.contentHash, tier: p.tier, posture: p.posture, egress: p.egress, warnings: p.warnings },
+  }, null, 2));
+  process.exit(res.status === 'ok' || res.status === 'not-modified' ? 0 : 1);
+}
+main().catch((e) => { console.error('acquire failed:', e); process.exit(1); });

--- a/socioprophet-web/acquire-worker/src/nodeTransport.ts
+++ b/socioprophet-web/acquire-worker/src/nodeTransport.ts
@@ -1,0 +1,48 @@
+// Real Node transport for the governed acquisition plane — this is where "make it real" happens:
+// live HTTP via Node's global fetch (undici), optional per-request proxy egress, real robots.txt
+// fetching, and real SHA-256 content hashing. It plugs into the SAME GovernedFetcher the cockpit
+// unit-tests with a fake net, so the governance (policy → identity → robots → rate → provenance) is
+// identical; only the socket is real here.
+import { createHash } from 'node:crypto';
+import type { DirectFetch } from '../../client-vue/src/features/acquisition/transport';
+import type { NetResponse } from '../../client-vue/src/features/acquisition/fetcher';
+import { parseRobots, type RobotsRules } from '../../client-vue/src/features/acquisition/robots';
+
+// Real content hash for provenance/dedup.
+export function sha256(body: string): string {
+  return 'sha256:' + createHash('sha256').update(body, 'utf8').digest('hex');
+}
+
+// A live directFetch: real network, optional undici ProxyAgent dispatcher for T2/T3 egress.
+export function makeNodeDirectFetch(opts: { timeoutMs?: number } = {}): DirectFetch {
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  return async (url, { headers, proxyUrl }) => {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const init: RequestInit & { dispatcher?: unknown } = { headers, redirect: 'follow', signal: ctrl.signal };
+      if (proxyUrl) {
+        const { ProxyAgent } = await import('undici'); // only pulled in when a proxy is actually used
+        init.dispatcher = new ProxyAgent(proxyUrl);
+      }
+      const res = await fetch(url, init as RequestInit);
+      const body = await res.text();
+      const h: Record<string, string> = {};
+      res.headers.forEach((v, k) => { h[k] = v; });
+      return { status: res.status, headers: h, body } satisfies NetResponse;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+// Fetch + parse a site's robots.txt (best-effort; a fetch failure means "no rules resolved").
+export async function fetchRobots(origin: string, userAgent: string): Promise<RobotsRules | null> {
+  try {
+    const res = await fetch(`${origin}/robots.txt`, { headers: { 'User-Agent': userAgent }, signal: AbortSignal.timeout(8000) });
+    if (!res.ok) return null;
+    return parseRobots(await res.text());
+  } catch {
+    return null;
+  }
+}

--- a/socioprophet-web/acquire-worker/src/server.ts
+++ b/socioprophet-web/acquire-worker/src/server.ts
@@ -1,0 +1,42 @@
+// HTTP entry point — the same AcquisitionService behind a tiny endpoint, so prophet-mesh, Noetica,
+// Turtle Terminal or GooseNotes can drive governed acquisition over the network instead of importing
+// the library. POST /acquire { url, accountClass?, tier?, geo?, sink? }.
+import { createServer } from 'node:http';
+import { AcquisitionService } from './service';
+import { LocalFileSink, JsonlLedgerSink, HttpSink, MemorySink, MultiSink, type Sink } from './sinks';
+
+const svc = new AcquisitionService();
+
+function makeSink(spec: string | undefined): Sink {
+  if (!spec) return new MemorySink();
+  return new MultiSink(spec.split(',').map((s) => {
+    const [kind, ...rest] = s.split(':');
+    const t = rest.join(':');
+    if (kind === 'local') return new LocalFileSink(t || './landed');
+    if (kind === 'ledger') return new JsonlLedgerSink(t || './acquire-ledger.jsonl');
+    if (kind === 'http') return new HttpSink(t);
+    throw new Error(`unknown sink '${s}'`);
+  }));
+}
+
+const port = Number(process.env.PORT ?? 8790);
+createServer(async (req, res) => {
+  if (req.method !== 'POST' || !req.url?.startsWith('/acquire')) {
+    res.writeHead(404).end('POST /acquire');
+    return;
+  }
+  try {
+    const chunks: Buffer[] = [];
+    for await (const c of req) chunks.push(c as Buffer);
+    const body = JSON.parse(Buffer.concat(chunks).toString() || '{}');
+    if (!body.url) { res.writeHead(400).end(JSON.stringify({ error: 'url required' })); return; }
+    const result = await svc.acquire(body.url, {
+      accountClass: body.accountClass, tier: body.tier, geo: body.geo, sink: makeSink(body.sink),
+    });
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ status: result.status, httpStatus: result.httpStatus, landed: result.landed, sink: result.sink, provenance: result.provenance, reason: result.reason }));
+  } catch (e) {
+    res.writeHead(500, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: e instanceof Error ? e.message : 'error' }));
+  }
+}).listen(port, () => console.log(`acquire-worker listening on :${port} (POST /acquire)`));

--- a/socioprophet-web/acquire-worker/src/service.test.ts
+++ b/socioprophet-web/acquire-worker/src/service.test.ts
@@ -1,0 +1,43 @@
+// Network-free tests for the worker — inject a fake directFetch so CI proves the governed pipeline
+// + sink landing without hitting the wire. (A real live fetch is exercised by the CLI; see README.)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AcquisitionService } from './service.ts';
+import { MemorySink } from './sinks.ts';
+
+function svcWith(bodyByUrl: (url: string) => { status: number; body: string }) {
+  return new AcquisitionService({
+    directFetch: async (url) => { const r = bodyByUrl(url); return { status: r.status, headers: {}, body: r.body }; },
+    userAgent: 'test-bot',
+  });
+}
+
+test('acquires, records provenance, and lands in the sink', async () => {
+  const sink = new MemorySink();
+  const svc = svcWith(() => ({ status: 200, body: 'hello world' }));
+  const res = await svc.acquire('https://example.com/a', { sink });
+  assert.equal(res.status, 'ok');
+  assert.equal(res.landed, true);
+  assert.equal(sink.records.length, 1);
+  assert.equal(sink.records[0].body, 'hello world');
+  assert.match(sink.records[0].provenance.contentHash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(sink.records[0].provenance.httpStatus, 200);
+});
+
+test('the line holds: an auth-gated policy is blocked and nothing lands', async () => {
+  const sink = new MemorySink();
+  const svc = svcWith(() => ({ status: 200, body: 'secret' }));
+  const res = await svc.acquire('https://example.com/private', {
+    sink,
+    policy: { robots: 'allowed', tos: 'auth-gated', pii: false, legalBasis: 'public-data' },
+  });
+  assert.equal(res.status, 'blocked');
+  assert.equal(res.landed, false);
+  assert.equal(sink.records.length, 0);
+});
+
+test('commercial account enforces tier gating (T3 needs an override)', async () => {
+  const svc = svcWith(() => ({ status: 200, body: 'x' }));
+  const res = await svc.acquire('https://example.com/a', { accountClass: 'commercial', tier: 'T3' });
+  assert.equal(res.status, 'blocked');
+});

--- a/socioprophet-web/acquire-worker/src/service.ts
+++ b/socioprophet-web/acquire-worker/src/service.ts
@@ -1,0 +1,96 @@
+// AcquisitionService — the programmatic entry point the whole estate calls (BearBrowser, Turtle
+// Terminal, GooseNotes, Noetica, prophet-mesh). Give it a URL and an account context; it runs the
+// governed pipeline for real (live fetch, robots, rate, provenance) and lands the result in whatever
+// sink you pass (local / cloud / mesh). Governance is identical to the cockpit's — same code.
+import { GovernedFetcher, type FetchResult } from '../../client-vue/src/features/acquisition/fetcher';
+import { RateGovernor } from '../../client-vue/src/features/acquisition/rateGovernor';
+import { makeTieredTransport, type TransportDeps } from '../../client-vue/src/features/acquisition/transport';
+import type { ProxyPool } from '../../client-vue/src/features/acquisition/egress';
+import type { Unblocker } from '../../client-vue/src/features/acquisition/unblocker';
+import type { EgressIdentity } from '../../client-vue/src/features/acquisition/reputation';
+import type { AccountClass, AcquisitionTier, SourcePolicy, Override } from '../../client-vue/src/features/acquisition/policy';
+import type { RobotsRules } from '../../client-vue/src/features/acquisition/robots';
+import { makeNodeDirectFetch, fetchRobots, sha256 } from './nodeTransport';
+import type { Sink } from './sinks';
+
+const DEFAULT_UA = 'SocioProphetBot/1.0 (+https://socioprophet.ai/bot; governed-acquisition)';
+const PUBLIC: SourcePolicy = { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' };
+
+const DEFAULT_POOL: EgressIdentity[] = [
+  { id: 'direct-us', egressClass: 'direct', geo: 'US', fingerprintId: 'node-default', cookieJar: 'j0', reputation: 0.6, successes: 0, challenges: 0, blocks: 0, lastUsedAt: 0 },
+];
+
+export interface ServiceConfig {
+  userAgent?: string;
+  identityPool?: EgressIdentity[];
+  proxyPool?: ProxyPool;
+  unblocker?: Unblocker;
+  directFetch?: TransportDeps['directFetch']; // override the transport (e.g. a BearBrowser transport)
+  timeoutMs?: number;
+}
+
+export interface AcquireOptions {
+  accountClass?: AccountClass;
+  tier?: AcquisitionTier;
+  sink?: Sink;
+  policy?: SourcePolicy;
+  override?: Override;
+  sourceId?: string;
+  geo?: string;
+  maxRateWaits?: number;      // how many times to honor a rate-limit deferral before giving up
+}
+
+export type AcquireResult = FetchResult & { landed: boolean; sink?: string };
+
+export class AcquisitionService {
+  private fetcher: GovernedFetcher;
+  private governor = new RateGovernor();
+  private robotsCache = new Map<string, RobotsRules | null>();
+  private ua: string;
+  private pool: EgressIdentity[];
+
+  constructor(cfg: ServiceConfig = {}) {
+    this.ua = cfg.userAgent ?? DEFAULT_UA;
+    this.pool = cfg.identityPool ?? DEFAULT_POOL;
+    const net = makeTieredTransport({
+      directFetch: cfg.directFetch ?? makeNodeDirectFetch({ timeoutMs: cfg.timeoutMs }),
+      proxyPool: cfg.proxyPool,
+      unblocker: cfg.unblocker,
+    });
+    this.fetcher = new GovernedFetcher({
+      net,
+      hash: sha256,
+      robotsFor: (origin) => this.robotsCache.get(origin) ?? null,
+      governor: this.governor,
+    });
+  }
+
+  async acquire(url: string, opts: AcquireOptions = {}): Promise<AcquireResult> {
+    const origin = new URL(url).origin;
+    if (!this.robotsCache.has(origin)) this.robotsCache.set(origin, await fetchRobots(origin, this.ua));
+
+    const job = {
+      accountClass: opts.accountClass ?? 'sovereign' as AccountClass,
+      sourceId: opts.sourceId ?? url,
+      policy: opts.policy ?? PUBLIC,
+      tier: opts.tier ?? 'T1' as AcquisitionTier,
+      override: opts.override ?? null,
+    };
+    const req = { url, job, identityPool: this.pool, userAgent: this.ua, geo: opts.geo };
+
+    // Honor the rate governor for real: if deferred, wait the requested time and retry (bounded).
+    let res = await this.fetcher.fetch(req);
+    let waits = opts.maxRateWaits ?? 3;
+    while (res.status === 'rate-limited' && waits-- > 0) {
+      await new Promise((r) => setTimeout(r, Math.min(res.retryAfterMs ?? 1000, 30_000)));
+      res = await this.fetcher.fetch(req);
+    }
+
+    let landed = false;
+    if (res.provenance && opts.sink) {
+      await opts.sink.write({ provenance: res.provenance, body: res.body ?? null });
+      landed = true;
+    }
+    return { ...res, landed, sink: opts.sink?.name };
+  }
+}

--- a/socioprophet-web/acquire-worker/src/sinks.ts
+++ b/socioprophet-web/acquire-worker/src/sinks.ts
@@ -1,0 +1,67 @@
+// Sinks — where acquired data lands. First-class local OR cloud (the estate requirement): a job can
+// write to the local filesystem, a provenance ledger, a cloud bucket / prophet-mesh ingest endpoint,
+// or several at once (MultiSink fan-out). Everything lands WITH its provenance record, so the chain
+// of custody survives wherever the bytes go.
+import { mkdir, writeFile, appendFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ProvenanceRecord } from '../../client-vue/src/features/acquisition/policy';
+
+export interface LandedRecord { provenance: ProvenanceRecord; body: string | null }
+export interface Sink { readonly name: string; write(rec: LandedRecord): Promise<void> }
+
+// Local filesystem: content-addressed body + sidecar provenance JSON under a directory.
+export class LocalFileSink implements Sink {
+  readonly name: string;
+  private ready?: Promise<void>;
+  constructor(private dir: string) { this.name = `local:${dir}`; }
+  private ensure() { return (this.ready ??= mkdir(this.dir, { recursive: true }).then(() => undefined)); }
+  async write(rec: LandedRecord): Promise<void> {
+    await this.ensure();
+    const key = rec.provenance.contentHash.replace(/^sha256:/, '').slice(0, 16) || String(Date.now());
+    await writeFile(join(this.dir, `${key}.json`), JSON.stringify(rec.provenance, null, 2));
+    if (rec.body != null) await writeFile(join(this.dir, `${key}.body`), rec.body);
+  }
+}
+
+// Append-only provenance ledger (one JSON object per line) — the audit trail, cheap and greppable.
+export class JsonlLedgerSink implements Sink {
+  readonly name: string;
+  constructor(private file: string) { this.name = `ledger:${file}`; }
+  async write(rec: LandedRecord): Promise<void> {
+    await appendFile(this.file, JSON.stringify(rec.provenance) + '\n');
+  }
+}
+
+// Cloud / prophet-mesh: POST {provenance, body} to a configured ingest endpoint. Works against a
+// GCS signed URL, an S3 presigned PUT (override method), or the mesh's ingest API. Real HTTP.
+export class HttpSink implements Sink {
+  readonly name: string;
+  constructor(private endpoint: string, private opts: { method?: string; headers?: Record<string, string> } = {}) {
+    this.name = `http:${endpoint}`;
+  }
+  async write(rec: LandedRecord): Promise<void> {
+    const res = await fetch(this.endpoint, {
+      method: this.opts.method ?? 'POST',
+      headers: { 'content-type': 'application/json', ...this.opts.headers },
+      body: JSON.stringify(rec),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) throw new Error(`sink ${this.endpoint} responded ${res.status}`);
+  }
+}
+
+// Fan-out: land local AND cloud (or any combination) in one write.
+export class MultiSink implements Sink {
+  readonly name: string;
+  constructor(private sinks: Sink[]) { this.name = `multi(${sinks.map((s) => s.name).join(',')})`; }
+  async write(rec: LandedRecord): Promise<void> {
+    await Promise.all(this.sinks.map((s) => s.write(rec)));
+  }
+}
+
+// In-memory — tests + dry runs.
+export class MemorySink implements Sink {
+  readonly name = 'memory';
+  readonly records: LandedRecord[] = [];
+  async write(rec: LandedRecord): Promise<void> { this.records.push(rec); }
+}


### PR DESCRIPTION
## What
Makes the acquisition plane **real** — a runnable Node worker that actually fetches live public data through the same governance the cockpit unit-tests, and lands it **local or cloud** with an intact provenance chain. Stacked on #553 (imports the plane core from `client-vue/src/features/acquisition/*` — one source of truth, no duplication).

## Pieces
- **`nodeTransport.ts`** — live undici `fetch`, optional `ProxyAgent` egress, real `robots.txt` fetch, real `node:crypto` SHA-256.
- **`sinks.ts`** — land **local or cloud**, first-class: `LocalFileSink`, `JsonlLedgerSink`, `HttpSink` (cloud / prophet-mesh ingest), `MultiSink` fan-out.
- **`service.ts`** — `AcquisitionService`, the API the estate calls; honors the rate governor for real (bounded waits).
- **`bearBrowserTransport.ts`** — the seam where **BearBrowser** becomes the agentic-ops browser (T2/T3 transport).
- **`cli.ts` / `server.ts`** — `acquire <url>` + `POST /acquire`.

## Verified live
```
$ acquire https://en.wikipedia.org/wiki/Web_scraping --sink local:./landed,ledger:./acquire-ledger.jsonl
→ 200, ~239 KB, landed body + provenance sidecar + ledger line
→ recomputed SHA-256 == provenance.contentHash  ✓
```
Network-free tests (3): landing + provenance, the-line block (auth-gated → nothing lands), commercial tier gating.

## Meta-surface integration (seams defined, wiring per-surface is follow-on)
BearBrowser (render host) · Turtle Terminal (CLI verb) · GooseNotes (capture w/ provenance) · Noetica (governed invocation) · prophet-mesh (`HttpSink` → mesh ingest; policy/provenance ↔ trust kernel).

> Long-term the plane core should live in a shared sovereign package (e.g. `prophet-core-ingest`) both the cockpit and this worker import — tracked convergence follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)