### PR TITLE
feat(acquire-worker): Sherlock crawl driver + SynapseIQ enrichment seams

### DIFF
--- a/socioprophet-web/acquire-worker/src/cli.ts
+++ b/socioprophet-web/acquire-worker/src/cli.ts
@@ -1,9 +1,12 @@
 #!/usr/bin/env -S npx tsx
-// acquire — CLI for the governed acquisition worker. Fetches a live URL through the full plane and
-// lands it. Usage:
-//   acquire <url> [--account sovereign|research|own-estate|commercial] [--tier T0..T4]
-//                 [--sink local:<dir> | ledger:<file> | http:<url>] [--geo US] [--dry]
+// acquire — CLI for the governed acquisition worker. Fetches (or crawls) live URLs through the full
+// plane and lands them, optionally enriched by SynapseIQ. Usage:
+//   acquire <url> [--account ..] [--tier T0..T4] [--sink local:<dir>|ledger:<file>|http:<url>]
+//                 [--geo US] [--enrich synapseiq:<endpoint>] [--dry]
+//   acquire crawl <seed...> [--max-pages N] [--max-depth N] [--same-origin] [--enrich ..] [--sink ..]
 import { AcquisitionService } from './service';
+import { crawl } from './crawl';
+import { SynapseIQEnricher, NullEnricher, type Enricher } from './enricher';
 import { LocalFileSink, JsonlLedgerSink, HttpSink, MemorySink, MultiSink, type Sink } from './sinks';
 import type { AccountClass, AcquisitionTier } from '../../client-vue/src/features/acquisition/policy';
 
@@ -11,6 +14,8 @@ function arg(flag: string, def?: string): string | undefined {
   const i = process.argv.indexOf(flag);
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
 }
+function flag(name: string): boolean { return process.argv.includes(name); }
+
 function makeSink(spec: string | undefined): Sink {
   if (!spec || spec === 'dry') return new MemorySink();
   return new MultiSink(spec.split(',').map((s) => {
@@ -22,29 +27,57 @@ function makeSink(spec: string | undefined): Sink {
     throw new Error(`unknown sink '${s}' (use local:<dir> | ledger:<file> | http:<url>)`);
   }));
 }
+// --enrich synapseiq:<endpoint>  → SynapseIQ language enrichment (entities/extraction/embeddings).
+function makeEnricher(spec: string | undefined): Enricher {
+  if (!spec) return new NullEnricher();
+  const [kind, ...rest] = spec.split(':');
+  if (kind === 'synapseiq') return new SynapseIQEnricher({ endpoint: rest.join(':'), apiKey: process.env.SYNAPSEIQ_KEY });
+  throw new Error(`unknown enricher '${spec}' (use synapseiq:<endpoint>)`);
+}
 
-async function main() {
+async function runCrawl() {
+  const seeds = process.argv.slice(3).filter((a) => !a.startsWith('--') && !isFlagValue(a));
+  if (!seeds.length) { console.error('usage: acquire crawl <seed-url...> [--max-pages N] [--max-depth N]'); process.exit(2); }
+  const svc = new AcquisitionService();
+  const report = await crawl(seeds, svc, {
+    accountClass: (arg('--account', 'sovereign') as AccountClass),
+    tier: (arg('--tier', 'T1') as AcquisitionTier),
+    maxPages: Number(arg('--max-pages', '25')),
+    maxDepth: Number(arg('--max-depth', '2')),
+    sameOrigin: !flag('--any-origin'),
+    sink: makeSink(flag('--dry') ? 'dry' : arg('--sink', 'local:./landed')),
+    enricher: makeEnricher(arg('--enrich')),
+    onPage: (u, s) => console.error(`  [${s}] ${u}`),
+  });
+  console.log(JSON.stringify(report, null, 2));
+  process.exit(report.errored > 0 && report.landed === 0 ? 1 : 0);
+}
+
+// crude: values that follow a known value-taking flag shouldn't be treated as seeds
+function isFlagValue(a: string): boolean {
+  const i = process.argv.indexOf(a);
+  return i > 0 && ['--max-pages', '--max-depth', '--account', '--tier', '--sink', '--enrich', '--geo'].includes(process.argv[i - 1]);
+}
+
+async function runOne() {
   const url = process.argv[2];
-  if (!url || url.startsWith('--')) { console.error('usage: acquire <url> [--account ..] [--tier ..] [--sink local:<dir>]'); process.exit(2); }
-  const sink = makeSink(arg('--dry') !== undefined ? 'dry' : arg('--sink', 'local:./landed'));
+  if (!url || url.startsWith('--')) { console.error('usage: acquire <url> [--account ..] [--tier ..] [--sink ..] [--enrich synapseiq:<endpoint>]'); process.exit(2); }
   const svc = new AcquisitionService();
   const res = await svc.acquire(url, {
     accountClass: (arg('--account', 'sovereign') as AccountClass),
     tier: (arg('--tier', 'T1') as AcquisitionTier),
     geo: arg('--geo', 'US'),
-    sink,
+    sink: makeSink(flag('--dry') ? 'dry' : arg('--sink', 'local:./landed')),
+    enricher: makeEnricher(arg('--enrich')),
   });
-
   const p = res.provenance;
   console.log(JSON.stringify({
-    status: res.status,
-    httpStatus: res.httpStatus,
-    bytes: res.body?.length ?? 0,
-    landed: res.landed,
-    sink: res.sink,
-    reason: res.reason,
+    status: res.status, httpStatus: res.httpStatus, bytes: res.body?.length ?? 0,
+    landed: res.landed, sink: res.sink, enriched: res.enriched, reason: res.reason,
     provenance: p && { url: p.url, fetchedAt: p.fetchedAt, httpStatus: p.httpStatus, contentHash: p.contentHash, tier: p.tier, posture: p.posture, egress: p.egress, warnings: p.warnings },
   }, null, 2));
   process.exit(res.status === 'ok' || res.status === 'not-modified' ? 0 : 1);
 }
+
+const main = process.argv[2] === 'crawl' ? runCrawl : runOne;
 main().catch((e) => { console.error('acquire failed:', e); process.exit(1); });

--- a/socioprophet-web/acquire-worker/src/crawl.ts
+++ b/socioprophet-web/acquire-worker/src/crawl.ts
@@ -1,0 +1,106 @@
+// Crawl driver — where Sherlock plugs in. Sherlock's search drives acquisition: it supplies seeds
+// and, at each page, RANKED discovery of what to fetch next. The frontier stays governed — every URL
+// the crawl visits goes through AcquisitionService.acquire, so it inherits policy, robots, rate
+// limiting, reputation, provenance and (optionally) SynapseIQ enrichment. Sherlock decides WHAT to
+// crawl; the plane decides WHETHER and HOW. A default same-origin link extractor stands in when
+// Sherlock isn't wired.
+import type { AcquisitionService, AcquireOptions } from './service';
+
+// A Discoverer turns a fetched page into the next URLs to consider. Sherlock implements this with
+// ranked, relevance-scored discovery; the default just extracts in-page links.
+export interface Discoverer {
+  readonly name: string;
+  discover(input: { url: string; body: string; depth: number }): string[];
+}
+
+// Default discovery: same-doc <a href> / <link href> extraction, resolved against the page URL.
+export class LinkDiscoverer implements Discoverer {
+  readonly name = 'links';
+  discover({ url, body }: { url: string; body: string }): string[] {
+    const out: string[] = [];
+    const re = /(?:href|src)\s*=\s*["']([^"'#]+)["']/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body))) {
+      try {
+        const abs = new URL(m[1], url).toString();
+        if (abs.startsWith('http')) out.push(abs.split('#')[0]);
+      } catch { /* skip malformed */ }
+    }
+    return out;
+  }
+}
+
+export interface CrawlOptions extends Omit<AcquireOptions, 'sink' | 'enricher'> {
+  maxPages?: number;
+  maxDepth?: number;
+  sameOrigin?: boolean;        // stay on the seed's origin (default true)
+  allowHosts?: string[];       // additional hosts permitted beyond the seed origin(s)
+  discoverer?: Discoverer;     // Sherlock plugs in here
+  sink?: AcquireOptions['sink'];
+  enricher?: AcquireOptions['enricher'];
+  onPage?: (url: string, status: string) => void;
+}
+
+export interface CrawlReport {
+  seeds: string[];
+  visited: number;
+  landed: number;
+  blocked: number;
+  errored: number;
+  byStatus: Record<string, number>;
+  frontierExhausted: boolean;   // false = stopped on maxPages
+}
+
+interface FrontierItem { url: string; depth: number }
+
+// Bounded, deduped, scope-checked frontier. Sherlock's ranking only reorders what we consider; the
+// scope + budget + governance are non-negotiable.
+export async function crawl(seeds: string[], svc: AcquisitionService, opts: CrawlOptions = {}): Promise<CrawlReport> {
+  const maxPages = opts.maxPages ?? 50;
+  const maxDepth = opts.maxDepth ?? 2;
+  const sameOrigin = opts.sameOrigin ?? true;
+  const discoverer = opts.discoverer ?? new LinkDiscoverer();
+  const seedOrigins = new Set(seeds.map((s) => safeOrigin(s)).filter(Boolean) as string[]);
+  const allowHosts = new Set(opts.allowHosts ?? []);
+
+  const inScope = (url: string): boolean => {
+    const o = safeOrigin(url);
+    if (!o) return false;
+    if (!sameOrigin) return true;
+    if (seedOrigins.has(o)) return true;
+    try { return allowHosts.has(new URL(url).host); } catch { return false; }
+  };
+
+  const visited = new Set<string>();
+  const queue: FrontierItem[] = seeds.filter(inScope).map((url) => ({ url, depth: 0 }));
+  const report: CrawlReport = { seeds, visited: 0, landed: 0, blocked: 0, errored: 0, byStatus: {}, frontierExhausted: true };
+
+  while (queue.length) {
+    if (report.visited >= maxPages) { report.frontierExhausted = false; break; }
+    const { url, depth } = queue.shift()!;
+    const norm = url.split('#')[0];
+    if (visited.has(norm)) continue;
+    visited.add(norm);
+
+    const res = await svc.acquire(norm, { ...opts, sink: opts.sink, enricher: opts.enricher });
+    report.visited += 1;
+    report.byStatus[res.status] = (report.byStatus[res.status] ?? 0) + 1;
+    if (res.landed) report.landed += 1;
+    if (res.status === 'blocked' || res.status === 'robots-denied') report.blocked += 1;
+    if (res.status === 'error') report.errored += 1;
+    opts.onPage?.(norm, res.status);
+
+    // Discover the next hop only from a page we actually read, and only within budget.
+    if ((res.status === 'ok') && res.body && depth < maxDepth) {
+      for (const next of discoverer.discover({ url: norm, body: res.body, depth })) {
+        const n = next.split('#')[0];
+        if (!visited.has(n) && inScope(n)) queue.push({ url: n, depth: depth + 1 });
+      }
+    }
+  }
+  return report;
+}
+
+function safeOrigin(url: string): string | null {
+  try { return new URL(url).origin; } catch { return null; }
+}

--- a/socioprophet-web/acquire-worker/src/enrichCrawl.test.ts
+++ b/socioprophet-web/acquire-worker/src/enrichCrawl.test.ts
@@ -1,0 +1,77 @@
+// Network-free tests for the SynapseIQ enrichment stage + Sherlock crawl driver. We inject
+// directFetch (same pattern as service.test.ts) so nothing hits the wire; robots resolves to
+// allowed offline.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AcquisitionService } from './service.ts';
+import { MemorySink } from './sinks.ts';
+import { NullEnricher, type Enricher } from './enricher.ts';
+import { crawl, LinkDiscoverer } from './crawl.ts';
+
+function svcWith(pages: Record<string, { status: number; body: string }>) {
+  return new AcquisitionService({
+    directFetch: async (url: string) => {
+      const p = pages[url.split('#')[0]];
+      return p ? { status: p.status, headers: {}, body: p.body } : { status: 404, headers: {}, body: '' };
+    },
+    userAgent: 'test-bot',
+  });
+}
+
+test('SynapseIQ: enricher runs between fetch and sink and the enrichment lands', async () => {
+  const sink = new MemorySink();
+  const enricher: Enricher = {
+    name: 'test-iq',
+    async enrich({ body }) { return { enricher: 'test-iq', enrichedAt: '2026-08-04T00:00:00Z', entities: [{ text: 'world', type: 'thing' }], language: body.includes('hello') ? 'en' : 'xx' }; },
+  };
+  const res = await svcWith({ 'https://ex.test/a': { status: 200, body: 'hello world' } }).acquire('https://ex.test/a', { sink, enricher });
+  assert.equal(res.status, 'ok');
+  assert.equal(res.enriched, true);
+  assert.equal(sink.records[0].enrichment?.entities?.[0].text, 'world');
+  assert.equal(sink.records[0].enrichment?.language, 'en');
+});
+
+test('SynapseIQ: an enrichment failure never loses the document — it still lands, unenriched', async () => {
+  const sink = new MemorySink();
+  const boom: Enricher = { name: 'boom', async enrich() { throw new Error('synapseiq down'); } };
+  const res = await svcWith({ 'https://ex.test/a': { status: 200, body: 'data' } }).acquire('https://ex.test/a', { sink, enricher: boom });
+  assert.equal(res.status, 'ok');
+  assert.equal(res.enriched, false);
+  assert.equal(sink.records.length, 1);
+  assert.equal(sink.records[0].enrichment, undefined);
+});
+
+test('NullEnricher lands raw', async () => {
+  assert.equal((await new NullEnricher().enrich({ url: '', body: '', contentHash: '' })).enricher, 'none');
+});
+
+test('Sherlock seam: LinkDiscoverer resolves in-page links against the base', () => {
+  const links = new LinkDiscoverer().discover({ url: 'https://ex.test/dir/a', body: '<a href="b">x</a><a href="/c">y</a><a href="https://other.test/z">o</a>', depth: 0 });
+  assert.ok(links.includes('https://ex.test/dir/b'));
+  assert.ok(links.includes('https://ex.test/c'));
+  assert.ok(links.includes('https://other.test/z'));
+});
+
+test('crawl: same-origin, deduped, lands every page, off-origin excluded', async () => {
+  const sink = new MemorySink();
+  const svc = svcWith({
+    'https://ex.test/': { status: 200, body: '<a href="/a">a</a><a href="/b">b</a><a href="https://off.test/x">off</a>' },
+    'https://ex.test/a': { status: 200, body: '<a href="/">home</a>' }, // links back → must dedupe
+    'https://ex.test/b': { status: 200, body: 'leaf' },
+  });
+  const report = await crawl(['https://ex.test/'], svc, { sink, maxPages: 10, maxDepth: 2, sameOrigin: true });
+  assert.equal(report.visited, 3);   // /, /a, /b (off-origin excluded, / not revisited)
+  assert.equal(report.landed, 3);
+  assert.equal(sink.records.length, 3);
+  assert.equal(report.frontierExhausted, true);
+});
+
+test('crawl: maxPages is a hard budget', async () => {
+  const svc = svcWith({
+    'https://ex.test/': { status: 200, body: '<a href="/a">a</a><a href="/b">b</a><a href="/c">c</a>' },
+    'https://ex.test/a': { status: 200, body: 'a' }, 'https://ex.test/b': { status: 200, body: 'b' }, 'https://ex.test/c': { status: 200, body: 'c' },
+  });
+  const report = await crawl(['https://ex.test/'], svc, { sink: new MemorySink(), maxPages: 2 });
+  assert.equal(report.visited, 2);
+  assert.equal(report.frontierExhausted, false);
+});

--- a/socioprophet-web/acquire-worker/src/enricher.ts
+++ b/socioprophet-web/acquire-worker/src/enricher.ts
@@ -1,0 +1,57 @@
+// Enrichment seam — where SynapseIQ plugs in. After a page is fetched (and before it lands), the
+// body runs through an Enricher for language intelligence: entities, structured extractions,
+// embeddings, language ID. The enrichment travels WITH the provenance record into the sink, so what
+// lands is not raw HTML but a governed, enriched, attributed document. SynapseIQ is one Enricher
+// behind a stable interface — swap it, stack it, or run NullEnricher to land raw.
+export interface EnrichmentResult {
+  enricher: string;
+  enrichedAt: string;
+  language?: string;
+  entities?: { text: string; type: string; confidence?: number }[];
+  extractions?: Record<string, unknown>;
+  embedding?: number[];
+  cost?: number;
+}
+export interface EnrichInput { url: string; body: string; contentHash: string }
+export interface Enricher { readonly name: string; enrich(input: EnrichInput): Promise<EnrichmentResult> }
+
+// SynapseIQ — our language-intelligence engine. Generic HTTP adapter: POST the document, get back
+// entities/extractions/embeddings. The request/response mapping is config so the SynapseIQ API can
+// evolve without touching callers.
+export interface SynapseIQConfig {
+  endpoint: string;
+  apiKey?: string;
+  tasks?: ('entities' | 'extraction' | 'embedding' | 'language')[];
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+export class SynapseIQEnricher implements Enricher {
+  readonly name = 'synapseiq';
+  constructor(private cfg: SynapseIQConfig) {}
+  async enrich(input: EnrichInput): Promise<EnrichmentResult> {
+    const f = this.cfg.fetchImpl ?? fetch;
+    const res = await f(this.cfg.endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(this.cfg.apiKey ? { authorization: `Bearer ${this.cfg.apiKey}` } : {}) },
+      body: JSON.stringify({ url: input.url, text: input.body, contentHash: input.contentHash, tasks: this.cfg.tasks ?? ['entities', 'extraction', 'embedding', 'language'] }),
+      signal: AbortSignal.timeout(this.cfg.timeoutMs ?? 30_000),
+    });
+    if (!res.ok) throw new Error(`SynapseIQ ${this.cfg.endpoint} responded ${res.status}`);
+    const out = await res.json() as Partial<EnrichmentResult>;
+    return {
+      enricher: this.name,
+      enrichedAt: new Date().toISOString(),
+      language: out.language,
+      entities: out.entities,
+      extractions: out.extractions,
+      embedding: out.embedding,
+      cost: out.cost,
+    };
+  }
+}
+
+// Default: land raw (no enrichment configured).
+export class NullEnricher implements Enricher {
+  readonly name = 'none';
+  async enrich(): Promise<EnrichmentResult> { return { enricher: 'none', enrichedAt: new Date().toISOString() }; }
+}

--- a/socioprophet-web/acquire-worker/src/service.ts
+++ b/socioprophet-web/acquire-worker/src/service.ts
@@ -12,6 +12,7 @@ import type { AccountClass, AcquisitionTier, SourcePolicy, Override } from '../.
 import type { RobotsRules } from '../../client-vue/src/features/acquisition/robots';
 import { makeNodeDirectFetch, fetchRobots, sha256 } from './nodeTransport';
 import type { Sink } from './sinks';
+import type { Enricher, EnrichmentResult } from './enricher';
 
 const DEFAULT_UA = 'SocioProphetBot/1.0 (+https://socioprophet.ai/bot; governed-acquisition)';
 const PUBLIC: SourcePolicy = { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' };
@@ -38,9 +39,10 @@ export interface AcquireOptions {
   sourceId?: string;
   geo?: string;
   maxRateWaits?: number;      // how many times to honor a rate-limit deferral before giving up
+  enricher?: Enricher;        // SynapseIQ (or any Enricher) — runs after fetch, before the sink
 }
 
-export type AcquireResult = FetchResult & { landed: boolean; sink?: string };
+export type AcquireResult = FetchResult & { landed: boolean; sink?: string; enriched: boolean };
 
 export class AcquisitionService {
   private fetcher: GovernedFetcher;
@@ -86,11 +88,22 @@ export class AcquisitionService {
       res = await this.fetcher.fetch(req);
     }
 
+    // Enrich (SynapseIQ) between fetch and sink — only on a real body, and never let an enrichment
+    // failure lose the governed fetch: the document still lands, just without enrichment.
+    let enrichment: EnrichmentResult | undefined;
+    if (res.status === 'ok' && res.body && opts.enricher) {
+      try {
+        enrichment = await opts.enricher.enrich({ url, body: res.body, contentHash: res.provenance?.contentHash ?? '' });
+      } catch {
+        enrichment = undefined;
+      }
+    }
+
     let landed = false;
     if (res.provenance && opts.sink) {
-      await opts.sink.write({ provenance: res.provenance, body: res.body ?? null });
+      await opts.sink.write({ provenance: res.provenance, body: res.body ?? null, enrichment });
       landed = true;
     }
-    return { ...res, landed, sink: opts.sink?.name };
+    return { ...res, landed, sink: opts.sink?.name, enriched: !!enrichment };
   }
 }

--- a/socioprophet-web/acquire-worker/src/sinks.ts
+++ b/socioprophet-web/acquire-worker/src/sinks.ts
@@ -5,8 +5,11 @@
 import { mkdir, writeFile, appendFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ProvenanceRecord } from '../../client-vue/src/features/acquisition/policy';
+import type { EnrichmentResult } from './enricher';
 
-export interface LandedRecord { provenance: ProvenanceRecord; body: string | null }
+// Everything lands WITH its provenance; when an Enricher (e.g. SynapseIQ) ran, the enrichment
+// (entities / extractions / embeddings) lands alongside it.
+export interface LandedRecord { provenance: ProvenanceRecord; body: string | null; enrichment?: EnrichmentResult }
 export interface Sink { readonly name: string; write(rec: LandedRecord): Promise<void> }
 
 // Local filesystem: content-addressed body + sidecar provenance JSON under a directory.
@@ -20,6 +23,7 @@ export class LocalFileSink implements Sink {
     const key = rec.provenance.contentHash.replace(/^sha256:/, '').slice(0, 16) || String(Date.now());
     await writeFile(join(this.dir, `${key}.json`), JSON.stringify(rec.provenance, null, 2));
     if (rec.body != null) await writeFile(join(this.dir, `${key}.body`), rec.body);
+    if (rec.enrichment) await writeFile(join(this.dir, `${key}.enrichment.json`), JSON.stringify(rec.enrichment, null, 2));
   }
 }
 


### PR DESCRIPTION
Wires the two integration seams you asked for into the governed acquisition worker: **Sherlock drives crawling, SynapseIQ enriches**.

## SynapseIQ — enrichment (`enricher.ts`)
An `Enricher` runs **after fetch, before the sink**, so what lands is a governed, enriched, attributed document — not raw HTML.
- `SynapseIQEnricher` — generic HTTP adapter: POST the document, get back entities / extractions / embeddings / language. Vendor/API evolves via config.
- Enrichment travels **with provenance** into every sink (`LandedRecord.enrichment`; `LocalFileSink` writes a `.enrichment.json` sidecar).
- **Fail-safe:** an enrichment error never loses the fetch — the document still lands, unenriched.

## Sherlock — crawling (`crawl.ts`)
A bounded, deduped, scope-checked crawl **frontier** where Sherlock plugs in through the `Discoverer` interface (ranked, relevance-scored discovery). Default `LinkDiscoverer` extracts in-page links.
- Sherlock decides **what** to crawl; the plane decides **whether/how** — every visited URL goes through `AcquisitionService.acquire`, inheriting policy, robots, rate limiting, reputation, provenance, and (optionally) SynapseIQ enrichment.
- `maxPages` / `maxDepth` / `sameOrigin` budgets are non-negotiable; Sherlock's ranking only reorders what's considered.

## CLI
`acquire crawl <seed...> [--max-pages N] [--max-depth N] [--enrich synapseiq:<endpoint>] [--sink ..]`

## Verification
- **9/9** worker tests (`node:test`, network-free via injected `directFetch`): enrichment lands, enrichment-failure still lands, crawl same-origin/dedupe/maxPages budget.
- **Verified LIVE**: `acquire crawl https://example.com` fetched + landed through the full governed pipeline; off-origin (iana.org) correctly excluded.

> Note (pre-existing, not from this PR): the worker has no `tsconfig.json`, so its `typecheck` script is a no-op — it runs via tsx and the shared core is typechecked in client-vue CI. Worth a follow-up to add a Node tsconfig + a CI job for the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)