### PR TITLE
feat(enroll): device-enrollment gate — attested boot × validator quorum (21 tests)

### DIFF
--- a/.github/workflows/builder-contract-tests.yml
+++ b/.github/workflows/builder-contract-tests.yml
@@ -18,8 +18,11 @@ on:
       - "socioprophet-web/server/src/routes/boot-route.ts"
       - "socioprophet-web/server/src/services/bootServer.ts"
       - "socioprophet-web/server/src/services/bootAttestation.ts"
+      - "socioprophet-web/server/src/services/deviceEnrollment.ts"
+      - "socioprophet-web/server/src/services/quorum.ts"
       - "socioprophet-web/server/test/contracts.test.mjs"
       - "socioprophet-web/server/test/boot-attestation.test.mjs"
+      - "socioprophet-web/server/test/device-enrollment.test.mjs"
       - ".github/workflows/builder-contract-tests.yml"
   pull_request:
     paths:
@@ -28,8 +31,11 @@ on:
       - "socioprophet-web/server/src/routes/boot-route.ts"
       - "socioprophet-web/server/src/services/bootServer.ts"
       - "socioprophet-web/server/src/services/bootAttestation.ts"
+      - "socioprophet-web/server/src/services/deviceEnrollment.ts"
+      - "socioprophet-web/server/src/services/quorum.ts"
       - "socioprophet-web/server/test/contracts.test.mjs"
       - "socioprophet-web/server/test/boot-attestation.test.mjs"
+      - "socioprophet-web/server/test/device-enrollment.test.mjs"
 
 jobs:
   contracts:
@@ -48,3 +54,5 @@ jobs:
         run: npm run test:contracts
       - name: Verify boot attestation (measured boot ↔ dm-verity, fail-closed)
         run: npm run test:boot
+      - name: Verify device enrollment gate (attested boot × validator quorum, fail-closed)
+        run: npm run test:enroll

--- a/socioprophet-web/server/package.json
+++ b/socioprophet-web/server/package.json
@@ -47,6 +47,7 @@
     "test:boot": "node test/boot-attestation.test.mjs",
     "test:delivery": "node test/delivery.reconcile.test.mjs",
     "test:mirror": "node test/githubMirror.test.mjs",
+    "test:enroll": "node test/device-enrollment.test.mjs",
     "test:sovereign": "node test/delivery.reconcile.test.mjs && node test/githubMirror.test.mjs"
   },
   "author": "Will Jones",

--- a/socioprophet-web/server/src/contracts/index.ts
+++ b/socioprophet-web/server/src/contracts/index.ts
@@ -25,6 +25,7 @@ const validatorNames = [
   "NLBootPlan", "DeviceIdentity", "BootProofRecord", "ContentSpec",
   "ControlNodeProfile", "DesktopProfile", "Offer", "WorkOrder",
   "UsageReceipt", "SettlementEvent", "EventEnvelope",
+  "QuorumProof",
 ];
 const validators: Record<string, any> = {};
 for (const n of validatorNames) validators[n] = ajv.getSchema(idByName[n]);

--- a/socioprophet-web/server/src/contracts/schemas/QuorumProof.PROVENANCE.txt
+++ b/socioprophet-web/server/src/contracts/schemas/QuorumProof.PROVENANCE.txt
@@ -1,0 +1,5 @@
+QuorumProof.json — vendored verbatim from SourceOS-Linux/mcp-a2a-zero-trust ::
+schemas/canonical/quorum_proof.schema.json (the authoritative QuorumProof shape).
+Hash-pinned; DO NOT edit here — reconcile from mcp-a2a-zero-trust. The prophet-platform
+quorum verifier (PP #1370) and this server's device-enrollment gate both CONFORM to this
+one shape — verify the canonical proof, never invent a second one.

--- a/socioprophet-web/server/src/contracts/schemas/QuorumProof.json
+++ b/socioprophet-web/server/src/contracts/schemas/QuorumProof.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/quorum_proof.schema.json",
+  "title": "QuorumProof",
+  "type": "object",
+  "required": [
+    "rule",
+    "validators",
+    "signed_payload_hash",
+    "signatures"
+  ],
+  "properties": {
+    "rule": {
+      "type": "string",
+      "minLength": 1
+    },
+    "validators": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "signed_payload_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "kind",
+          "spiffe_id",
+          "sig"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "human"
+            ]
+          },
+          "spiffe_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "sig": {
+            "type": "string",
+            "minLength": 16
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/socioprophet-web/server/src/services/deviceEnrollment.ts
+++ b/socioprophet-web/server/src/services/deviceEnrollment.ts
@@ -1,0 +1,91 @@
+export {};
+// Device enrollment gate — quorum → literal (fuses boot attestation + validator quorum).
+//
+// A device joins the fleet only if BOTH hold:
+//   1. its boot ATTESTS — the measured chain matches the pinned golden policy FOR ITS ARCH
+//      (bootAttestation.attestBoot, PP-side dm-verity bound), and
+//   2. an N-of-M validator QUORUM co-signs THIS enrollment (quorum.verifyQuorum, bound to the
+//      enrollment payload hash so the vote can't be replayed onto another device).
+//
+// ARCH-NEUTRAL BY DESIGN: the golden boot chain differs per silicon (Apple-Silicon arm64,
+// x86_64, riscv64, …), so the caller passes an attestationPolicies MAP keyed by archClass (with
+// a platform fallback). The gate hardcodes NO architecture — the same gate, and the same tests,
+// demonstrate on an M2 and on a sovereign-silicon Linux box; only the pinned policy differs.
+
+const crypto = require("crypto");
+const { attestBoot } = require("./bootAttestation");
+const { verifyQuorum } = require("./quorum");
+
+const _canon = (o: any): string => JSON.stringify(o, Object.keys(o).sort());
+
+// Resolve the attestation policy for a device's silicon. Fail-closed: no policy = no enrollment.
+const _policyForDevice = (device: any, policies: any): any | null => {
+  if (!policies || typeof policies !== "object") return null;
+  const key = device?.archClass ?? device?.platform;
+  return policies[key] ?? policies[device?.platform] ?? null;
+};
+
+// The payload the validators co-sign: binds the device + the exact boot that was attested, so a
+// quorum vote is valid for THIS enrollment only (not replayable to another device or boot).
+const enrollmentPayloadHash = (device: any, attestationHash: string): string => {
+  const payload = {
+    device_ref: device?.id ?? null,
+    device_name: device?.deviceName ?? null,
+    platform: device?.platform ?? null,
+    arch_class: device?.archClass ?? null,
+    attestation: attestationHash,
+  };
+  return "sha256:" + crypto.createHash("sha256").update(_canon(payload)).digest("hex");
+};
+
+const enrollDevice = (
+  input: {
+    deviceIdentity: any;
+    bootProof: any;
+    attestationPolicies: any;      // { [archClass|platform]: AttestationPolicy }
+    quorumProof: any;
+  },
+  opts?: { validateBootProof?: (r: any) => string[]; validateQuorum?: (p: any) => string[] },
+) => {
+  const { deviceIdentity: device, bootProof, attestationPolicies, quorumProof } = input;
+  const reasons: string[] = [];
+
+  // 1. attest the boot against the per-arch golden policy.
+  const policy = _policyForDevice(device, attestationPolicies);
+  if (!policy) {
+    reasons.push(`no attestation policy for arch '${device?.archClass ?? device?.platform ?? "unknown"}' `
+      + `— fail-closed (add the golden boot chain for this silicon)`);
+  }
+  const attestation = policy
+    ? attestBoot(bootProof, policy, { validate: opts?.validateBootProof })
+    : { attested: false, reasons: ["no policy"], sealed: null };
+  if (!attestation.attested) {
+    reasons.push("boot not attested: " + (attestation.reasons || []).join("; "));
+  }
+
+  // 2. the quorum must co-sign THIS enrollment (bound to device + attested boot).
+  const attestationHash = attestation.sealed?.hash ?? "sha256:" + "0".repeat(64);
+  const payloadHash = enrollmentPayloadHash(device, attestationHash);
+  const quorum = verifyQuorum(quorumProof, { payloadHash, validate: opts?.validateQuorum });
+  if (!quorum.ok) {
+    reasons.push("quorum not satisfied: " + quorum.reasons.join("; "));
+  }
+
+  const enrolled = reasons.length === 0;
+  const receipt: any = {
+    enrolled,
+    device_ref: device?.id ?? null,
+    platform: device?.platform ?? null,
+    arch_class: device?.archClass ?? null,
+    attestation_ref: attestationHash,
+    attestation_verity_bound: Boolean(attestation.sealed?.verity_bound),
+    quorum_rule: quorumProof?.rule ?? null,
+    enrollment_payload_hash: payloadHash,
+    reason: reasons.join(" | ") || "boot attested and quorum co-signed the enrollment",
+    enrolled_at: new Date().toISOString(),
+  };
+  receipt.hash = "sha256:" + crypto.createHash("sha256").update(_canon(receipt)).digest("hex");
+  return { enrolled, reasons, receipt, attestation, quorum };
+};
+
+module.exports = { enrollDevice, enrollmentPayloadHash };

--- a/socioprophet-web/server/src/services/quorum.ts
+++ b/socioprophet-web/server/src/services/quorum.ts
@@ -1,0 +1,59 @@
+export {};
+// Validator-quorum verification (TS twin of prophet-platform tools/quorum.py, PP #1370).
+// Both CONFORM to the one authoritative QuorumProof shape (vendored contracts/schemas/
+// QuorumProof.json) — we verify that shape + the M-of-N threshold; we do not invent a second.
+// Fail-closed: sub-threshold, non-validator signer, duplicate signer, payload-hash mismatch,
+// kind mismatch, or a malformed rule → NOT a valid quorum.
+
+const _RULE = /^(\d+)of(\d+)-([a-z]+)$/;                 // e.g. "2of3-human"
+const _PAYLOAD_HASH = /^sha256:[0-9a-f]{64}$/;
+
+const parseRule = (rule: string): { threshold: number; total: number; kind: string } | null => {
+  const m = _RULE.exec(rule || "");
+  if (!m) return null;
+  const threshold = Number(m[1]), total = Number(m[2]);
+  if (threshold < 1 || total < 1 || threshold > total) return null;
+  return { threshold, total, kind: m[3] };
+};
+
+// verifyQuorum(proof, { payloadHash?, validate? }) -> { ok, reasons }
+const verifyQuorum = (
+  proof: any,
+  opts?: { payloadHash?: string; validate?: (p: any) => string[] },
+): { ok: boolean; reasons: string[] } => {
+  const reasons: string[] = [];
+  if (opts?.validate) {
+    const errs = opts.validate(proof);
+    if (errs.length) return { ok: false, reasons: ["QuorumProof not conformant: " + errs.join("; ")] };
+  }
+  const rule = parseRule(proof?.rule);
+  if (!rule) return { ok: false, reasons: [`rule '${proof?.rule}' does not parse as MofN-kind`] };
+
+  const validators: string[] = Array.isArray(proof?.validators) ? proof.validators : [];
+  const vset = new Set(validators);
+  if (vset.size !== validators.length) reasons.push("validators list has duplicates");
+  if (vset.size < rule.total) reasons.push(`rule needs ${rule.total} validators; only ${vset.size} listed`);
+
+  const phash = proof?.signed_payload_hash;
+  if (typeof phash !== "string" || !_PAYLOAD_HASH.test(phash)) reasons.push("signed_payload_hash must be sha256:<64hex>");
+  else if (opts?.payloadHash !== undefined && phash !== opts.payloadHash) {
+    reasons.push("signed_payload_hash does not match the payload being admitted (quorum unbound)");
+  }
+
+  const sigs: any[] = Array.isArray(proof?.signatures) ? proof.signatures : [];
+  const seen = new Set<string>();
+  let valid = 0;
+  sigs.forEach((s, i) => {
+    if (!s || s.kind == null || s.spiffe_id == null || s.sig == null) { reasons.push(`signature[${i}] missing fields`); return; }
+    if (s.kind !== rule.kind) { reasons.push(`signature[${i}] kind '${s.kind}' != rule kind '${rule.kind}'`); return; }
+    if (!vset.has(s.spiffe_id)) { reasons.push(`signature[${i}] signer '${s.spiffe_id}' not a listed validator`); return; }
+    if (seen.has(s.spiffe_id)) { reasons.push(`signature[${i}] duplicate signer '${s.spiffe_id}'`); return; }
+    if (typeof s.sig !== "string" || s.sig.length < 16) { reasons.push(`signature[${i}] sig too short`); return; }
+    seen.add(s.spiffe_id); valid += 1;
+  });
+  if (valid < rule.threshold) reasons.push(`${valid} valid distinct signature(s) < threshold ${rule.threshold} (rule ${proof?.rule})`);
+
+  return { ok: reasons.length === 0, reasons };
+};
+
+module.exports = { verifyQuorum, parseRule };

--- a/socioprophet-web/server/test/device-enrollment.test.mjs
+++ b/socioprophet-web/server/test/device-enrollment.test.mjs
@@ -1,0 +1,204 @@
+// Device-enrollment test: a device joins the fleet only if boot attests AND a validator quorum
+// co-signs. Self-contained — transpiles TS on the fly (same pattern as boot-attestation.test.mjs).
+// Run: node test/device-enrollment.test.mjs
+import { createRequire } from "module";
+import path from "path";
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const fs = require("fs");
+const Module = require("module");
+
+// Transpile + load a TS file into a new Module instance, registering it in
+// require.cache so that cross-service require('./bootAttestation') etc. resolve.
+// We intercept Module._resolveFilename so Node doesn't hit the filesystem for
+// the fake .js paths (the real .ts sources are never compiled to disk).
+const _realResolve = Module._resolveFilename.bind(Module);
+const _virtual = new Map();   // absPath → exports — virtual .js stubs
+
+Module._resolveFilename = function (request, parentModule, ...rest) {
+  if (parentModule && typeof request === "string" && request.startsWith(".")) {
+    const abs = path.resolve(path.dirname(parentModule.filename), request + ".js");
+    if (_virtual.has(abs)) return abs;
+  }
+  return _realResolve(request, parentModule, ...rest);
+};
+
+const load = (rel) => {
+  const abs = path.resolve(rel.replace(/\.ts$/, ".js"));
+  if (_virtual.has(abs)) return _virtual.get(abs);
+  const src = fs.readFileSync(rel, "utf8");
+  const js  = ts.transpileModule(src, { compilerOptions: { module: "commonjs", target: "es2020" } }).outputText;
+  const m   = new Module(abs);
+  m.filename = abs;
+  m.paths    = Module._nodeModulePaths(path.dirname(abs));
+  // register BEFORE _compile so circular (or self-referencing) requires don't loop
+  require.cache[abs] = m;
+  _virtual.set(abs, null);   // sentinel so _resolveFilename knows this is virtual
+  m._compile(js, abs);
+  _virtual.set(abs, m.exports);
+  return m.exports;
+};
+
+// Load order matters: dependencies first.
+const c                                    = load("src/contracts/index.ts");
+const { attestBoot }                       = load("src/services/bootAttestation.ts");
+const { verifyQuorum, parseRule }          = load("src/services/quorum.ts");
+const { enrollDevice, enrollmentPayloadHash } = load("src/services/deviceEnrollment.ts");
+
+let fail = 0;
+const ck = (n, ok) => { console.log((ok ? "ok  " : "FAIL ") + n); if (!ok) fail++; };
+
+// ── shared fixtures ────────────────────────────────────────────────────────────
+const VERITY  = "sha256:" + "a".repeat(64);
+const WRONG   = "sha256:" + "b".repeat(64);
+
+const stage   = (name, hash, verdict = "verified") =>
+  ({ stageName: name, artifactRef: `urn:srcos:artifact:${name}`, contentHash: hash, verdict });
+
+const STAGES  = [
+  stage("firmware",   "sha256:" + "1".repeat(64)),
+  stage("bootloader", "sha256:" + "2".repeat(64)),
+  stage("kernel",     "sha256:" + "3".repeat(64)),
+  stage("rootfs",     VERITY),
+];
+
+const POLICY  = {
+  expectedStages:   STAGES.map((s) => ({ stageName: s.stageName, contentHash: s.contentHash })),
+  rootfsStage:      "rootfs",
+  rootfsVerityRoot: VERITY,
+};
+
+const DEV = { id: "dev-001", deviceName: "edge-node-1", platform: "linux-x86_64", archClass: "x86_64" };
+
+function bootProof(stages = STAGES, outcome = "success") {
+  const r = c.bootProofRecord(DEV.id, "urn:srcos:boot-plan:edge", outcome);
+  return { ...r, stageProofs: stages };
+}
+
+function quorumProof(payloadHash, validCount = 2) {
+  const validators = ["spiffe://estate/node/v1", "spiffe://estate/node/v2", "spiffe://estate/node/v3"];
+  const sigs = validators.slice(0, validCount).map((id) => ({
+    kind:      "human",
+    spiffe_id: id,
+    sig:       "0".repeat(32),
+  }));
+  return {
+    kind:                "QuorumProof",
+    rule:                "2of3-human",
+    validators,
+    signed_payload_hash: payloadHash,
+    signatures:          sigs,
+  };
+}
+
+// ── 1. happy path ─────────────────────────────────────────────────────────────
+// attestBoot includes attested_at in the sealed hash — freeze time so the hash
+// computed here (for building the quorum proof) matches the hash enrollDevice sees.
+{
+  const FIXED = "2026-08-04T00:00:00.000Z";
+  const origToISO = Date.prototype.toISOString;
+  Date.prototype.toISOString = () => FIXED;
+  try {
+    const bp  = bootProof();
+    const attest = attestBoot(bp, POLICY);
+    const ph  = enrollmentPayloadHash(DEV, attest.sealed.hash);
+    const qp  = quorumProof(ph, 2);
+    const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { x86_64: POLICY }, quorumProof: qp });
+    ck("1. enrolled on good boot + good quorum", r.enrolled === true);
+    ck("1. receipt has enrolled_at",             typeof r.receipt.enrolled_at === "string");
+    ck("1. receipt hash present",                typeof r.receipt.hash === "string" && r.receipt.hash.startsWith("sha256:"));
+    ck("1. attestation_verity_bound true",       r.receipt.attestation_verity_bound === true);
+  } finally {
+    Date.prototype.toISOString = origToISO;
+  }
+}
+
+// ── 2. bad boot (tampered rootfs hash) ────────────────────────────────────────
+{
+  const tampered = STAGES.map((s) => s.stageName === "rootfs" ? { ...s, contentHash: WRONG } : s);
+  const bp  = bootProof(tampered);
+  const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { x86_64: POLICY }, quorumProof: quorumProof("sha256:" + "0".repeat(64)) });
+  ck("2. rejected on tampered rootfs",         r.enrolled === false);
+  ck("2. reason mentions boot",                r.reasons.some((x) => /boot not attested/i.test(x)));
+}
+
+// ── 3. wrong outcome ──────────────────────────────────────────────────────────
+{
+  const bp  = bootProof(STAGES, "firmware_fail");
+  const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { x86_64: POLICY }, quorumProof: quorumProof("sha256:" + "0".repeat(64)) });
+  ck("3. rejected on non-success outcome",     r.enrolled === false);
+}
+
+// ── 4. sub-threshold quorum (only 1 signature, need 2) ────────────────────────
+{
+  const bp  = bootProof();
+  const attest = attestBoot(bp, POLICY);
+  const ph  = enrollmentPayloadHash(DEV, attest.sealed.hash);
+  const qp  = quorumProof(ph, 1);
+  const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { x86_64: POLICY }, quorumProof: qp });
+  ck("4. rejected sub-threshold quorum",       r.enrolled === false);
+  ck("4. reason mentions quorum",              r.reasons.some((x) => /quorum not satisfied/i.test(x)));
+}
+
+// ── 5. wrong payload hash in quorum ───────────────────────────────────────────
+{
+  const bp  = bootProof();
+  const qp  = quorumProof("sha256:" + "0".repeat(64), 2);  // hash doesn't match the enrollment
+  const attest = attestBoot(bp, POLICY);
+  const ph  = enrollmentPayloadHash(DEV, attest.sealed.hash);
+  const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { x86_64: POLICY }, quorumProof: qp });
+  ck("5. rejected wrong payload hash",         r.enrolled === false);
+}
+
+// ── 6. no attestation policy for this arch ────────────────────────────────────
+{
+  const bp  = bootProof();
+  const r   = enrollDevice({ deviceIdentity: DEV, bootProof: bp, attestationPolicies: { arm64: POLICY }, quorumProof: quorumProof("sha256:" + "0".repeat(64)) });
+  ck("6. rejected missing arch policy",        r.enrolled === false);
+  ck("6. reason mentions arch",                r.reasons.some((x) => /no attestation policy/i.test(x)));
+}
+
+// ── 7. enrollmentPayloadHash binds device + attestation ───────────────────────
+{
+  const hash1 = enrollmentPayloadHash(DEV, "sha256:" + "a".repeat(64));
+  const hash2 = enrollmentPayloadHash({ ...DEV, id: "dev-002" }, "sha256:" + "a".repeat(64));
+  const hash3 = enrollmentPayloadHash(DEV, "sha256:" + "b".repeat(64));
+  ck("7. different device → different hash",   hash1 !== hash2);
+  ck("7. different attestation → different hash", hash1 !== hash3);
+  ck("7. same inputs → same hash",             hash1 === enrollmentPayloadHash(DEV, "sha256:" + "a".repeat(64)));
+}
+
+// ── 8. platform fallback in policy resolution ─────────────────────────────────
+{
+  const devNoArch = { id: "dev-003", deviceName: "edge-2", platform: "linux-x86_64" };
+  const FIXED = "2026-08-04T00:00:00.000Z";
+  const origToISO = Date.prototype.toISOString;
+  Date.prototype.toISOString = () => FIXED;
+  try {
+    const bp    = bootProof();
+    const attest = attestBoot(bp, POLICY);
+    const ph    = enrollmentPayloadHash(devNoArch, attest.sealed.hash);
+    const qp    = quorumProof(ph, 2);
+    const r     = enrollDevice({ deviceIdentity: devNoArch, bootProof: bp, attestationPolicies: { "linux-x86_64": POLICY }, quorumProof: qp });
+    ck("8. platform fallback resolves policy",   r.enrolled === true);
+  } finally {
+    Date.prototype.toISOString = origToISO;
+  }
+}
+
+// ── quorum unit tests ─────────────────────────────────────────────────────────
+ck("Q1. parseRule '2of3-human'",    JSON.stringify(parseRule("2of3-human")) === JSON.stringify({ threshold: 2, total: 3, kind: "human" }));
+ck("Q2. parseRule null on garbage", parseRule("bad") === null);
+ck("Q3. parseRule 0of1 invalid",    parseRule("0of1-human") === null);
+ck("Q4. verifyQuorum ok",           verifyQuorum(quorumProof("sha256:" + "0".repeat(64)), {}).ok === true);
+ck("Q5. verifyQuorum rejects dup signer", (() => {
+  const validators = ["spiffe://a", "spiffe://b", "spiffe://c"];
+  const sigs = [
+    { kind: "human", spiffe_id: "spiffe://a", sig: "0".repeat(32) },
+    { kind: "human", spiffe_id: "spiffe://a", sig: "1".repeat(32) },  // duplicate
+  ];
+  return !verifyQuorum({ kind: "QuorumProof", rule: "2of3-human", validators, signed_payload_hash: "sha256:" + "0".repeat(64), signatures: sigs }).ok;
+})());
+
+console.log(`\n${fail ? fail + " FAIL" : "all ok"}`);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Summary

- Completes the Canon Genesis binding: a device joins the fleet only when boot **attests** AND a **validator quorum** co-signs the enrollment — both fail-closed
- `src/services/quorum.ts` — TS verifier conforming to the one authoritative `QuorumProof` shape (vendored from mcp-a2a-zero-trust); twin of PP #1370 quorum.py; no second verifier invented
- `src/services/deviceEnrollment.ts` — `enrollDevice()` fuses boot attestation × quorum; arch-neutral (policy keyed by `archClass` with `platform` fallback); enrollment payload hash binds device + attestation hash so the quorum vote can't be replayed onto another device/boot
- `src/contracts/schemas/QuorumProof.json` — vendored from mcp-a2a-zero-trust (authoritative shape); provenance file included
- `test/device-enrollment.test.mjs` — 21 checks, CI-gated

## Security properties

| Property | Mechanism |
|---|---|
| Boot must attest | `bootAttestation.attestBoot` fail-closed (PR #561) |
| Rootfs bound to dm-verity | rootfsStage hash == dm-verity root (one evidence chain) |
| Quorum bound to this enrollment | `signed_payload_hash = sha256(device + attestation_hash)` |
| Replay-proof | Quorum co-signed a different device → hash mismatch → rejected |
| Arch-neutral | Same gate, same tests, different pinned policy per silicon |

## Test plan

- [x] `npm run test:enroll` → 21 passed, 0 failed
- [x] Happy path: good boot + threshold quorum → enrolled
- [x] Rejection: tampered rootfs, wrong outcome, sub-threshold quorum, wrong payload hash, missing arch policy
- [x] `enrollmentPayloadHash` binds device identity + attestation hash (different device or different attestation → different payload hash)
- [x] Platform fallback in policy resolution (no archClass → uses platform key)
- [x] Quorum unit tests: parseRule, verifyQuorum, duplicate-signer rejection
- [x] CI workflow updated with device enrollment step + path filters