### PR TITLE
feat(acquire-worker): GooseNotes integration — land acquisitions as workspace Notes

### DIFF
--- a/socioprophet-web/acquire-worker/src/cli.ts
+++ b/socioprophet-web/acquire-worker/src/cli.ts
@@ -8,6 +8,7 @@ import { AcquisitionService } from './service';
 import { crawl } from './crawl';
 import { SynapseIQEnricher, NullEnricher, type Enricher } from './enricher';
 import { LocalFileSink, JsonlLedgerSink, HttpSink, MemorySink, MultiSink, type Sink } from './sinks';
+import { WorkspaceNoteSink } from './workspaceNote';
 import type { AccountClass, AcquisitionTier } from '../../client-vue/src/features/acquisition/policy';
 
 function arg(flag: string, def?: string): string | undefined {
@@ -24,7 +25,8 @@ function makeSink(spec: string | undefined): Sink {
     if (kind === 'local') return new LocalFileSink(target || './landed');
     if (kind === 'ledger') return new JsonlLedgerSink(target || './acquire-ledger.jsonl');
     if (kind === 'http') return new HttpSink(target);
-    throw new Error(`unknown sink '${s}' (use local:<dir> | ledger:<file> | http:<url>)`);
+    if (kind === 'note') return new WorkspaceNoteSink(target || './workspace-inbox'); // GooseNotes / Office Plane capture
+    throw new Error(`unknown sink '${s}' (use local:<dir> | ledger:<file> | http:<url> | note:<dir>)`);
   }));
 }
 // --enrich synapseiq:<endpoint>  → SynapseIQ language enrichment (entities/extraction/embeddings).

--- a/socioprophet-web/acquire-worker/src/workspaceNote.test.ts
+++ b/socioprophet-web/acquire-worker/src/workspaceNote.test.ts
@@ -1,0 +1,61 @@
+// Conformance tests for the workspace-note sink — an acquired LandedRecord must map to a Note that
+// conforms to prophet-workspace/contracts/notes/note.schema.json (v0.1): required fields present,
+// no key outside the allowed set (additionalProperties:false), valid enums.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { landedToNote, NOTE_ALLOWED_KEYS, WorkspaceNoteSink } from './workspaceNote.ts';
+import type { LandedRecord } from './sinks.ts';
+import type { ProvenanceRecord } from '../../client-vue/src/features/acquisition/policy.ts';
+
+const prov = (o: Partial<ProvenanceRecord> = {}): ProvenanceRecord => ({
+  sourceId: 'src', url: 'https://ex.test/article', fetchedAt: '2026-08-04T00:00:00Z', httpStatus: 200,
+  contentHash: 'sha256:abc123', tier: 'T1', renderMode: 'http', egress: { class: 'residential', geo: 'US' },
+  posture: 'advisory', policy: { robots: 'allowed', tos: 'public', pii: false, legalBasis: 'public-data' },
+  override: null, accountClass: 'sovereign', warnings: [], ...o,
+});
+const REQUIRED = ['schemaVersion', 'noteId', 'accountRef', 'title', 'status', 'createdAt'];
+
+test('landedToNote emits a schema-conforming clip note', () => {
+  const rec: LandedRecord = { provenance: prov(), body: '<html><head><title>Hello World</title></head><body><p>hi there</p></body></html>' };
+  const note = landedToNote(rec, { accountRef: 'acct-1' });
+  // required present
+  for (const k of REQUIRED) assert.ok((note as Record<string, unknown>)[k] !== undefined, `missing required ${k}`);
+  // no key outside the allowed set (additionalProperties:false)
+  for (const k of Object.keys(note)) assert.ok((NOTE_ALLOWED_KEYS as readonly string[]).includes(k), `illegal key ${k}`);
+  // valid enums + mapping
+  assert.equal(note.schemaVersion, 'v0.1');
+  assert.equal(note.noteType, 'clip');
+  assert.equal(note.sourceType, 'url');
+  assert.equal(note.sourceRef, 'https://ex.test/article');
+  assert.equal(note.status, 'active');
+  assert.equal(note.title, 'Hello World');           // pulled from <title>
+  assert.equal(note.bodyText, 'hi there');           // HTML stripped for text body
+  assert.ok(note.bodyHtml?.includes('<p>'));         // HTML preserved
+  assert.equal(note.memoryRef, 'sha256:abc123');     // cross-links the mesh evidence record
+  assert.equal(note.accountRef, 'acct-1');
+  assert.ok(note.labels?.includes('acquired') && note.labels?.includes('tier:T1'));
+});
+
+test('SynapseIQ enrichment becomes the note aiSummary', () => {
+  const rec: LandedRecord = {
+    provenance: prov(), body: 'plain text body',
+    enrichment: { enricher: 'synapseiq', enrichedAt: '2026-08-04T00:00:00Z', language: 'en', entities: [{ text: 'Acme', type: 'org' }, { text: 'Paris', type: 'place' }] },
+  };
+  const note = landedToNote(rec);
+  assert.ok(note.aiSummary?.startsWith('SynapseIQ'));
+  assert.ok(note.aiSummary?.includes('lang en'));
+  assert.ok(note.aiSummary?.includes('Acme'));
+  assert.equal(note.bodyText, 'plain text body');    // non-HTML body kept as text, no bodyHtml
+  assert.equal(note.bodyHtml, undefined);
+});
+
+test('noteId is content-addressed (idempotent re-landing)', () => {
+  const a = landedToNote({ provenance: prov(), body: 'x' });
+  const b = landedToNote({ provenance: prov(), body: 'y' }); // same url+hash → same id
+  assert.equal(a.noteId, b.noteId);
+  assert.ok(a.noteId.startsWith('acq-'));
+});
+
+test('WorkspaceNoteSink names itself by its inbox dir', () => {
+  assert.equal(new WorkspaceNoteSink('./inbox').name, 'note:./inbox');
+});

--- a/socioprophet-web/acquire-worker/src/workspaceNote.ts
+++ b/socioprophet-web/acquire-worker/src/workspaceNote.ts
@@ -1,0 +1,103 @@
+// Workspace-note sink — lands acquired documents as prophet-workspace Notes, which is the capture
+// surface GooseNotes (Rust/Tauri) renders. GooseNotes has no data model of its own; it's a thin shell
+// over the prophet-workspace contracts, so the correct, no-Rust integration is to EMIT a conforming
+// Note. An acquired page is a `clip` note with sourceType 'url'; SynapseIQ enrichment becomes the
+// note's aiSummary + labels. Conforms to prophet-workspace/contracts/notes/note.schema.json (v0.1).
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Sink, LandedRecord } from './sinks';
+
+// The complete allowed key set from note.schema.v0.1 (additionalProperties:false). We only emit a
+// subset, but the sink must never emit a key outside this set — the test enforces it.
+export const NOTE_ALLOWED_KEYS = [
+  'schemaVersion', 'noteId', 'accountRef', 'title', 'bodyText', 'bodyHtml', 'noteType', 'checklistItems',
+  'status', 'isPinned', 'color', 'labels', 'attachments', 'reminder', 'collaborators', 'shareMode',
+  'sourceRef', 'sourceType', 'eventRef', 'mailThreadRefs', 'taskRefs', 'noteRefs', 'workroomRef',
+  'driveFileRef', 'aiSummary', 'memoryRef', 'createdAt', 'updatedAt', 'policyRefs',
+] as const;
+
+export interface Note {
+  schemaVersion: 'v0.1';
+  noteId: string;
+  accountRef: string;
+  title: string;
+  status: 'active' | 'archived' | 'trashed';
+  createdAt: string;
+  bodyText?: string;
+  bodyHtml?: string;
+  noteType?: 'freeform' | 'checklist' | 'meeting_notes' | 'clip' | 'voice_transcript';
+  labels?: string[];
+  sourceRef?: string;
+  sourceType?: 'mail' | 'calendar_event' | 'doc' | 'url' | 'voice' | 'manual';
+  aiSummary?: string;
+  memoryRef?: string;
+}
+
+export interface NoteSinkOptions {
+  accountRef?: string;   // whose workspace these land in (default WORKSPACE_ACCOUNT_REF or 'sovereign')
+  maxBody?: number;      // truncate stored body (default 200k chars)
+}
+
+const TITLE_RE = /<title[^>]*>([^<]{1,200})<\/title>/i;
+const H1_RE = /<h1[^>]*>([^<]{1,200})<\/h1>/i;
+
+function deriveTitle(body: string, url: string): string {
+  const t = TITLE_RE.exec(body)?.[1] ?? H1_RE.exec(body)?.[1];
+  if (t) return t.trim().replace(/\s+/g, ' ');
+  try { const u = new URL(url); return `${u.host}${u.pathname}`.slice(0, 120); } catch { return url.slice(0, 120); }
+}
+
+function looksHtml(body: string): boolean { return /<\s*(html|body|div|p|h[1-6]|article)\b/i.test(body.slice(0, 2000)); }
+function stripHtml(body: string): string {
+  return body.replace(/<head[\s\S]*?<\/head>/gi, ' ').replace(/<script[\s\S]*?<\/script>/gi, ' ').replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+// Compose a human aiSummary from the SynapseIQ enrichment (entities + language), when present.
+function summaryFromEnrichment(e: LandedRecord['enrichment']): string | undefined {
+  if (!e) return undefined;
+  const bits: string[] = [];
+  if (e.language) bits.push(`lang ${e.language}`);
+  if (e.entities?.length) bits.push(`${e.entities.length} entities: ${e.entities.slice(0, 8).map((x) => x.text).join(', ')}`);
+  return bits.length ? `SynapseIQ · ${bits.join(' · ')}` : undefined;
+}
+
+// Map a governed LandedRecord → a conforming prophet-workspace Note (clip from a URL).
+export function landedToNote(rec: LandedRecord, opts: NoteSinkOptions = {}): Note {
+  const p = rec.provenance;
+  const body = rec.body ?? '';
+  const html = looksHtml(body);
+  const max = opts.maxBody ?? 200_000;
+  const note: Note = {
+    schemaVersion: 'v0.1',
+    noteId: `acq-${(p.contentHash || p.url).replace(/[^a-zA-Z0-9]/g, '').slice(0, 40)}`,
+    accountRef: opts.accountRef ?? process.env['WORKSPACE_ACCOUNT_REF'] ?? 'sovereign',
+    title: deriveTitle(body, p.url),
+    status: 'active',
+    createdAt: p.fetchedAt,
+    noteType: 'clip',
+    sourceType: 'url',
+    sourceRef: p.url,
+    labels: ['acquired', `tier:${p.tier}`, `posture:${p.posture}`, `egress:${p.egress.class}`],
+    memoryRef: p.contentHash || undefined,   // cross-links to the mesh evidence record (same hash)
+  };
+  if (body) {
+    if (html) { note.bodyHtml = body.slice(0, max); note.bodyText = stripHtml(body).slice(0, max); }
+    else { note.bodyText = body.slice(0, max); }
+  }
+  const summary = summaryFromEnrichment(rec.enrichment);
+  if (summary) note.aiSummary = summary;
+  return note;
+}
+
+// Lands each acquired record as a conforming Note JSON in an inbox directory the Office Plane /
+// GooseNotes ingests. Content-addressed filename → idempotent re-landing.
+export class WorkspaceNoteSink implements Sink {
+  readonly name: string;
+  constructor(private dir: string, private opts: NoteSinkOptions = {}) { this.name = `note:${dir}`; }
+  async write(rec: LandedRecord): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+    const note = landedToNote(rec, this.opts);
+    await writeFile(join(this.dir, `${note.noteId}.note.json`), JSON.stringify(note, null, 2));
+  }
+}


### PR DESCRIPTION
Wires acquisition into **GooseNotes** — the last-but-one meta-surface.

GooseNotes is a Rust/Tauri **thin capture shell over the prophet-workspace contracts** (it explicitly has no data model of its own). So the correct integration is on the acquisition side (my lane, TS), not its Rust core: a worker **sink that emits a conforming Note**.

## What lands
An acquired document → a **`clip` note** conforming to `prophet-workspace/contracts/notes/note.schema.json` (v0.1):
- `sourceType: 'url'`, `sourceRef` = the URL, title pulled from the page's `<title>`/`<h1>`
- HTML → `bodyHtml` + stripped `bodyText`; content-addressed `noteId` (idempotent re-landing)
- **SynapseIQ enrichment → `aiSummary`** + labels (`acquired`, `tier:*`, `posture:*`, `egress:*`)
- **`memoryRef` = provenance `contentHash`** → the note cross-links to the *same* mesh evidence record

CLI: `acquire <url> --sink note:<dir>` (an inbox the Office Plane / GooseNotes ingests).

## Verification
- 13/13 worker tests (4 new conformance tests).
- Validated against the **real** `note.schema.json` — `CONFORMS=true` (no illegal keys, all required present).
- **Live**: `acquire https://example.com --sink note:/tmp/goose-inbox` produced a valid "Example Domain" clip note.

No Rust touched — Rust is out of my lane; the contract is the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)