### PR TITLE
feat(client-vue): wire the consent board into routes, registry and dev proxy (WO-2)

### DIFF
--- a/socioprophet-web/client-vue/src/config/routeRegistry.ts
+++ b/socioprophet-web/client-vue/src/config/routeRegistry.ts
@@ -20,6 +20,19 @@ export type RouteRegistryEntry = {
 
 export const routeRegistry: RouteRegistryEntry[] = [
   {
+    path: '/capability/consent',
+    label: 'Consent',
+    domain: 'Capability',
+    maturity: 'L2',
+    stateMode: 'live-fallback',
+    navTier: 'tab-only',
+    userJob: 'See exactly what telemetry could be recorded about your own usage, and turn each one on or off — every item default-off, explained, and revocable.',
+    ownerPlane: 'client-vue ConsentBoard over the sourceos-spec ConsentSurfaceRegistry + CapabilityConsentPolicy; live via /svc/consent (opt-in, fails closed to a default-off fixture)',
+    boundary: 'Self-sovereign: observed party and record-holder are the same principal. Default-deny; nothing collected until granted; every grant revocable. No capture mechanism lives here — this surface only shows and toggles consent state.',
+    primaryObject: 'consent surface',
+    breadcrumbs: ['Capability', 'Consent'],
+  },
+  {
     path: '/capability/assay-fleet',
     label: 'Assay Fleet',
     domain: 'Capability',

--- a/socioprophet-web/client-vue/src/main.ts
+++ b/socioprophet-web/client-vue/src/main.ts
@@ -91,6 +91,7 @@ import DeliveryExcellence from './pages/DeliveryExcellence.vue';
 import Cowork from './pages/Cowork.vue';
 import WorkbenchPage from './pages/WorkbenchPage.vue';
 import ScopeDFabric from './pages/workbench/ScopeDFabric.vue';
+import ConsentBoard from './pages/ConsentBoard.vue';
 import './styles.css';
 import './components/workbench/primitives.css';
 
@@ -99,6 +100,7 @@ const explicitRoutes = [
   { path: '/login', component: Login, meta: { public: true } },
   { path: '/capability/dashboard', component: OperatorDashboard },
   { path: '/capability/assay-fleet', component: AssayFleetDashboard },
+  { path: '/capability/consent', component: ConsentBoard },
   { path: '/agentic-os', component: AgenticOS },
   { path: '/marketplace', component: Marketplace },
   { path: '/people/labor-market', component: LaborMarket },

--- a/socioprophet-web/client-vue/vite.config.ts
+++ b/socioprophet-web/client-vue/vite.config.ts
@@ -83,6 +83,13 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/assay/, ''),
         },
+        // Consent service — self-sovereign consent surface registry + grant/revoke.
+        // Opt-in; the board fails closed to a default-off fixture when absent.
+        '/svc/consent': {
+          target: env.VITE_CONSENT_BASE || 'http://localhost:8790',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/consent/, ''),
+        },
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',


### PR DESCRIPTION
Completes WO-2. #570 landed the consent board's components, API client and
fixture test, but nothing routed to them — the surface existed and was
unreachable. `/capability/consent` 404s on master today.

## Changes
- **`src/main.ts`** — import `ConsentBoard`, mount at `/capability/consent`.
- **`src/config/routeRegistry.ts`** — registry entry at the array head, declaring
  the self-sovereign boundary (observed party == record-holder), default-deny,
  and that no capture mechanism lives on this surface.
- **`vite.config.ts`** — `/svc/consent` proxy (`VITE_CONSENT_BASE`, `:8790`) so
  the board's live mode has a dev target. Absent it, the board fails closed to
  the default-off fixture — no backend required to render.

## Verification (local, on this branch)
- `npx vue-tsc --noEmit` — clean
- `npx vitest run` — **891/891** across 145 files; `ConsentBoardFixture` **5/5**
- `npx vite build` — succeeds

## Acceptance
`/capability/consent` renders every telemetry surface default-off with its
plain-language explanation and a grant/revoke toggle; self-sovereign banner
shows subject == collector. Fixture mode needs no backend; live state arrives
with the consent service (WO-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)