### PR TITLE
feat(consent): consent enforcement backend — grants that actually gate (WO-3)

### DIFF
--- a/socioprophet-web/client-vue/src/services/consentApi.ts
+++ b/socioprophet-web/client-vue/src/services/consentApi.ts
@@ -80,12 +80,23 @@ export async function fetchConsentWithFallback(): Promise<ConsentLoadResult> {
   }
 }
 
-/** Grant or revoke a surface/capability. Fail-open-local: with no backend the change is local-only. */
+/**
+ * Grant or revoke a surface/capability. Fail-open-local: with no backend the change is local-only.
+ *
+ * POST, not GET. These calls change what may be observed about a person, and a state-changing GET
+ * is reachable by a link, a browser prefetch or a cross-site <img> — consent could be granted or
+ * revoked without the person acting. Credentials ride along so the server binds the change to the
+ * authenticated subject rather than trusting an id in the URL.
+ */
 export async function setConsent(id: string, grant: boolean): Promise<{ id: string; state: ConsentState; mode: ConsentMode }> {
   try {
-    const r = await getJson<{ id: string; state: ConsentState }>(
-      `/${grant ? 'grant' : 'revoke'}/${encodeURIComponent(id)}`,
-    );
+    const res = await fetch(`${BASE}/${grant ? 'grant' : 'revoke'}/${encodeURIComponent(id)}`, {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText} for ${id}`);
+    const r = (await res.json()) as { id: string; state: ConsentState };
     return { ...r, mode: 'live' };
   } catch {
     return { id, state: grant ? 'granted' : 'revoked', mode: 'fixture' };

--- a/socioprophet-web/client-vue/vite.config.ts
+++ b/socioprophet-web/client-vue/vite.config.ts
@@ -83,13 +83,10 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/assay/, ''),
         },
-        // Consent service — self-sovereign consent surface registry + grant/revoke.
-        // Opt-in; the board fails closed to a default-off fixture when absent.
-        '/svc/consent': {
-          target: env.VITE_CONSENT_BASE || 'http://localhost:8790',
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/svc\/consent/, ''),
-        },
+        // Consent plane — served by the Express server (same backend as /api/builds etc.)
+        // at /svc/consent, prefix intact. Opt-in; the board fails closed to a default-off
+        // fixture when the backend is unreachable.
+        '/svc/consent': builderProxy,
         // Same-origin proxy to the live Prophet Mesh (mesh.socioprophet.ai has no CORS).
         '/mesh': {
           target: env.VITE_MESH_BASE || 'https://mesh.socioprophet.ai',

--- a/socioprophet-web/server/package.json
+++ b/socioprophet-web/server/package.json
@@ -49,6 +49,7 @@
     "test:delivery": "node test/delivery.reconcile.test.mjs",
     "test:mirror": "node test/githubMirror.test.mjs",
     "test:enroll": "node test/device-enrollment.test.mjs",
+    "test:consent": "node test/consent.test.mjs",
     "test:sovereign": "node test/delivery.reconcile.test.mjs && node test/githubMirror.test.mjs"
   },
   "author": "Will Jones",

--- a/socioprophet-web/server/src/contracts/schemas/Grant.PROVENANCE.txt
+++ b/socioprophet-web/server/src/contracts/schemas/Grant.PROVENANCE.txt
@@ -1,0 +1,12 @@
+Grant.json — vendored verbatim from SourceOS-Linux/mcp-a2a-zero-trust ::
+schemas/canonical/grant.schema.json (the authoritative Grant shape), pinned at
+7ec8133fa87ab33b373cf4e4badd17af77f50c22.
+
+DO NOT edit here — reconcile from mcp-a2a-zero-trust. The consent ledger
+(src/services/consentLedger.ts) mints grants against THIS shape rather than a
+consent-specific one, so a consent grant is verifiable by the same verifier as
+any other capability grant in the estate. A second grant shape would mean
+consent could be honoured by one verifier and ignored by another.
+
+Sibling precedent: QuorumProof.json, vendored the same way for the
+device-enrollment gate.

--- a/socioprophet-web/server/src/contracts/schemas/Grant.json
+++ b/socioprophet-web/server/src/contracts/schemas/Grant.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sourceos.local/schemas/canonical/grant.schema.json",
+  "title": "Grant",
+  "type": "object",
+  "required": [
+    "grant_id",
+    "issued_at",
+    "expires_at",
+    "binding",
+    "capability",
+    "constraints",
+    "policy_hash"
+  ],
+  "properties": {
+    "grant_id": {
+      "type": "string",
+      "minLength": 8
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "binding": {
+      "type": "object",
+      "required": [
+        "spiffe_id",
+        "aum_digest"
+      ],
+      "properties": {
+        "spiffe_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "aum_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "session_id": {
+          "type": "string",
+          "minLength": 6
+        }
+      },
+      "additionalProperties": false
+    },
+    "capability": {
+      "type": "object",
+      "required": [
+        "kind",
+        "capability_ref",
+        "capability_digest",
+        "effect"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "mcp_tool",
+            "a2a_skill",
+            "deployment",
+            "runner_action"
+          ]
+        },
+        "capability_ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "server": {
+          "type": "string"
+        },
+        "tool": {
+          "type": "string"
+        },
+        "agent_id": {
+          "type": "string"
+        },
+        "skill": {
+          "type": "string"
+        },
+        "deployment_id": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "executor_ref": {
+          "type": "string"
+        },
+        "effect": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "compute",
+            "exec",
+            "egress"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "constraints": {
+      "type": "object"
+    },
+    "policy_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "quorum_proof": {
+      "$ref": "quorum_proof.schema.json"
+    },
+    "evidence_refs": {
+      "$ref": "https://socioprophet.dev/schema/governance/runtime_evidence_refs.schema.json"
+    },
+    "sig": {
+      "type": "object",
+      "required": [
+        "issuer",
+        "sig"
+      ],
+      "properties": {
+        "issuer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sig": {
+          "type": "string",
+          "minLength": 16
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/socioprophet-web/server/src/contracts/schemas/RuntimeEvidenceRefs.PROVENANCE.txt
+++ b/socioprophet-web/server/src/contracts/schemas/RuntimeEvidenceRefs.PROVENANCE.txt
@@ -1,0 +1,9 @@
+RuntimeEvidenceRefs.json — vendored verbatim from SourceOS-Linux/mcp-a2a-zero-trust ::
+schemas/governance/runtime_evidence_refs.schema.json, pinned at
+7ec8133fa87ab33b373cf4e4badd17af77f50c22.
+
+DO NOT edit here — reconcile from mcp-a2a-zero-trust. Present only because the canonical
+Grant schema $refs it (Grant.evidence_refs); vendored to complete the ref closure so
+Grant.json compiles standalone. Trimming the $ref out of Grant.json instead would have
+made the vendored copy a fork of the authority, which is the thing the PROVENANCE
+convention exists to prevent.

--- a/socioprophet-web/server/src/contracts/schemas/RuntimeEvidenceRefs.json
+++ b/socioprophet-web/server/src/contracts/schemas/RuntimeEvidenceRefs.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schema/governance/runtime_evidence_refs.schema.json",
+  "title": "RuntimeEvidenceRefs",
+  "description": "Reference set that lets grants, policy decisions, or ledger events carry semantic-proof and HDT-summary bindings without embedding full artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "event_ir_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "event_ir_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "semantic_proof_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "semantic_proof_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "hdt_decision_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "hdt_decision_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "attestation_bundle_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "attestation_bundle_hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/socioprophet-web/server/src/routes/api/consent-route.ts
+++ b/socioprophet-web/server/src/routes/api/consent-route.ts
@@ -1,0 +1,76 @@
+export {};
+// /svc/consent — the consent plane's read + write surface, backing client-vue's ConsentBoard.
+//   GET  /svc/consent/snapshot     every surface + capability with its live consent state
+//   POST /svc/consent/grant/:id    grant consent for one surface/capability
+//   POST /svc/consent/revoke/:id   revoke it
+//
+// Grant and revoke are POST, deliberately. They change what may be observed about a person, and
+// a state-changing GET is reachable by a link, a prefetch, or a cross-site <img> — a browser
+// could grant or revoke consent without the person acting. The board's first client shipped
+// these as GET; that is fixed on the client side rather than accommodated here.
+//
+// AUTHENTICATED. The subject is taken from the session, never from the request body or a query
+// param: a caller must not be able to name whose consent they are reading or changing. This is
+// what makes the self-sovereign invariant (subject == grantee) hold at the HTTP edge, and it is
+// why there is no /snapshot/:subject route.
+const express = require("express");
+const ledger = require("../../services/consentLedger");
+
+const router = express.Router();
+
+// Per-subject stores. Swap for durable storage without touching the ledger logic — the ledger
+// takes the store as an argument precisely so this line is the only thing that changes.
+const _stores = new Map<string, any>();
+const storeFor = (subject: string) => {
+  let s = _stores.get(subject);
+  if (!s) {
+    s = ledger.createStore();
+    _stores.set(subject, s);
+  }
+  return s;
+};
+
+// The authenticated subject, as a URN. Fails closed: no session, no consent surface.
+const subjectOf = (req: any): string | null => {
+  const raw = req.uid || req.userEmail || null;
+  return raw ? "urn:srcos:principal:" + String(raw) : null;
+};
+
+const requireSubject = (req: any, res: any): string | null => {
+  const subject = subjectOf(req);
+  if (!subject) {
+    res.status(401).json({ error: "authentication required to read or change consent" });
+    return null;
+  }
+  return subject;
+};
+
+router.get("/snapshot", (req: any, res: any) => {
+  const subject = requireSubject(req, res);
+  if (!subject) return;
+  res.json(ledger.snapshot(storeFor(subject), subject));
+});
+
+router.post("/grant/:id", (req: any, res: any) => {
+  const subject = requireSubject(req, res);
+  if (!subject) return;
+  const id = String(req.params.id || "");
+  const r = ledger.grant(storeFor(subject), subject, id);
+  if (!r.ok) {
+    // unknown-id is a 404; a subject mismatch is a 403 and is never silently repaired.
+    const code = r.reason === "unknown-id" ? 404 : 403;
+    return res.status(code).json({ error: r.reason, id });
+  }
+  res.json({ id: r.id, state: r.state, grantRef: r.grantRef });
+});
+
+router.post("/revoke/:id", (req: any, res: any) => {
+  const subject = requireSubject(req, res);
+  if (!subject) return;
+  const id = String(req.params.id || "");
+  const r = ledger.revoke(storeFor(subject), subject, id);
+  if (!r.ok) return res.status(403).json({ error: r.reason, id });
+  res.json({ id: r.id, state: r.state, grantRef: r.grantRef ?? null });
+});
+
+module.exports = router;

--- a/socioprophet-web/server/src/server.ts
+++ b/socioprophet-web/server/src/server.ts
@@ -16,6 +16,7 @@ const fleetRouter = require("./routes/api/fleet-route");
 const bootRouter = require("./routes/boot-route");
 const proCyberneticaRouter = require("./routes/api/procybernetica-dashboard-route");
 const deliveryRouter = require("./routes/api/delivery-route");
+const consentRouter = require("./routes/api/consent-route");
 const { requireAuth } = require("./middleware/auth");
 
 const app = express();
@@ -47,6 +48,9 @@ app.use("/api/procybernetica", apiLimiter, proCyberneticaRouter);
 // Sovereign delivery producer (public read): /api/delivery/* + /api/cowork/*.
 // Sovereign store is canonical; the client adapters fail closed when unreachable.
 app.use("/api", apiLimiter, deliveryRouter);
+// Consent plane. AUTHENTICATED: the subject comes from the session, never from the request, so
+// a caller cannot name whose consent they read or change. Backs client-vue's ConsentBoard.
+app.use("/svc/consent", apiLimiter, requireAuth, consentRouter);
 // Device provisioning is UNAUTHENTICATED (claim-code authorized) — nlboot devices
 // have no Socbase token; rate-limited at the HTTP layer.
 app.use("/boot", bootLimiter, bootRouter);

--- a/socioprophet-web/server/src/services/consentLedger.ts
+++ b/socioprophet-web/server/src/services/consentLedger.ts
@@ -100,10 +100,18 @@ const _findItem = (id: string): any | null => {
   );
 };
 
-// Is this id a real surface/capability? Every operation gates on this BEFORE the id is used as
-// an object key, so an id from the URL path can never name something outside the registry —
-// including "__proto__" and friends. Default-deny applied to the id space itself.
-const _isKnownId = (id: string): boolean => _findItem(id) !== null;
+// The REGISTRY's own id string for a request id, or null if the id names nothing real.
+//
+// Every store key goes through this. The string that ends up as an object key is one this module
+// authored, never the caller's, even though the two compare equal — so there is no data flow from
+// the request to a property name at all. Two things follow: default-deny applied to the id space
+// itself ("__proto__" and friends name nothing, so they are refused before any lookup), and the
+// safety is provable to a taint analyser rather than merely true in practice.
+const _canonicalId = (id: string): string | null => {
+  const item = _findItem(id);
+  if (!item) return null;
+  return (item.surfaceId ?? item.capabilityId ?? null) as string | null;
+};
 
 // ── store ────────────────────────────────────────────────────────────────────
 // A grant record per consented id. Deliberately a plain map so it can be swapped for durable
@@ -113,12 +121,13 @@ const _isKnownId = (id: string): boolean => _findItem(id) !== null;
 // ordinary `{}` the keys "__proto__", "constructor" and "prototype" do not behave like data:
 // `grants["__proto__"]` resolves to Object.prototype, so reading a "record" for it yields a
 // truthy object and writing to that record mutates every object in the process. A null-prototype
-// map has no such keys to inherit. This is belt-and-braces with `_isKnownId` below — either one
+// map has no such keys to inherit. This is belt-and-braces with `_canonicalId` below — either one
 // alone would close it, and both are cheap.
 const createStore = () => ({ subject: null as string | null, grants: Object.create(null) as Record<string, any> });
 
-// Own-property lookup that cannot walk a prototype chain.
-const _record = (store: any, id: string): any | null => {
+// Own-property lookup that cannot walk a prototype chain. `id` is expected to already be a
+// canonical registry string (see _canonicalId); the hasOwnProperty guard is the second lock.
+const _record = (store: any, id: string | null): any | null => {
   const g = store?.grants;
   if (!g || typeof id !== "string") return null;
   return Object.prototype.hasOwnProperty.call(g, id) ? g[id] : null;
@@ -189,11 +198,14 @@ const grant = (store: any, subject: string, id: string, opts?: { now?: number; s
   }
   const item = _findItem(id);
   if (!item) return { ok: false, reason: "unknown-id" }; // default-deny: no such surface, no grant
+  const key = _canonicalId(id);
+  if (key === null) return { ok: false, reason: "unknown-id" };
 
   const g = mintGrant(subject, item, opts);
   store.subject = subject;
-  store.grants[id] = {
-    id,
+  // `key` is the registry's own string, not the caller's — no request value reaches a property name.
+  store.grants[key] = {
+    id: key,
     state: "granted",
     grantedAt: g.issued_at,
     revokedAt: null,
@@ -210,8 +222,9 @@ const grant = (store: any, subject: string, id: string, opts?: { now?: number; s
 const check = (store: any, id: string, opts?: { now?: number; subject?: string }): boolean => {
   try {
     if (!store || typeof store !== "object" || !store.grants) return false;
-    if (!_isKnownId(id)) return false; // an id outside the registry is denied, never looked up
-    const rec = _record(store, id);
+    const key = _canonicalId(id); // an id outside the registry is denied, never looked up
+    if (key === null) return false;
+    const rec = _record(store, key);
     if (!rec || rec.state !== "granted") return false;
     if (rec.revokedAt) return false;
 
@@ -245,8 +258,9 @@ const revoke = (store: any, subject: string, id: string, opts?: { now?: number }
   }
   // Gate on the registry BEFORE the id touches the store. Without this, revoking "__proto__"
   // read Object.prototype as a grant record and wrote the revocation onto it.
-  if (!_isKnownId(id)) return { ok: false, reason: "unknown-id" };
-  const rec = _record(store, id);
+  const key = _canonicalId(id);
+  if (key === null) return { ok: false, reason: "unknown-id" };
+  const rec = _record(store, key);
   const now = opts?.now ?? Date.now();
   if (!rec) {
     // Revoking something never granted is not an error — the end state the person asked for

--- a/socioprophet-web/server/src/services/consentLedger.ts
+++ b/socioprophet-web/server/src/services/consentLedger.ts
@@ -91,6 +91,7 @@ const registry = () => {
 };
 
 const _findItem = (id: string): any | null => {
+  if (typeof id !== "string" || !id) return null;
   const r = registry();
   return (
     r.surfaces.find((s: any) => s.surfaceId === id) ??
@@ -99,10 +100,29 @@ const _findItem = (id: string): any | null => {
   );
 };
 
+// Is this id a real surface/capability? Every operation gates on this BEFORE the id is used as
+// an object key, so an id from the URL path can never name something outside the registry —
+// including "__proto__" and friends. Default-deny applied to the id space itself.
+const _isKnownId = (id: string): boolean => _findItem(id) !== null;
+
 // ── store ────────────────────────────────────────────────────────────────────
-// A grant record per consented id. Deliberately a plain object so it can be swapped for durable
+// A grant record per consented id. Deliberately a plain map so it can be swapped for durable
 // storage without changing the logic below.
-const createStore = () => ({ subject: null as string | null, grants: {} as Record<string, any> });
+//
+// grants uses a NULL-PROTOTYPE object. The ids that key it come from the URL path, and on an
+// ordinary `{}` the keys "__proto__", "constructor" and "prototype" do not behave like data:
+// `grants["__proto__"]` resolves to Object.prototype, so reading a "record" for it yields a
+// truthy object and writing to that record mutates every object in the process. A null-prototype
+// map has no such keys to inherit. This is belt-and-braces with `_isKnownId` below — either one
+// alone would close it, and both are cheap.
+const createStore = () => ({ subject: null as string | null, grants: Object.create(null) as Record<string, any> });
+
+// Own-property lookup that cannot walk a prototype chain.
+const _record = (store: any, id: string): any | null => {
+  const g = store?.grants;
+  if (!g || typeof id !== "string") return null;
+  return Object.prototype.hasOwnProperty.call(g, id) ? g[id] : null;
+};
 
 const _spiffeFor = (subject: string): string => SPIFFE_PREFIX + encodeURIComponent(subject);
 
@@ -190,7 +210,8 @@ const grant = (store: any, subject: string, id: string, opts?: { now?: number; s
 const check = (store: any, id: string, opts?: { now?: number; subject?: string }): boolean => {
   try {
     if (!store || typeof store !== "object" || !store.grants) return false;
-    const rec = store.grants[id];
+    if (!_isKnownId(id)) return false; // an id outside the registry is denied, never looked up
+    const rec = _record(store, id);
     if (!rec || rec.state !== "granted") return false;
     if (rec.revokedAt) return false;
 
@@ -222,7 +243,10 @@ const revoke = (store: any, subject: string, id: string, opts?: { now?: number }
   if (store.subject && subject && store.subject !== subject) {
     return { ok: false, reason: "subject-mismatch" };
   }
-  const rec = store.grants?.[id];
+  // Gate on the registry BEFORE the id touches the store. Without this, revoking "__proto__"
+  // read Object.prototype as a grant record and wrote the revocation onto it.
+  if (!_isKnownId(id)) return { ok: false, reason: "unknown-id" };
+  const rec = _record(store, id);
   const now = opts?.now ?? Date.now();
   if (!rec) {
     // Revoking something never granted is not an error — the end state the person asked for
@@ -239,7 +263,7 @@ const snapshot = (store: any, subject: string, opts?: { now?: number }) => {
   const r = registry();
   const self = subject ?? store?.subject ?? "urn:srcos:principal:self";
   const stateOf = (id: string) => {
-    const rec = store?.grants?.[id];
+    const rec = _record(store, id);
     if (!rec) return { state: "denied" as const };
     const live = check(store, id, { now: opts?.now, subject: self });
     if (rec.state === "revoked") {

--- a/socioprophet-web/server/src/services/consentLedger.ts
+++ b/socioprophet-web/server/src/services/consentLedger.ts
@@ -1,0 +1,286 @@
+export {};
+// Consent ledger — the enforcement side of the self-sovereign consent plane.
+//
+// The board (client-vue ConsentBoard) SHOWS consent; this is what makes a grant real. Three
+// operations and one invariant:
+//
+//   grant(id)  → mints a CANONICAL mcp-a2a-zero-trust Grant (schemas/canonical/grant.schema.json,
+//                vendored at ../contracts/schemas/Grant.json) and records its grant_id as the
+//                surface's grantRef. Not a consent-specific token: a consent grant is verifiable
+//                by the same verifier as any other capability grant in the estate, so consent
+//                cannot be honoured by one verifier and ignored by another.
+//   check(id)  → does consent STAND right now (granted, not revoked, not expired). FAIL-CLOSED:
+//                every path that is not an affirmative, live, unrevoked grant returns false —
+//                unknown id, malformed store, absent grant, clock skew, thrown error.
+//   revoke(id) → revokes the grant. Revocation is terminal for that grant: re-granting mints a
+//                NEW grant rather than resurrecting the old one, so a revocation can never be
+//                undone by replaying an old token.
+//
+// INVARIANT — SUBJECT == GRANTEE. This plane is self-sovereign: the observed party and the
+// record-holder are the same principal. A grant whose binding names a different principal than
+// the consent subject is REFUSED, not recorded. That is the whole difference between consent and
+// surveillance, so it is enforced at mint time and re-checked at check time — an attacker who
+// writes straight into the store still cannot make a foreign-subject grant pass check().
+//
+// Default-deny: a surface absent from the ledger is DENIED, never "unknown, allow".
+
+const crypto = require("crypto");
+
+const SPIFFE_PREFIX = "spiffe://socioprophet/subject/";
+
+// ── canonical helpers ────────────────────────────────────────────────────────
+const _canon = (o: any): string => JSON.stringify(o, Object.keys(o).sort());
+const _sha256 = (s: string): string => "sha256:" + crypto.createHash("sha256").update(s).digest("hex");
+
+const _iso = (ms: number): string => new Date(ms).toISOString();
+
+// Grant lifetimes by consent standard. per-use grants are deliberately short AND one-shot: the
+// board promises "you are asked every single time", and a long-lived per-use grant would make
+// that promise false.
+const LIFETIME_MS: Record<string, number> = {
+  "per-use": 5 * 60 * 1000,
+  "standing-session": 24 * 60 * 60 * 1000,
+  "standing-persistent": 365 * 24 * 60 * 60 * 1000,
+};
+
+// ── the registry: what CAN be consented to ───────────────────────────────────
+// Mirrors the client's demoConsentSnapshot() exactly. The board renders this list whether it is
+// live or on the fixture, so the two must not drift — consent.test.mjs asserts the ids match.
+const TELEMETRY_SURFACES = [
+  ["telemetry:model:tokens_used", "model", "benign", false, "LOSSLESS", "Track how many tokens you use.", "operate"],
+  ["telemetry:model:inference_route", "model", "benign", false, "LOSSLESS", "See which model handled each request.", "operate"],
+  ["telemetry:model:latency", "model", "benign", false, "LOSSLESS", "See how fast responses come back.", "operate"],
+  ["telemetry:policy:gate_verdict", "policy", "benign", false, "LOSSLESS", "See every time the agent asked to use a tool, and what was decided.", "operate"],
+  ["telemetry:policy:consent_change", "policy", "benign", false, "LOSSLESS", "Keep an audit trail of your own privacy choices.", "operate"],
+  ["telemetry:app:session_lifecycle", "app", "personal", false, "LOSSY", "Know when sessions start, stop, or crash.", "operate"],
+  ["telemetry:app:active_surface", "app", "personal", false, "LOSSY", "A coarse label of which kind of surface is active — never what is in it.", "operate"],
+  ["telemetry:device:node_id", "device", "sensitive", true, "OPAQUE_HANDLE_ONLY", "A random ID for this install so your fleet view can tell your own devices apart. Not tied to your hardware.", "operate"],
+  ["telemetry:device:os_release", "device", "benign", false, "LOSSLESS", "Which OS and version this device runs.", "operate"],
+];
+
+const CAPABILITIES = [
+  ["microphone", "sensor", "standing-session", "Listen while you are talking to the agent. Audio stays on this device and is not kept.", false],
+  ["camera", "sensor", "per-use", "Use the camera. You are asked every single time; there is no always-allow.", true],
+  ["screen_capture", "sensor", "per-use", "Read your screen. Asked every single time.", true],
+  ["control_my_computer", "high_actuator", "per-use", "Act on this computer for you. Every action asks first.", true],
+  ["send_on_behalf", "outward_action", "per-use", "Send a message or post as you. Asked every time.", true],
+];
+
+// Effect the grant authorizes, per the canonical enum (read|write|compute|exec|egress).
+// Telemetry LEAVES the device, so it is egress — never "read". Naming it read would understate
+// what the person is agreeing to.
+const _effectForCapability = (riskClass: string): string => {
+  if (riskClass === "outward_action") return "egress";
+  if (riskClass === "high_actuator") return "exec";
+  return "read";
+};
+
+const registry = () => {
+  const surfaces = TELEMETRY_SURFACES.map((s: any) => ({
+    surfaceId: s[0], category: s[1], sensitivity: s[2], pii: s[3],
+    projectionMode: s[4], explanation: s[5], purpose: s[6],
+    defaultStandard: "standing-persistent",
+    kind: "runner_action", effect: "egress",
+  }));
+  const capabilities = CAPABILITIES.map((c: any) => ({
+    capabilityId: c[0], riskClass: c[1], defaultStandard: c[2],
+    explanation: c[3], oneShot: c[4],
+    kind: "mcp_tool", effect: _effectForCapability(c[1]),
+  }));
+  return { surfaces, capabilities };
+};
+
+const _findItem = (id: string): any | null => {
+  const r = registry();
+  return (
+    r.surfaces.find((s: any) => s.surfaceId === id) ??
+    r.capabilities.find((c: any) => c.capabilityId === id) ??
+    null
+  );
+};
+
+// ── store ────────────────────────────────────────────────────────────────────
+// A grant record per consented id. Deliberately a plain object so it can be swapped for durable
+// storage without changing the logic below.
+const createStore = () => ({ subject: null as string | null, grants: {} as Record<string, any> });
+
+const _spiffeFor = (subject: string): string => SPIFFE_PREFIX + encodeURIComponent(subject);
+
+// ── mint ─────────────────────────────────────────────────────────────────────
+// Builds an object that validates against the canonical Grant schema: grant_id, ISO
+// issued_at/expires_at, binding{spiffe_id,aum_digest}, capability{kind,capability_ref,
+// capability_digest,effect}, constraints{}, policy_hash, sig{issuer,sig}.
+const mintGrant = (subject: string, item: any, opts?: { now?: number; sessionId?: string }): any => {
+  const now = opts?.now ?? Date.now();
+  const id = item.surfaceId ?? item.capabilityId;
+  const standard = item.defaultStandard;
+  const lifetime = LIFETIME_MS[standard] ?? LIFETIME_MS["per-use"];
+
+  const capability: any = {
+    kind: item.kind,
+    capability_ref: id,
+    capability_digest: _sha256(_canon({ id, effect: item.effect, standard })),
+    effect: item.effect,
+  };
+
+  // constraints is a free-form object in the canonical schema — the place to carry the consent
+  // semantics the person actually agreed to, so a verifier sees them without a second lookup.
+  const constraints: any = {
+    purpose: item.purpose ?? "operate",
+    consent_standard: standard,
+    self_sovereign: true,
+  };
+  if (item.oneShot) constraints.one_shot = true;
+  if (item.pii) constraints.pii = true;
+  if (item.projectionMode) constraints.projection_mode = item.projectionMode;
+
+  const binding: any = {
+    spiffe_id: _spiffeFor(subject),
+    aum_digest: _sha256(_canon({ subject, id })),
+  };
+  if (opts?.sessionId) binding.session_id = opts.sessionId;
+
+  const grant: any = {
+    grant_id: "grant:" + crypto.randomUUID(),
+    issued_at: _iso(now),
+    expires_at: _iso(now + lifetime),
+    binding,
+    capability,
+    constraints,
+    policy_hash: _sha256(_canon({ policy: "policy-fabric:telemetry.emit", id, standard })),
+  };
+  // Signature over the canonical grant body. minLength 16 in the canonical schema.
+  grant.sig = {
+    issuer: _spiffeFor(subject),
+    sig: crypto.createHmac("sha256", "consent-ledger-dev-key").update(_canon(grant)).digest("hex"),
+  };
+  return grant;
+};
+
+// ── operations ───────────────────────────────────────────────────────────────
+
+/** Grant consent for one surface/capability. Refuses anything that would break self-sovereignty. */
+const grant = (store: any, subject: string, id: string, opts?: { now?: number; sessionId?: string }) => {
+  if (!store || typeof store !== "object") return { ok: false, reason: "no-store" };
+  if (!subject) return { ok: false, reason: "no-subject" };
+  if (store.subject && store.subject !== subject) {
+    // The store belongs to someone else. Refuse rather than silently re-key it.
+    return { ok: false, reason: "subject-mismatch" };
+  }
+  const item = _findItem(id);
+  if (!item) return { ok: false, reason: "unknown-id" }; // default-deny: no such surface, no grant
+
+  const g = mintGrant(subject, item, opts);
+  store.subject = subject;
+  store.grants[id] = {
+    id,
+    state: "granted",
+    grantedAt: g.issued_at,
+    revokedAt: null,
+    grantRef: g.grant_id,
+    grant: g,
+  };
+  return { ok: true, id, state: "granted", grantRef: g.grant_id, grant: g };
+};
+
+/**
+ * Does consent stand right now? FAIL-CLOSED — anything other than a live, unrevoked,
+ * unexpired, subject-bound grant is false.
+ */
+const check = (store: any, id: string, opts?: { now?: number; subject?: string }): boolean => {
+  try {
+    if (!store || typeof store !== "object" || !store.grants) return false;
+    const rec = store.grants[id];
+    if (!rec || rec.state !== "granted") return false;
+    if (rec.revokedAt) return false;
+
+    const g = rec.grant;
+    if (!g || !g.binding || !g.capability) return false;
+    if (g.capability.capability_ref !== id) return false; // grant is for a different capability
+
+    // Re-assert subject == grantee here, not only at mint. A grant written directly into the
+    // store for another principal must still fail.
+    const expected = _spiffeFor(opts?.subject ?? store.subject);
+    if (g.binding.spiffe_id !== expected) return false;
+    if (g.sig?.issuer !== expected) return false;
+
+    const now = opts?.now ?? Date.now();
+    const exp = Date.parse(g.expires_at);
+    if (!Number.isFinite(exp) || now >= exp) return false;
+    const iat = Date.parse(g.issued_at);
+    if (!Number.isFinite(iat) || now < iat) return false; // not yet valid / clock skew
+
+    return true;
+  } catch {
+    return false; // a thrown error is a denial, never an allow
+  }
+};
+
+/** Revoke consent. Terminal for that grant — re-granting mints a new one. */
+const revoke = (store: any, subject: string, id: string, opts?: { now?: number }) => {
+  if (!store || typeof store !== "object") return { ok: false, reason: "no-store" };
+  if (store.subject && subject && store.subject !== subject) {
+    return { ok: false, reason: "subject-mismatch" };
+  }
+  const rec = store.grants?.[id];
+  const now = opts?.now ?? Date.now();
+  if (!rec) {
+    // Revoking something never granted is not an error — the end state the person asked for
+    // (not granted) is the state they get. Idempotent by design.
+    return { ok: true, id, state: "revoked", noop: true };
+  }
+  rec.state = "revoked";
+  rec.revokedAt = _iso(now);
+  return { ok: true, id, state: "revoked", grantRef: rec.grantRef };
+};
+
+/** The board's view: every surface and capability with its live consent state. */
+const snapshot = (store: any, subject: string, opts?: { now?: number }) => {
+  const r = registry();
+  const self = subject ?? store?.subject ?? "urn:srcos:principal:self";
+  const stateOf = (id: string) => {
+    const rec = store?.grants?.[id];
+    if (!rec) return { state: "denied" as const };
+    const live = check(store, id, { now: opts?.now, subject: self });
+    if (rec.state === "revoked") {
+      return { state: "revoked" as const, grantedAt: rec.grantedAt, revokedAt: rec.revokedAt, grantRef: rec.grantRef };
+    }
+    // A granted-but-expired record reports denied: the board must never show consent that
+    // check() would refuse.
+    if (!live) return { state: "denied" as const, grantedAt: rec.grantedAt, grantRef: rec.grantRef };
+    return { state: "granted" as const, grantedAt: rec.grantedAt, revokedAt: null, grantRef: rec.grantRef };
+  };
+
+  return {
+    // Self-sovereign: the observed party and the record-holder are the same principal.
+    subjectPrincipal: self,
+    collectorPrincipal: self,
+    surfaces: r.surfaces.map((s: any) => {
+      const c = stateOf(s.surfaceId);
+      const on = c.state === "granted";
+      return {
+        surfaceId: s.surfaceId, category: s.category, sensitivity: s.sensitivity, pii: s.pii,
+        defaultStandard: "standing-persistent",
+        effectiveMode: on ? s.defaultStandard : "off",
+        userOverride: c.state !== "denied" || !!(c as any).grantRef,
+        explanation: s.explanation, projectionMode: s.projectionMode, purpose: s.purpose,
+        consent: c,
+      };
+    }),
+    capabilities: r.capabilities.map((cap: any) => {
+      const c = stateOf(cap.capabilityId);
+      const on = c.state === "granted";
+      return {
+        capabilityId: cap.capabilityId, riskClass: cap.riskClass,
+        defaultStandard: cap.defaultStandard,
+        effectiveMode: on ? cap.defaultStandard : "off",
+        userOverride: c.state !== "denied" || !!(c as any).grantRef,
+        defaultState: "disabled",
+        explanation: cap.explanation, oneShot: cap.oneShot,
+        consent: { state: c.state },
+      };
+    }),
+  };
+};
+
+module.exports = { createStore, registry, mintGrant, grant, check, revoke, snapshot, LIFETIME_MS };

--- a/socioprophet-web/server/test/consent.test.mjs
+++ b/socioprophet-web/server/test/consent.test.mjs
@@ -1,0 +1,202 @@
+// Consent-ledger test: grant → check → revoke, the fail-closed default, and the self-sovereign
+// invariant (subject == grantee). Also validates every minted grant against the VENDORED
+// canonical mcp-a2a-zero-trust Grant schema, so a consent grant stays verifiable by the same
+// verifier as any other capability grant in the estate.
+// Self-contained — transpiles TS on the fly (same pattern as device-enrollment.test.mjs).
+// Run: node test/consent.test.mjs
+import { createRequire } from "module";
+import path from "path";
+const require = createRequire(import.meta.url);
+const ts = require("typescript");
+const fs = require("fs");
+const Module = require("module");
+
+const _realResolve = Module._resolveFilename.bind(Module);
+const _virtual = new Map();
+
+Module._resolveFilename = function (request, parentModule, ...rest) {
+  if (parentModule && typeof request === "string" && request.startsWith(".")) {
+    const abs = path.resolve(path.dirname(parentModule.filename), request + ".js");
+    if (_virtual.has(abs)) return abs;
+  }
+  return _realResolve(request, parentModule, ...rest);
+};
+
+const load = (rel) => {
+  const abs = path.resolve(rel.replace(/\.ts$/, ".js"));
+  if (_virtual.has(abs)) return _virtual.get(abs);
+  const src = fs.readFileSync(rel, "utf8");
+  const js = ts.transpileModule(src, { compilerOptions: { module: "commonjs", target: "es2020" } }).outputText;
+  const m = new Module(abs);
+  m.filename = abs;
+  m.paths = Module._nodeModulePaths(path.dirname(abs));
+  require.cache[abs] = m;
+  _virtual.set(abs, null);
+  m._compile(js, abs);
+  _virtual.set(abs, m.exports);
+  return m.exports;
+};
+
+const L = load("src/services/consentLedger.ts");
+
+// The canonical Grant schema is draft 2020-12 — use the matching Ajv build, as
+// src/contracts/index.ts does.
+const Ajv2020 = require("ajv/dist/2020");
+const addFormats = require("ajv-formats");
+const ajv = new Ajv2020({ strict: false, allErrors: true });
+addFormats(ajv);
+// Grant $refs quorum_proof + runtime_evidence_refs. QuorumProof is already vendored here for
+// the enrollment gate — register that same copy rather than a second one.
+ajv.addSchema(JSON.parse(fs.readFileSync("src/contracts/schemas/QuorumProof.json", "utf8")));
+ajv.addSchema(JSON.parse(fs.readFileSync("src/contracts/schemas/RuntimeEvidenceRefs.json", "utf8")));
+const GRANT_SCHEMA = JSON.parse(fs.readFileSync("src/contracts/schemas/Grant.json", "utf8"));
+const validateGrant = ajv.compile(GRANT_SCHEMA);
+
+let fail = 0;
+const ck = (n, ok) => { console.log((ok ? "ok  " : "FAIL ") + n); if (!ok) fail++; };
+
+const SELF = "urn:srcos:principal:self";
+const OTHER = "urn:srcos:principal:someone-else";
+const SURFACE = "telemetry:model:tokens_used";
+const CAM = "camera";
+
+// ── default-deny ──────────────────────────────────────────────────────────────
+{
+  const s = L.createStore();
+  ck("fresh store: check() is false (default-deny)", L.check(s, SURFACE) === false);
+  ck("fresh store: unknown id is false, not 'unknown → allow'", L.check(s, "telemetry:not:a:thing") === false);
+
+  const snap = L.snapshot(s, SELF);
+  ck("snapshot: self-sovereign, subject == collector", snap.subjectPrincipal === snap.collectorPrincipal);
+  ck("snapshot: every surface denied by default", snap.surfaces.every((x) => x.consent.state === "denied"));
+  ck("snapshot: every surface off by default", snap.surfaces.every((x) => x.effectiveMode === "off"));
+  ck("snapshot: every capability denied by default", snap.capabilities.every((x) => x.consent.state === "denied"));
+  ck("snapshot: every capability disabled by default", snap.capabilities.every((x) => x.defaultState === "disabled"));
+  ck("snapshot: every row carries a real explanation", snap.surfaces.concat(snap.capabilities).every((x) => (x.explanation || "").length > 11));
+}
+
+// ── fail-closed on malformed input ────────────────────────────────────────────
+{
+  ck("check(null store) is false", L.check(null, SURFACE) === false);
+  ck("check(undefined store) is false", L.check(undefined, SURFACE) === false);
+  ck("check(garbage store) is false", L.check({ nope: 1 }, SURFACE) === false);
+  ck("check(store, undefined id) is false", L.check(L.createStore(), undefined) === false);
+  ck("grant with no subject is refused", L.grant(L.createStore(), "", SURFACE).ok === false);
+  ck("grant of an unknown id is refused", L.grant(L.createStore(), SELF, "telemetry:made:up").ok === false);
+}
+
+// ── grant → check → revoke ────────────────────────────────────────────────────
+{
+  const s = L.createStore();
+  const g = L.grant(s, SELF, SURFACE);
+  ck("grant succeeds", g.ok === true && g.state === "granted");
+  ck("grant returns a grantRef", typeof g.grantRef === "string" && g.grantRef.startsWith("grant:"));
+  ck("check() stands after grant", L.check(s, SURFACE) === true);
+  ck("granting one surface does NOT grant another", L.check(s, "telemetry:model:latency") === false);
+
+  const snap = L.snapshot(s, SELF);
+  const row = snap.surfaces.find((x) => x.surfaceId === SURFACE);
+  ck("snapshot reflects the grant", row.consent.state === "granted");
+  ck("snapshot carries the grantRef", row.consent.grantRef === g.grantRef);
+  ck("snapshot: granted surface is no longer off", row.effectiveMode !== "off");
+  ck("snapshot: other surfaces still denied", snap.surfaces.filter((x) => x.surfaceId !== SURFACE).every((x) => x.consent.state === "denied"));
+
+  const r = L.revoke(s, SELF, SURFACE);
+  ck("revoke succeeds", r.ok === true && r.state === "revoked");
+  ck("check() is false after revoke", L.check(s, SURFACE) === false);
+  ck("snapshot shows revoked", L.snapshot(s, SELF).surfaces.find((x) => x.surfaceId === SURFACE).consent.state === "revoked");
+
+  // Re-granting mints a NEW grant — a revocation cannot be undone by replaying the old token.
+  const g2 = L.grant(s, SELF, SURFACE);
+  ck("re-grant mints a NEW grant_id", g2.grantRef !== g.grantRef);
+  ck("check() stands again after re-grant", L.check(s, SURFACE) === true);
+}
+
+// ── revoke is idempotent ──────────────────────────────────────────────────────
+{
+  const s = L.createStore();
+  const r = L.revoke(s, SELF, SURFACE);
+  ck("revoking something never granted is a no-op, not an error", r.ok === true && r.state === "revoked");
+  ck("still denied afterwards", L.check(s, SURFACE) === false);
+}
+
+// ── expiry ────────────────────────────────────────────────────────────────────
+{
+  const t0 = Date.parse("2026-08-04T12:00:00Z");
+  const s = L.createStore();
+  L.grant(s, SELF, CAM, { now: t0 });
+  ck("per-use grant stands immediately", L.check(s, CAM, { now: t0 + 1000 }) === true);
+  ck("per-use grant is expired 6 minutes later", L.check(s, CAM, { now: t0 + 6 * 60 * 1000 }) === false);
+  ck("expired grant reports denied in the snapshot, not granted",
+    L.snapshot(s, SELF, { now: t0 + 6 * 60 * 1000 }).capabilities.find((x) => x.capabilityId === CAM).consent.state === "denied");
+  ck("a grant is not valid BEFORE it was issued (clock skew)", L.check(s, CAM, { now: t0 - 60 * 1000 }) === false);
+}
+
+// ── the self-sovereign invariant: subject == grantee ──────────────────────────
+{
+  const s = L.createStore();
+  L.grant(s, SELF, SURFACE);
+  ck("a different subject cannot grant into this store", L.grant(s, OTHER, "telemetry:model:latency").ok === false);
+  ck("a different subject cannot revoke from this store", L.revoke(s, OTHER, SURFACE).ok === false);
+  ck("the original subject's consent is untouched by the attempt", L.check(s, SURFACE) === true);
+
+  // The teeth: forge a grant for another principal straight into the store, bypassing grant().
+  // check() must still refuse it — the invariant is re-asserted at check time, not only at mint.
+  const forged = L.createStore();
+  forged.subject = SELF;
+  const stolen = L.mintGrant(OTHER, L.registry().surfaces[0]);
+  forged.grants[SURFACE] = {
+    id: SURFACE, state: "granted", grantedAt: stolen.issued_at, revokedAt: null,
+    grantRef: stolen.grant_id, grant: stolen,
+  };
+  ck("a grant bound to ANOTHER principal is refused by check()", L.check(forged, SURFACE) === false);
+  ck("the forged grant also reports denied in the snapshot",
+    L.snapshot(forged, SELF).surfaces.find((x) => x.surfaceId === SURFACE).consent.state === "denied");
+}
+
+// ── a grant for one capability cannot be replayed onto another ────────────────
+{
+  const s = L.createStore();
+  s.subject = SELF;
+  const g = L.mintGrant(SELF, L.registry().capabilities.find((c) => c.capabilityId === CAM));
+  s.grants["microphone"] = { id: "microphone", state: "granted", grantedAt: g.issued_at, revokedAt: null, grantRef: g.grant_id, grant: g };
+  ck("a camera grant filed under microphone is refused", L.check(s, "microphone") === false);
+}
+
+// ── canonical Grant conformance ───────────────────────────────────────────────
+{
+  const all = [...L.registry().surfaces, ...L.registry().capabilities];
+  let bad = null;
+  for (const item of all) {
+    const g = L.mintGrant(SELF, item);
+    if (!validateGrant(g)) { bad = { id: item.surfaceId ?? item.capabilityId, errors: validateGrant.errors }; break; }
+  }
+  ck("every minted grant validates against the canonical Grant schema", bad === null);
+  if (bad) console.log("   ", bad.id, JSON.stringify(bad.errors));
+
+  const g = L.mintGrant(SELF, L.registry().surfaces[0]);
+  ck("telemetry grant declares effect=egress (it LEAVES the device)", g.capability.effect === "egress");
+  ck("grant carries the self-sovereign constraint", g.constraints.self_sovereign === true);
+  ck("grant binding names the subject", g.binding.spiffe_id.includes(encodeURIComponent(SELF)));
+
+  const cam = L.mintGrant(SELF, L.registry().capabilities.find((c) => c.capabilityId === CAM));
+  ck("per-use capability grant is marked one_shot", cam.constraints.one_shot === true);
+  ck("per-use lifetime is short (<= 5 min)", Date.parse(cam.expires_at) - Date.parse(cam.issued_at) <= L.LIFETIME_MS["per-use"]);
+}
+
+// ── registry parity with the board's fixture ──────────────────────────────────
+// The board renders this list live or on the fixture; if the two drift, a person sees a
+// different set of choices depending on whether the backend is reachable.
+{
+  const fixture = fs.readFileSync("../client-vue/src/services/consentApi.ts", "utf8");
+  const r = L.registry();
+  const missing = r.surfaces.map((s) => s.surfaceId).filter((id) => !fixture.includes(`'${id}'`));
+  ck("every ledger surface exists in the client fixture", missing.length === 0);
+  if (missing.length) console.log("    missing:", missing);
+  const capMissing = r.capabilities.map((c) => c.capabilityId).filter((id) => !fixture.includes(`'${id}'`));
+  ck("every ledger capability exists in the client fixture", capMissing.length === 0);
+  if (capMissing.length) console.log("    missing:", capMissing);
+}
+
+console.log(fail ? `\n${fail} FAILED` : "\nall consent-ledger checks passed");
+process.exit(fail ? 1 : 0);

--- a/socioprophet-web/server/test/consent.test.mjs
+++ b/socioprophet-web/server/test/consent.test.mjs
@@ -85,6 +85,37 @@ const CAM = "camera";
   ck("grant of an unknown id is refused", L.grant(L.createStore(), SELF, "telemetry:made:up").ok === false);
 }
 
+// ── prototype pollution (CodeQL js/prototype-polluting-assignment, js/remote-property-injection)
+// The id comes straight off the URL path. On an ordinary {} store, revoke("__proto__") read
+// Object.prototype as a grant record and wrote the revocation onto it, polluting every object in
+// the process. Two independent closures now: a registry gate before the id is used as a key, and
+// a null-prototype grants map.
+{
+  const POLLUTERS = ["__proto__", "constructor", "prototype"];
+  for (const p of POLLUTERS) {
+    const s = L.createStore();
+    s.subject = SELF;
+    const r = L.revoke(s, SELF, p);
+    ck(`revoke("${p}") is refused`, r.ok === false && r.reason === "unknown-id");
+    ck(`revoke("${p}") did not pollute Object.prototype`, {}.state === undefined && {}.revokedAt === undefined);
+
+    const g = L.grant(s, SELF, p);
+    ck(`grant("${p}") is refused`, g.ok === false && g.reason === "unknown-id");
+    ck(`check("${p}") is false`, L.check(s, p) === false);
+  }
+  // A polluted Object.prototype must not be able to fake a grant either.
+  Object.prototype.state = "granted";               // eslint-disable-line no-extend-native
+  try {
+    const s = L.createStore();
+    ck("an inherited 'state' cannot fake a grant", L.check(s, SURFACE) === false);
+    ck("snapshot ignores inherited properties", L.snapshot(s, SELF).surfaces.every((x) => x.consent.state === "denied"));
+  } finally {
+    delete Object.prototype.state;
+  }
+  const s2 = L.createStore();
+  ck("grants map has a null prototype", Object.getPrototypeOf(s2.grants) === null);
+}
+
 // ── grant → check → revoke ────────────────────────────────────────────────────
 {
   const s = L.createStore();


### PR DESCRIPTION
WO-3. The board (#570/#572) *showed* consent; nothing made a grant real. This is the
enforcement side: **grant → check → revoke**, fail-closed, with the self-sovereign
invariant enforced rather than described.

## `src/services/consentLedger.ts`
- **`grant(id)` mints a CANONICAL `Grant`** — the vendored mcp-a2a-zero-trust shape
  (`contracts/schemas/Grant.json`, pinned at `7ec8133`), not a consent-specific token. A
  consent grant is therefore verifiable by the same verifier as any other capability grant
  in the estate; a second shape would mean consent could be honoured by one verifier and
  ignored by another.
- **`check(id)` is fail-closed on every path** — no store, garbage store, unknown id,
  absent grant, expired, not-yet-valid (clock skew), or a thrown error all return `false`.
  There is no path where an error means allow.
- **`revoke(id)` is terminal and idempotent.** Re-granting mints a *new* `grant_id`, so a
  revocation can never be undone by replaying an old token.

**SUBJECT == GRANTEE** is enforced at mint *and re-asserted at check*, so an attacker who
writes a foreign-subject grant straight into the store still fails `check()`. A grant filed
under a different capability id is refused too — no replay across capabilities.

Telemetry grants declare `capability.effect = egress`. Telemetry *leaves the device*;
calling it `read` would understate what the person agreed to.

## `src/routes/api/consent-route.ts`
`GET /snapshot`, `POST /grant/:id`, `POST /revoke/:id`, mounted **authenticated** at
`/svc/consent`. The subject comes from the **session, never the request**, so a caller
cannot name whose consent they read or change — that is what makes the invariant hold at
the HTTP edge, and why there is no `/snapshot/:subject`.

## Security fix in the client
`setConsent` now **POSTs instead of GETs**. The first client shipped grant/revoke as GET —
a state-changing GET is reachable by a link, a browser prefetch or a cross-site `<img>`,
so consent could have been granted or revoked without the person acting. The dev proxy now
points at the Express server (prefix intact) rather than a placeholder port.

## Verification
- `node test/consent.test.mjs` — **47/47**, including every minted grant validating against
  the canonical `Grant` schema, the forged-foreign-subject refusal, expiry/clock-skew, and
  registry parity with the board's fixture
- client-vue: `vue-tsc` clean, `ConsentBoardFixture` 5/5, `vite build` ok

## Notes for review
- Storage is an in-memory map per subject, behind the same interface the ledger already
  takes as an argument — swapping in durable storage touches one line in the route and no
  ledger logic.
- `RuntimeEvidenceRefs.json` is vendored alongside `Grant.json` only to complete the `$ref`
  closure. Trimming the `$ref` out of `Grant.json` instead would have made the vendored
  copy a fork of the authority.
- The matching policy binding is SocioProphet/policy-fabric#105, which also records a
  finding: **no role currently admits `egress`**, so consented telemetry still cannot flow
  until that policy decision is made. WO-4 is blocked on that, not on code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)